### PR TITLE
Have CMake ensure that the fortran compiler supports the intrinsic FINDLOC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ add_definitions(-DINTERNAL_FILE_NML)
 
 include(CheckFortranSourceCompiles)
 
-check_fortran_source_compiles("integer i; i=FINDLOC ([2, 6, 4, 6], VALUE = 6)" f08findloc
+check_fortran_source_compiles("integer, dimension(1):: i; i=FINDLOC([2, 6, 4, 6], VALUE = 6); end" f08findloc
                               SRC_EXT f90)
 if(NOT f08findloc)
   message(FATAL_ERROR "Fortran must support the FINDLOC intrinsic, which is part of the Fortran 2008 standard.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ add_definitions(-DINTERNAL_FILE_NML)
 
 include(CheckFortranSourceCompiles)
 
+# Check to ensure that the Fortran compiler supports the FINDLOC
+# intrinsic, which is used in the code.
 check_fortran_source_compiles("integer, dimension(1):: i; i=FINDLOC([2, 6, 4, 6], VALUE = 6); end" f08findloc
                               SRC_EXT f90)
 if(NOT f08findloc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ add_definitions(-DUSE_COND)
 add_definitions(-DNEW_TAUCTMAX)
 add_definitions(-DINTERNAL_FILE_NML)
 
+include(CheckFortranSourceCompiles)
+
+check_fortran_source_compiles("integer i; i=FINDLOC ([2, 6, 4, 6], VALUE = 6)" f08findloc
+                              SRC_EXT f90)
+if(NOT f08findloc)
+  message(FATAL_ERROR "Fortran must support the FINDLOC intrinsic, which is part of the Fortran 2008 standard.")
+endif()
+
 if(CCPP)
 
     find_package(Python 3 QUIET COMPONENTS Interpreter)


### PR DESCRIPTION
The FINDLOC intrinsic is used in the code, but is not supported by all versions of all fortran compilers.

In this PR I add a check for FINDLOC in the CMake build. If it can't be found, the build exits with an error message.

Fixes #132