### PR TITLE
Update modulefile for hera.gnu

### DIFF
--- a/modulefiles/hera.gnu/fv3
+++ b/modulefiles/hera.gnu/fv3
@@ -23,13 +23,12 @@ module load sutils
 ## this typically includes compiler, MPI and job scheduler
 ##
 module load gnu/9.2.0
-module load openmpi/3.1.4
-module load netcdf/4.7.2
+module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/mpich-3.3.2
+module load mpich/3.3.2
 
 ##
-## use pre-compiled EMSF library and NCEP libraries for above compiler / MPI combination
+## use pre-compiled netCDF, EMSF library and NCEP libraries for above compiler / MPI combination
 ##
-module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/openmpi-3.1.4
 module load NCEPlibs/1.0.0
 
 ##


### PR DESCRIPTION
The GNU software stack on Hera doesn't work with the ufs-weather-model. When compiled with the openmpi/3.1.4 module the model hangs indefinitely after initialization.

This PR updates the hera.gnu modulefile to use an mpich-3.3.2 build (and subsequent netCDF, ESMF and NCEPLIBS builds) that I created under the shared BMC/gmtb space.

The model runs are relativelty slow, presumably because I built mpich-3.3.2 without any tailoring to the Hera Infiniband fabric, but at least it runs. A C96 regression test finishes in about 10 minutes.

Note that I had to test the updated modulefile with an earlier version of the ufs-weather-model code, because the current code does not compile with GNU (FV3 dycore updates).