### PR TITLE
Fix /contrib module commands for Jet and Hera.

### DIFF
--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -59,8 +59,7 @@ module load hdf5_parallel/1.10.6
 ##
 ## load cmake
 ##
-module use /contrib/cmake/modulefiles
-module load cmake/3.9.0
+module load cmake/3.16.1
 setenv CMAKE_C_COMPILER mpiicc
 setenv CMAKE_CXX_COMPILER mpiicpc
 setenv CMAKE_Fortran_COMPILER mpiifort

--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -15,7 +15,8 @@ setenv NCEPLIBS /scratch2/NCEPDEV/nwprod/NCEPLIBS
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 ##
 ## load programming environment
@@ -58,7 +59,7 @@ module load hdf5_parallel/1.10.6
 ##
 ## load cmake
 ##
-module use /contrib/modulefiles
+module use /contrib/cmake/modulefiles
 module load cmake/3.9.0
 setenv CMAKE_C_COMPILER mpiicc
 setenv CMAKE_CXX_COMPILER mpiicpc

--- a/modulefiles/jet.intel/fv3
+++ b/modulefiles/jet.intel/fv3
@@ -13,7 +13,8 @@ module purge
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 module load intel/18.0.5.274
 module load impi/2018.4.274


### PR DESCRIPTION
Fix broken module commands that prevents production/GFS.v16 from building on Jet and Hera. Closes #145 