### PR TITLE
Build UFS on S4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	branch = develop
 [submodule "NEMS"]
 	path = NEMS
-	url = https://github.com/NOAA-EMC/NEMS
+	url = https://github.com/aerorahul/NEMS
 	branch = develop
 [submodule "FMS"]
 	path = FMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/aerorahul/NEMS
-	branch = develop
+	branch = feature/s4
 [submodule "FMS"]
 	path = FMS
 	url = https://github.com/NOAA-GFDL/FMS

--- a/conf/configure.fv3.s4.intel
+++ b/conf/configure.fv3.s4.intel
@@ -1,0 +1,193 @@
+## NEMS configuration file
+##
+## Platform: SSEC Wisconsin S4
+## Compiler: Intel with IntelMPI
+
+SHELL=/bin/sh
+
+################################################################################
+## Include the common configuration parts
+
+ifdef InNemsMakefile
+include $(TOP)/conf/configure.nems.NUOPC
+endif
+
+############
+# commands #
+############
+FC = mpiifort
+CC = mpiicc
+CXX = mpiicpc
+LD = mpiifort -mkl=sequential
+
+#########
+# flags #
+#########
+# default is 64-bit OpenMP non-hydrostatic build using AVX2
+DEBUG =
+REPRO =
+VERBOSE =
+OPENMP = Y
+AVX2 = N
+HYDRO = N
+CCPP = N
+STATIC = N
+INLINE_POST=N
+
+include       $(ESMFMKFILE)
+ESMF_INC    = $(ESMF_F90COMPILEPATHS)
+
+NEMSIOINC = -I$(NEMSIO_INC)
+NCEPLIBS = $(NEMSIO_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd)
+
+##############################################
+# Need to use at least GNU Make version 3.81 #
+##############################################
+need := 3.81
+ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
+ifneq ($(need),$(ok))
+$(error Need at least make version $(need).  Load module gmake/3.81)
+endif
+
+NETCDF_ROOT = $(NETCDF_DIR)
+NETCDF      = $(NETCDF_DIR)
+INCLUDE = -I$(NETCDF_ROOT)/include
+NETCDF_INC = -I$(NETCDF_ROOT)/include
+ifneq ($(findstring netcdf/4,$(LOADEDMODULES)),)
+  NETCDF_LIB += -L$(NETCDF)/lib -lnetcdff -lnetcdf
+else
+  NETCDF_LIB = -L$(NETCDF)/lib -lnetcdff -lnetcdf
+endif
+
+FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
+CFLAGS := $(INCLUDE)
+
+FFLAGS := $(INCLUDE) -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte
+
+CPPDEFS += -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP
+CPPDEFS += -DNEW_TAUCTMAX -DINTERNAL_FILE_NML
+
+ifeq ($(INLINE_POST),Y)
+CPPDEFS +=
+NCEPLIBS = $(POST_LIB) $(NEMSIO_LIB) $(G2_LIB4) $(G2TMPL_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd) $(CRTM_LIB) $(PNG_LIB) $(JASPER_LIB) $(Z_LIB)
+else
+CPPDEFS += -DNO_INLINE_POST
+endif
+
+ifeq ($(HYDRO),Y)
+CPPDEFS +=
+else
+CPPDEFS += -DMOIST_CAPPA -DUSE_COND
+endif
+
+ifeq ($(NAM_phys),Y)
+CPPDEFS += -DNAM_phys
+endif
+
+ifeq ($(32BIT),Y)
+CPPDEFS += -DOVERLOAD_R4 -DOVERLOAD_R8
+FFLAGS += -i4 -real-size 32
+else
+ifeq ($(REPRO),Y)
+FFLAGS += -i4 -real-size 64
+else
+FFLAGS += -i4 -real-size 64 -no-prec-div -no-prec-sqrt
+endif
+endif
+
+ifeq ($(REPRO),Y)
+FFLAGS += -qno-opt-dynamic-align
+CFLAGS += -qno-opt-dynamic-align
+else
+ifeq ($(AVX2),Y)
+FFLAGS += -xCORE-AVX2 -qno-opt-dynamic-align
+CFLAGS += -xCORE-AVX2 -qno-opt-dynamic-align
+else
+FFLAGS += -xHOST -qno-opt-dynamic-align
+CFLAGS += -xHOST -qno-opt-dynamic-align
+endif
+endif
+
+ifeq ($(MULTI_GASES),Y)
+CPPDEFS += -DMULTI_GASES
+endif
+
+FFLAGS_OPT = -O2 -debug minimal -fp-model strict -qoverride-limits -qopt-prefetch=3 -g -traceback
+FFLAGS_REPRO = -O2 -debug minimal -fp-model strict -qoverride-limits -g -traceback
+FFLAGS_DEBUG = -g -O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -traceback -ftrapuv
+
+TRANSCENDENTALS := -fast-transcendentals
+FFLAGS_OPENMP = -qopenmp
+FFLAGS_VERBOSE = -v -V -what
+
+CFLAGS += -D__IFC -sox -fp-model strict
+
+CFLAGS_OPT = -O2 -debug minimal
+CFLAGS_REPRO = -O2 -debug minimal
+CFLAGS_OPENMP = -qopenmp
+CFLAGS_DEBUG = -O0 -g -ftrapuv -traceback
+
+# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
+# *_TEST will match the production if no new option(s) is(are) to be tested.
+FFLAGS_TEST = -O2 -debug minimal -fp-model strict -qoverride-limits
+CFLAGS_TEST = -O2
+
+LDFLAGS :=
+LDFLAGS_OPENMP := -qopenmp
+LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
+
+# start with blank LIBS
+LIBS :=
+
+ifeq ($(REPRO),Y)
+CPPDEFS += -DREPRO
+CFLAGS += $(CFLAGS_REPRO)
+FFLAGS += $(FFLAGS_REPRO)
+FAST :=
+else ifeq ($(DEBUG),Y)
+CPPDEFS += -DDEBUG
+CFLAGS += $(CFLAGS_DEBUG)
+FFLAGS += $(FFLAGS_DEBUG)
+FAST :=
+else ifeq ($(TEST),Y)
+CFLAGS += $(CFLAGS_TEST)
+FFLAGS += $(FFLAGS_TEST)
+FAST :=
+else
+CFLAGS += $(CFLAGS_OPT)
+FFLAGS += $(FFLAGS_OPT)
+FAST := $(TRANSCENDENTALS)
+endif
+
+ifeq ($(OPENMP),Y)
+CPPDEFS += -DOPENMP
+CFLAGS += $(CFLAGS_OPENMP)
+FFLAGS += $(FFLAGS_OPENMP)
+LDFLAGS += $(LDFLAGS_OPENMP)
+endif
+
+ifeq ($(VERBOSE),Y)
+CFLAGS += $(CFLAGS_VERBOSE)
+FFLAGS += $(FFLAGS_VERBOSE)
+LDFLAGS += $(LDFLAGS_VERBOSE)
+endif
+
+ifeq ($(CCPP),Y)
+CPPDEFS += -DCCPP
+CFLAGS += -I$(PATH_CCPP)/include
+FFLAGS += -I$(PATH_CCPP)/include
+ifeq ($(STATIC),Y)
+CPPDEFS += -DSTATIC
+LDFLAGS += -L$(PATH_CCPP)/lib -lccppphys -lccpp $(NCEPLIBS) -lxml2
+else
+LDFLAGS += -L$(PATH_CCPP)/lib -lccpp
+endif
+endif
+
+LDFLAGS += $(LIBS)
+
+ifdef InNemsMakefile
+FFLAGS += $(ESMF_INC)
+CPPFLAGS += -traditional
+EXTLIBS = $(NCEPLIBS) $(ESMF_LIB) $(LDFLAGS) $(NETCDF_LIB)
+endif

--- a/modulefiles/s4.intel/fv3
+++ b/modulefiles/s4.intel/fv3
@@ -1,0 +1,41 @@
+#%Module######################################################################
+##
+##    NEMS FV3 Prerequisites: S4
+
+proc ModulesHelp {} {
+  puts stderr "\tcit - loads modules required for building and running FV3 under NEMS on S4"
+}
+
+module-whatis "loads NEMS FV3 prerequisites for S4"
+
+# NOTE: the "module purge" and loading of the module command are
+# handled by the module-setup.sh (or .csh) script.
+
+##
+## load programming environment
+## this typically includes compiler, MPI and job scheduler
+##
+module load license_intel/S4
+module load intel/18.0.3
+module load hdf/4.2.14
+module load hdf5/1.8.21
+module load netcdf4/4.6.2
+
+##
+## load nwprod libraries
+##
+module use -a /data/prod/ncep_libs/intel/18.0.3/modulefiles
+module load bacio/v2.0.2
+module load sp/v2.0.2
+module load ip/v3.0.0
+module load w3nco/v2.0.6
+module load w3emc/v2.3.0
+module load nemsio/v2.2.3
+module load g2/v3.1.0
+module load g2tmpl/v1.5.0
+module load crtm/v2.3.0
+module load jasper/v1.900.1
+module load png/v1.2.44
+module load z/v1.2.6
+
+module load esmf/v8.0.0


### PR DESCRIPTION
Build UFS on SSEC University of Wisconsin S4 supercomputer.

INLINE_POST is disabled on S4, since POST is not built/available.  It will be enabled in a future PR.

See corresponding [NEMS PR #49](https://github.com/NOAA-EMC/NEMS/pull/49)