### PR TITLE
Allow environment variable NEMS_MACHINE to overwrite (or set) MACHINE_ID

### DIFF
--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -122,6 +122,9 @@ case $(hostname -f) in
   login4.stampede2.tacc.utexas.edu) MACHINE_ID=stampede ;; ### stampede4
 esac
 
+# Overwrite auto-detect with NEMS_MACHINE if set
+MACHINE_ID=${NEMS_MACHINE:-${MACHINE_ID}}
+
 # For Theia and Cheyenne, append compiler
 if [ $MACHINE_ID = theia ] || [ $MACHINE_ID = hera ] || [ $MACHINE_ID = cheyenne ] || [ $MACHINE_ID = jet ] || [ $MACHINE_ID = gaea ] || [ $MACHINE_ID = stampede ] ; then
     MACHINE_ID=${MACHINE_ID}.${COMPILER}


### PR DESCRIPTION
This PR is a follow-up PR to the recent update from DTC. Similar to using the `NEMS_COMPILER` environment variable for setting the compiler when running `rt.sh`, one can use `NEMS_MACHINE` to overwrite (if the logic in `detect.sh` detects a machine) or set (if not) `MACHINE_ID`.

This is (a) required for automatic regression testing on Cheyenne, because `detect.sh` fails to identify the compute nodes as Cheyenne nodes, and (b) generally a good practice to avoid having to add more and more logic to `detect.sh` as we expand the UFS public release regression testing to other machines. 

This is also part of the NCAR dtc/develop branches, has been tested extensively, and will be proposed for inclusion in EMC's develop branch as well.