### PR TITLE
Bugfix for regional runs when dycore is compiled in double precision

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = develop
-	url = https://github.com/climbfuji/fv3atm
-	branch = regional_mpibugfix
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = develop
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = develop
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = develop
+	url = https://github.com/climbfuji/fv3atm
+	branch = regional_mpibugfix
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/Compile_hera.gnu.log
+++ b/tests/Compile_hera.gnu.log
@@ -1,26 +1,26 @@
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp'
 + export COMPILE_NR=1
 + COMPILE_NR=1
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1.env
 ++ export MACHINE_ID=hera.gnu
 ++ MACHINE_ID=hera.gnu
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
-++ export ACCNR=gmtb
-++ ACCNR=gmtb
+++ export ACCNR=gsd-hpcs
+++ ACCNR=gsd-hpcs
 ++ export QUEUE=batch
 ++ QUEUE=batch
 ++ export PARTITION=
@@ -29,10 +29,10 @@
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
 + source default_vars.sh
 ++ '[' hera.gnu = wcoss ']'
 ++ '[' hera.gnu = wcoss_cray ']'
@@ -64,15 +64,15 @@
 + TEST_NR=1
 + export JBNME=compile_1
 + JBNME=compile_1
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_1
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_1
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -85,43 +85,43 @@
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8891753
+Job id 9085150
 TEST 1 compile is waiting to enter the queue
 1 min. TEST 1 compile is running,            Status: R
 2 min. TEST 1 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8891753       COMPLETED  compile_1 
-8891753.bat+  COMPLETED      batch 
-8891753.ext+  COMPLETED     extern 
+9085150       COMPLETED  compile_1 
+9085150.bat+  COMPLETED      batch 
+9085150.ext+  COMPLETED     extern 
 3 min. TEST 1 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=185
-+ echo 'Elapsed time 185 seconds. Compile 1'
-Elapsed time 185 seconds. Compile 1
++ elapsed=186
++ echo 'Elapsed time 186 seconds. Compile 1'
+Elapsed time 186 seconds. Compile 1
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + export COMPILE_NR=2
 + COMPILE_NR=2
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2.env
 ++ export MACHINE_ID=hera.gnu
 ++ MACHINE_ID=hera.gnu
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
-++ export ACCNR=gmtb
-++ ACCNR=gmtb
+++ export ACCNR=gsd-hpcs
+++ ACCNR=gsd-hpcs
 ++ export QUEUE=batch
 ++ QUEUE=batch
 ++ export PARTITION=
@@ -130,10 +130,10 @@ Elapsed time 185 seconds. Compile 1
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
 + source default_vars.sh
 ++ '[' hera.gnu = wcoss ']'
 ++ '[' hera.gnu = wcoss_cray ']'
@@ -165,15 +165,15 @@ Elapsed time 185 seconds. Compile 1
 + TEST_NR=2
 + export JBNME=compile_2
 + JBNME=compile_2
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_2
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_2
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -186,48 +186,43 @@ Elapsed time 185 seconds. Compile 1
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8891757
+Job id 9085153
 TEST 2 compile is waiting to enter the queue
-1 min. TEST 2 compile is pending,            Status: PD
-2 min. TEST 2 compile is pending,            Status: PD
-3 min. TEST 2 compile is pending,            Status: PD
-4 min. TEST 2 compile is pending,            Status: PD
-5 min. TEST 2 compile is pending,            Status: PD
-6 min. TEST 2 compile is running,            Status: R
-7 min. TEST 2 compile is running,            Status: R
+1 min. TEST 2 compile is running,            Status: R
+2 min. TEST 2 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8891757       COMPLETED  compile_2 
-8891757.bat+  COMPLETED      batch 
-8891757.ext+  COMPLETED     extern 
-8 min. TEST 2 compile is COMPLETED
+9085153       COMPLETED  compile_2 
+9085153.bat+  COMPLETED      batch 
+9085153.ext+  COMPLETED     extern 
+3 min. TEST 2 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=486
-+ echo 'Elapsed time 486 seconds. Compile 2'
-Elapsed time 486 seconds. Compile 2
++ elapsed=186
++ echo 'Elapsed time 186 seconds. Compile 2'
+Elapsed time 186 seconds. Compile 2
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + export COMPILE_NR=3
 + COMPILE_NR=3
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3.env
 ++ export MACHINE_ID=hera.gnu
 ++ MACHINE_ID=hera.gnu
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
-++ export ACCNR=gmtb
-++ ACCNR=gmtb
+++ export ACCNR=gsd-hpcs
+++ ACCNR=gsd-hpcs
 ++ export QUEUE=batch
 ++ QUEUE=batch
 ++ export PARTITION=
@@ -236,10 +231,10 @@ Elapsed time 486 seconds. Compile 2
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
 + source default_vars.sh
 ++ '[' hera.gnu = wcoss ']'
 ++ '[' hera.gnu = wcoss_cray ']'
@@ -271,15 +266,15 @@ Elapsed time 486 seconds. Compile 2
 + TEST_NR=3
 + export JBNME=compile_3
 + JBNME=compile_3
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_3
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_3
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -292,49 +287,50 @@ Elapsed time 486 seconds. Compile 2
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8891756
+Job id 9085152
 TEST 3 compile is waiting to enter the queue
-1 min. TEST 3 compile is pending,            Status: PD
-2 min. TEST 3 compile is pending,            Status: PD
-3 min. TEST 3 compile is pending,            Status: PD
-4 min. TEST 3 compile is pending,            Status: PD
-5 min. TEST 3 compile is pending,            Status: PD
-6 min. TEST 3 compile is running,            Status: R
-7 min. TEST 3 compile is running,            Status: R
-8 min. TEST 3 compile is running,            Status: R
+1 min. TEST 3 compile is running,            Status: R
+2 min. TEST 3 compile is running,            Status: R
+Slurm unknown status CG. Check sacct ...
+9085152       COMPLETED  compile_3 
+9085152.bat+  COMPLETED      batch 
+9085152.ext+  COMPLETED     extern 
+3 min. TEST 3 compile is COMPLETED
+COMPLETED
+COMPLETED
 Slurm unknown status -. Check sacct ...
-8891756       COMPLETED  compile_3 
-8891756.bat+  COMPLETED      batch 
-8891756.ext+  COMPLETED     extern 
-9 min. TEST 3 compile is COMPLETED
+9085152       COMPLETED  compile_3 
+9085152.bat+  COMPLETED      batch 
+9085152.ext+  COMPLETED     extern 
+4 min. TEST 3 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=546
-+ echo 'Elapsed time 546 seconds. Compile 3'
-Elapsed time 546 seconds. Compile 3
++ elapsed=246
++ echo 'Elapsed time 246 seconds. Compile 3'
+Elapsed time 246 seconds. Compile 3
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=4
 + COMPILE_NR=4
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4.env
 ++ export MACHINE_ID=hera.gnu
 ++ MACHINE_ID=hera.gnu
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
-++ export ACCNR=gmtb
-++ ACCNR=gmtb
+++ export ACCNR=gsd-hpcs
+++ ACCNR=gsd-hpcs
 ++ export QUEUE=batch
 ++ QUEUE=batch
 ++ export PARTITION=
@@ -343,10 +339,10 @@ Elapsed time 546 seconds. Compile 3
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
 + source default_vars.sh
 ++ '[' hera.gnu = wcoss ']'
 ++ '[' hera.gnu = wcoss_cray ']'
@@ -378,15 +374,15 @@ Elapsed time 546 seconds. Compile 3
 + TEST_NR=4
 + export JBNME=compile_4
 + JBNME=compile_4
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_4
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_4
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -399,44 +395,42 @@ Elapsed time 546 seconds. Compile 3
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8891754
+Job id 9085151
 TEST 4 compile is waiting to enter the queue
-1 min. TEST 4 compile is pending,            Status: PD
-2 min. TEST 4 compile is running,            Status: R
-3 min. TEST 4 compile is running,            Status: R
+1 min. TEST 4 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8891754       COMPLETED  compile_4 
-8891754.bat+  COMPLETED      batch 
-8891754.ext+  COMPLETED     extern 
-4 min. TEST 4 compile is COMPLETED
+9085151       COMPLETED  compile_4 
+9085151.bat+  COMPLETED      batch 
+9085151.ext+  COMPLETED     extern 
+2 min. TEST 4 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=246
-+ echo 'Elapsed time 246 seconds. Compile 4'
-Elapsed time 246 seconds. Compile 4
++ elapsed=126
++ echo 'Elapsed time 126 seconds. Compile 4'
+Elapsed time 126 seconds. Compile 4
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + export COMPILE_NR=5
 + COMPILE_NR=5
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5.env
 ++ export MACHINE_ID=hera.gnu
 ++ MACHINE_ID=hera.gnu
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
-++ export ACCNR=gmtb
-++ ACCNR=gmtb
+++ export ACCNR=gsd-hpcs
+++ ACCNR=gsd-hpcs
 ++ export QUEUE=batch
 ++ QUEUE=batch
 ++ export PARTITION=
@@ -445,10 +439,10 @@ Elapsed time 246 seconds. Compile 4
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/RegressionTests_hera.gnu.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/log_hera.gnu
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/RegressionTests_hera.gnu.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/log_hera.gnu
 + source default_vars.sh
 ++ '[' hera.gnu = wcoss ']'
 ++ '[' hera.gnu = wcoss_cray ']'
@@ -480,15 +474,15 @@ Elapsed time 246 seconds. Compile 4
 + TEST_NR=5
 + export JBNME=compile_5
 + JBNME=compile_5
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/gnu/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/compile_5
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/compile_5
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -501,28 +495,23 @@ Elapsed time 246 seconds. Compile 4
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8891755
+Job id 9085149
 TEST 5 compile is waiting to enter the queue
-1 min. TEST 5 compile is pending,            Status: PD
-2 min. TEST 5 compile is pending,            Status: PD
-3 min. TEST 5 compile is pending,            Status: PD
-4 min. TEST 5 compile is pending,            Status: PD
-5 min. TEST 5 compile is pending,            Status: PD
-6 min. TEST 5 compile is running,            Status: R
+1 min. TEST 5 compile is running,            Status: R
 Slurm unknown status CG. Check sacct ...
-8891755       COMPLETED  compile_5 
-8891755.bat+  COMPLETED      batch 
-8891755.ext+  COMPLETED     extern 
-7 min. TEST 5 compile is COMPLETED
+9085149       COMPLETED  compile_5 
+9085149.bat+  COMPLETED      batch 
+9085149.ext+  COMPLETED     extern 
+2 min. TEST 5 compile is COMPLETED
 COMPLETED
 COMPLETED
 Slurm unknown status -. Check sacct ...
-8891755       COMPLETED  compile_5 
-8891755.bat+  COMPLETED      batch 
-8891755.ext+  COMPLETED     extern 
-8 min. TEST 5 compile is COMPLETED
+9085149       COMPLETED  compile_5 
+9085149.bat+  COMPLETED      batch 
+9085149.ext+  COMPLETED     extern 
+3 min. TEST 5 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=486
-+ echo 'Elapsed time 486 seconds. Compile 5'
-Elapsed time 486 seconds. Compile 5
++ elapsed=186
++ echo 'Elapsed time 186 seconds. Compile 5'
+Elapsed time 186 seconds. Compile 5

--- a/tests/Compile_hera.intel.log
+++ b/tests/Compile_hera.intel.log
@@ -1,22 +1,22 @@
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + export COMPILE_NR=10
 + COMPILE_NR=10
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -29,10 +29,10 @@
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -65,15 +65,15 @@
 + TEST_NR=10
 + export JBNME=compile_10
 + JBNME=compile_10
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_10
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_10
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -86,44 +86,39 @@
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890010
+Job id 9085162
 TEST 10 compile is waiting to enter the queue
 1 min. TEST 10 compile is running,            Status: R
 2 min. TEST 10 compile is running,            Status: R
-3 min. TEST 10 compile is running,            Status: R
-4 min. TEST 10 compile is running,            Status: R
-5 min. TEST 10 compile is running,            Status: R
-6 min. TEST 10 compile is running,            Status: R
-7 min. TEST 10 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890010       COMPLETED compile_10 
-8890010.bat+  COMPLETED      batch 
-8890010.ext+  COMPLETED     extern 
-8 min. TEST 10 compile is COMPLETED
+9085162       COMPLETED compile_10 
+9085162.bat+  COMPLETED      batch 
+9085162.ext+  COMPLETED     extern 
+3 min. TEST 10 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=486
-+ echo 'Elapsed time 486 seconds. Compile 10'
-Elapsed time 486 seconds. Compile 10
++ elapsed=185
++ echo 'Elapsed time 185 seconds. Compile 10'
+Elapsed time 185 seconds. Compile 10
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=11
 + COMPILE_NR=11
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -136,10 +131,10 @@ Elapsed time 486 seconds. Compile 10
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -172,15 +167,15 @@ Elapsed time 486 seconds. Compile 10
 + TEST_NR=11
 + export JBNME=compile_11
 + JBNME=compile_11
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_11
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_11
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -193,49 +188,42 @@ Elapsed time 486 seconds. Compile 10
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890065
+Job id 9085193
 TEST 11 compile is waiting to enter the queue
 1 min. TEST 11 compile is running,            Status: R
 2 min. TEST 11 compile is running,            Status: R
 3 min. TEST 11 compile is running,            Status: R
 4 min. TEST 11 compile is running,            Status: R
 5 min. TEST 11 compile is running,            Status: R
-Slurm unknown status CG. Check sacct ...
-8890065       COMPLETED compile_11 
-8890065.bat+  COMPLETED      batch 
-8890065.ext+  COMPLETED     extern 
+Slurm unknown status -. Check sacct ...
+9085193       COMPLETED compile_11 
+9085193.bat+  COMPLETED      batch 
+9085193.ext+  COMPLETED     extern 
 6 min. TEST 11 compile is COMPLETED
 COMPLETED
 COMPLETED
-Slurm unknown status -. Check sacct ...
-8890065       COMPLETED compile_11 
-8890065.bat+  COMPLETED      batch 
-8890065.ext+  COMPLETED     extern 
-7 min. TEST 11 compile is COMPLETED
-COMPLETED
-COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 11'
-Elapsed time 426 seconds. Compile 11
++ elapsed=365
++ echo 'Elapsed time 365 seconds. Compile 11'
+Elapsed time 365 seconds. Compile 11
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + export COMPILE_NR=12
 + COMPILE_NR=12
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -248,10 +236,10 @@ Elapsed time 426 seconds. Compile 11
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -284,15 +272,15 @@ Elapsed time 426 seconds. Compile 11
 + TEST_NR=12
 + export JBNME=compile_12
 + JBNME=compile_12
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_12
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_12
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -305,7 +293,7 @@ Elapsed time 426 seconds. Compile 11
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890152
+Job id 9085194
 TEST 12 compile is waiting to enter the queue
 1 min. TEST 12 compile is running,            Status: R
 2 min. TEST 12 compile is running,            Status: R
@@ -313,35 +301,38 @@ TEST 12 compile is waiting to enter the queue
 4 min. TEST 12 compile is running,            Status: R
 5 min. TEST 12 compile is running,            Status: R
 6 min. TEST 12 compile is running,            Status: R
+7 min. TEST 12 compile is running,            Status: R
+8 min. TEST 12 compile is running,            Status: R
+9 min. TEST 12 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890152       COMPLETED compile_12 
-8890152.bat+  COMPLETED      batch 
-8890152.ext+  COMPLETED     extern 
-7 min. TEST 12 compile is COMPLETED
+9085194       COMPLETED compile_12 
+9085194.bat+  COMPLETED      batch 
+9085194.ext+  COMPLETED     extern 
+10 min. TEST 12 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=427
-+ echo 'Elapsed time 427 seconds. Compile 12'
-Elapsed time 427 seconds. Compile 12
++ elapsed=606
++ echo 'Elapsed time 606 seconds. Compile 12'
+Elapsed time 606 seconds. Compile 12
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=13
 + COMPILE_NR=13
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -354,10 +345,10 @@ Elapsed time 427 seconds. Compile 12
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -390,15 +381,15 @@ Elapsed time 427 seconds. Compile 12
 + TEST_NR=13
 + export JBNME=compile_13
 + JBNME=compile_13
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_13
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_13
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -411,7 +402,7 @@ Elapsed time 427 seconds. Compile 12
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890151
+Job id 9085288
 TEST 13 compile is waiting to enter the queue
 1 min. TEST 13 compile is running,            Status: R
 2 min. TEST 13 compile is running,            Status: R
@@ -420,34 +411,34 @@ TEST 13 compile is waiting to enter the queue
 5 min. TEST 13 compile is running,            Status: R
 6 min. TEST 13 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890151       COMPLETED compile_13 
-8890151.bat+  COMPLETED      batch 
-8890151.ext+  COMPLETED     extern 
+9085288       COMPLETED compile_13 
+9085288.bat+  COMPLETED      batch 
+9085288.ext+  COMPLETED     extern 
 7 min. TEST 13 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=427
-+ echo 'Elapsed time 427 seconds. Compile 13'
-Elapsed time 427 seconds. Compile 13
++ elapsed=426
++ echo 'Elapsed time 426 seconds. Compile 13'
+Elapsed time 426 seconds. Compile 13
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017'
 + export COMPILE_NR=1
 + COMPILE_NR=1
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -460,10 +451,10 @@ Elapsed time 427 seconds. Compile 13
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -496,15 +487,15 @@ Elapsed time 427 seconds. Compile 13
 + TEST_NR=1
 + export JBNME=compile_1
 + JBNME=compile_1
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_1
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_1
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -517,7 +508,7 @@ Elapsed time 427 seconds. Compile 13
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890014
+Job id 9085157
 TEST 1 compile is waiting to enter the queue
 1 min. TEST 1 compile is running,            Status: R
 2 min. TEST 1 compile is running,            Status: R
@@ -525,36 +516,35 @@ TEST 1 compile is waiting to enter the queue
 4 min. TEST 1 compile is running,            Status: R
 5 min. TEST 1 compile is running,            Status: R
 6 min. TEST 1 compile is running,            Status: R
-7 min. TEST 1 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890014       COMPLETED  compile_1 
-8890014.bat+  COMPLETED      batch 
-8890014.ext+  COMPLETED     extern 
-8 min. TEST 1 compile is COMPLETED
+9085157       COMPLETED  compile_1 
+9085157.bat+  COMPLETED      batch 
+9085157.ext+  COMPLETED     extern 
+7 min. TEST 1 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=486
-+ echo 'Elapsed time 486 seconds. Compile 1'
-Elapsed time 486 seconds. Compile 1
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 1'
+Elapsed time 425 seconds. Compile 1
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + export COMPILE_NR=2
 + COMPILE_NR=2
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -567,10 +557,10 @@ Elapsed time 486 seconds. Compile 1
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -603,15 +593,15 @@ Elapsed time 486 seconds. Compile 1
 + TEST_NR=2
 + export JBNME=compile_2
 + JBNME=compile_2
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_2
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_2
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -624,7 +614,7 @@ Elapsed time 486 seconds. Compile 1
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890009
+Job id 9085155
 TEST 2 compile is waiting to enter the queue
 1 min. TEST 2 compile is running,            Status: R
 2 min. TEST 2 compile is running,            Status: R
@@ -632,35 +622,44 @@ TEST 2 compile is waiting to enter the queue
 4 min. TEST 2 compile is running,            Status: R
 5 min. TEST 2 compile is running,            Status: R
 6 min. TEST 2 compile is running,            Status: R
+7 min. TEST 2 compile is running,            Status: R
+8 min. TEST 2 compile is running,            Status: R
+Slurm unknown status CG. Check sacct ...
+9085155       COMPLETED  compile_2 
+9085155.bat+  COMPLETED      batch 
+9085155.ext+  COMPLETED     extern 
+9 min. TEST 2 compile is COMPLETED
+COMPLETED
+COMPLETED
 Slurm unknown status -. Check sacct ...
-8890009       COMPLETED  compile_2 
-8890009.bat+  COMPLETED      batch 
-8890009.ext+  COMPLETED     extern 
-7 min. TEST 2 compile is COMPLETED
+9085155       COMPLETED  compile_2 
+9085155.bat+  COMPLETED      batch 
+9085155.ext+  COMPLETED     extern 
+10 min. TEST 2 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 2'
-Elapsed time 426 seconds. Compile 2
++ elapsed=606
++ echo 'Elapsed time 606 seconds. Compile 2'
+Elapsed time 606 seconds. Compile 2
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + export COMPILE_NR=3
 + COMPILE_NR=3
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -673,10 +672,10 @@ Elapsed time 426 seconds. Compile 2
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -709,15 +708,15 @@ Elapsed time 426 seconds. Compile 2
 + TEST_NR=3
 + export JBNME=compile_3
 + JBNME=compile_3
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_3
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_3
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -730,7 +729,7 @@ Elapsed time 426 seconds. Compile 2
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890016
+Job id 9085154
 TEST 3 compile is waiting to enter the queue
 1 min. TEST 3 compile is running,            Status: R
 2 min. TEST 3 compile is running,            Status: R
@@ -738,35 +737,38 @@ TEST 3 compile is waiting to enter the queue
 4 min. TEST 3 compile is running,            Status: R
 5 min. TEST 3 compile is running,            Status: R
 6 min. TEST 3 compile is running,            Status: R
+7 min. TEST 3 compile is running,            Status: R
+8 min. TEST 3 compile is running,            Status: R
+9 min. TEST 3 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890016       COMPLETED  compile_3 
-8890016.bat+  COMPLETED      batch 
-8890016.ext+  COMPLETED     extern 
-7 min. TEST 3 compile is COMPLETED
+9085154       COMPLETED  compile_3 
+9085154.bat+  COMPLETED      batch 
+9085154.ext+  COMPLETED     extern 
+10 min. TEST 3 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 3'
-Elapsed time 426 seconds. Compile 3
++ elapsed=606
++ echo 'Elapsed time 606 seconds. Compile 3'
+Elapsed time 606 seconds. Compile 3
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + export COMPILE_NR=4
 + COMPILE_NR=4
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -779,10 +781,10 @@ Elapsed time 426 seconds. Compile 3
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -815,15 +817,15 @@ Elapsed time 426 seconds. Compile 3
 + TEST_NR=4
 + export JBNME=compile_4
 + JBNME=compile_4
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_4
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_4
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -836,7 +838,7 @@ Elapsed time 426 seconds. Compile 3
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890012
+Job id 9085158
 TEST 4 compile is waiting to enter the queue
 1 min. TEST 4 compile is running,            Status: R
 2 min. TEST 4 compile is running,            Status: R
@@ -845,34 +847,34 @@ TEST 4 compile is waiting to enter the queue
 5 min. TEST 4 compile is running,            Status: R
 6 min. TEST 4 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890012       COMPLETED  compile_4 
-8890012.bat+  COMPLETED      batch 
-8890012.ext+  COMPLETED     extern 
+9085158       COMPLETED  compile_4 
+9085158.bat+  COMPLETED      batch 
+9085158.ext+  COMPLETED     extern 
 7 min. TEST 4 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 4'
-Elapsed time 426 seconds. Compile 4
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 4'
+Elapsed time 425 seconds. Compile 4
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=5
 + COMPILE_NR=5
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -885,10 +887,10 @@ Elapsed time 426 seconds. Compile 4
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -921,15 +923,15 @@ Elapsed time 426 seconds. Compile 4
 + TEST_NR=5
 + export JBNME=compile_5
 + JBNME=compile_5
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_5
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_5
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -942,39 +944,39 @@ Elapsed time 426 seconds. Compile 4
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890017
+Job id 9085156
 TEST 5 compile is waiting to enter the queue
 1 min. TEST 5 compile is running,            Status: R
 2 min. TEST 5 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890017       COMPLETED  compile_5 
-8890017.bat+  COMPLETED      batch 
-8890017.ext+  COMPLETED     extern 
+9085156       COMPLETED  compile_5 
+9085156.bat+  COMPLETED      batch 
+9085156.ext+  COMPLETED     extern 
 3 min. TEST 5 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=186
-+ echo 'Elapsed time 186 seconds. Compile 5'
-Elapsed time 186 seconds. Compile 5
++ elapsed=185
++ echo 'Elapsed time 185 seconds. Compile 5'
+Elapsed time 185 seconds. Compile 5
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=6
 + COMPILE_NR=6
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -987,10 +989,10 @@ Elapsed time 186 seconds. Compile 5
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -1023,15 +1025,15 @@ Elapsed time 186 seconds. Compile 5
 + TEST_NR=6
 + export JBNME=compile_6
 + JBNME=compile_6
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_6
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_6
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1044,7 +1046,7 @@ Elapsed time 186 seconds. Compile 5
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890015
+Job id 9085159
 TEST 6 compile is waiting to enter the queue
 1 min. TEST 6 compile is running,            Status: R
 2 min. TEST 6 compile is running,            Status: R
@@ -1052,35 +1054,36 @@ TEST 6 compile is waiting to enter the queue
 4 min. TEST 6 compile is running,            Status: R
 5 min. TEST 6 compile is running,            Status: R
 6 min. TEST 6 compile is running,            Status: R
+7 min. TEST 6 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890015       COMPLETED  compile_6 
-8890015.bat+  COMPLETED      batch 
-8890015.ext+  COMPLETED     extern 
-7 min. TEST 6 compile is COMPLETED
+9085159       COMPLETED  compile_6 
+9085159.bat+  COMPLETED      batch 
+9085159.ext+  COMPLETED     extern 
+8 min. TEST 6 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 6'
-Elapsed time 426 seconds. Compile 6
++ elapsed=485
++ echo 'Elapsed time 485 seconds. Compile 6'
+Elapsed time 485 seconds. Compile 6
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + export COMPILE_NR=7
 + COMPILE_NR=7
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1093,10 +1096,10 @@ Elapsed time 426 seconds. Compile 6
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -1129,15 +1132,15 @@ Elapsed time 426 seconds. Compile 6
 + TEST_NR=7
 + export JBNME=compile_7
 + JBNME=compile_7
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_7
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_7
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1150,7 +1153,7 @@ Elapsed time 426 seconds. Compile 6
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890013
+Job id 9085160
 TEST 7 compile is waiting to enter the queue
 1 min. TEST 7 compile is running,            Status: R
 2 min. TEST 7 compile is running,            Status: R
@@ -1159,34 +1162,34 @@ TEST 7 compile is waiting to enter the queue
 5 min. TEST 7 compile is running,            Status: R
 6 min. TEST 7 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890013       COMPLETED  compile_7 
-8890013.bat+  COMPLETED      batch 
-8890013.ext+  COMPLETED     extern 
+9085160       COMPLETED  compile_7 
+9085160.bat+  COMPLETED      batch 
+9085160.ext+  COMPLETED     extern 
 7 min. TEST 7 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 7'
-Elapsed time 426 seconds. Compile 7
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 7'
+Elapsed time 425 seconds. Compile 7
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + export COMPILE_NR=8
 + COMPILE_NR=8
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1199,10 +1202,10 @@ Elapsed time 426 seconds. Compile 7
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -1235,15 +1238,15 @@ Elapsed time 426 seconds. Compile 7
 + TEST_NR=8
 + export JBNME=compile_8
 + JBNME=compile_8
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_8
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_8
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1256,7 +1259,7 @@ Elapsed time 426 seconds. Compile 7
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890018
+Job id 9085161
 TEST 8 compile is waiting to enter the queue
 1 min. TEST 8 compile is running,            Status: R
 2 min. TEST 8 compile is running,            Status: R
@@ -1264,11 +1267,17 @@ TEST 8 compile is waiting to enter the queue
 4 min. TEST 8 compile is running,            Status: R
 5 min. TEST 8 compile is running,            Status: R
 6 min. TEST 8 compile is running,            Status: R
-7 min. TEST 8 compile is running,            Status: R
+Slurm unknown status CG. Check sacct ...
+9085161       COMPLETED  compile_8 
+9085161.bat+  COMPLETED      batch 
+9085161.ext+  COMPLETED     extern 
+7 min. TEST 8 compile is COMPLETED
+COMPLETED
+COMPLETED
 Slurm unknown status -. Check sacct ...
-8890018       COMPLETED  compile_8 
-8890018.bat+  COMPLETED      batch 
-8890018.ext+  COMPLETED     extern 
+9085161       COMPLETED  compile_8 
+9085161.bat+  COMPLETED      batch 
+9085161.ext+  COMPLETED     extern 
 8 min. TEST 8 compile is COMPLETED
 COMPLETED
 COMPLETED
@@ -1277,23 +1286,23 @@ COMPLETED
 Elapsed time 486 seconds. Compile 8
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
-+ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349
++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ export RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
++ RUNDIR_ROOT=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + export COMPILE_NR=9
 + COMPILE_NR=9
-+ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-+ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9.env ]]
-+ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9.env
++ cd /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
++ [[ -e /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9.env ]]
++ source /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9.env
 ++ export MACHINE_ID=hera.intel
 ++ MACHINE_ID=hera.intel
-++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests
-++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
-++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel
+++ export PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ PATHRT=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests
+++ export PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
+++ PATHTR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1306,10 +1315,10 @@ Elapsed time 486 seconds. Compile 8
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/RegressionTests_hera.intel.log
-++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
-++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/log_hera.intel
+++ export REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ REGRESSIONTEST_LOG=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/RegressionTests_hera.intel.log
+++ export LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
+++ LOG_DIR=/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/log_hera.intel
 + source default_vars.sh
 ++ '[' hera.intel = wcoss ']'
 ++ '[' hera.intel = wcoss_cray ']'
@@ -1342,15 +1351,15 @@ Elapsed time 486 seconds. Compile 8
 + TEST_NR=9
 + export JBNME=compile_9
 + JBNME=compile_9
-+ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9
-+ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9
++ export RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9
++ RUNDIR=/scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9
 + source rt_utils.sh
 ++ set -eu
-++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/intel/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9
-+ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/compile_9
++ mkdir -p /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9
++ cd /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/compile_9
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1363,7 +1372,7 @@ Elapsed time 486 seconds. Compile 8
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 8890011
+Job id 9085163
 TEST 9 compile is waiting to enter the queue
 1 min. TEST 9 compile is running,            Status: R
 2 min. TEST 9 compile is running,            Status: R
@@ -1372,12 +1381,12 @@ TEST 9 compile is waiting to enter the queue
 5 min. TEST 9 compile is running,            Status: R
 6 min. TEST 9 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-8890011       COMPLETED  compile_9 
-8890011.bat+  COMPLETED      batch 
-8890011.ext+  COMPLETED     extern 
+9085163       COMPLETED  compile_9 
+9085163.bat+  COMPLETED      batch 
+9085163.ext+  COMPLETED     extern 
 7 min. TEST 9 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 9'
-Elapsed time 426 seconds. Compile 9
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 9'
+Elapsed time 425 seconds. Compile 9

--- a/tests/Compile_orion.intel.log
+++ b/tests/Compile_orion.intel.log
@@ -1,22 +1,22 @@
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y'
 + export COMPILE_NR=10
 + COMPILE_NR=10
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -29,10 +29,10 @@
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -64,15 +64,15 @@
 + TEST_NR=10
 + export JBNME=compile_10
 + JBNME=compile_10
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_10
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_10
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -85,39 +85,45 @@
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105662
+Job id 128086
 TEST 10 compile is waiting to enter the queue
 1 min. TEST 10 compile is running,            Status: R
 2 min. TEST 10 compile is running,            Status: R
+3 min. TEST 10 compile is running,            Status: R
+4 min. TEST 10 compile is running,            Status: R
+5 min. TEST 10 compile is running,            Status: R
+6 min. TEST 10 compile is running,            Status: R
+7 min. TEST 10 compile is running,            Status: R
+8 min. TEST 10 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105662        COMPLETED compile_10 
-105662.batch  COMPLETED      batch 
-105662.exte+  COMPLETED     extern 
-3 min. TEST 10 compile is COMPLETED
+128086        COMPLETED compile_10 
+128086.batch  COMPLETED      batch 
+128086.exte+  COMPLETED     extern 
+9 min. TEST 10 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=185
-+ echo 'Elapsed time 185 seconds. Compile 10'
-Elapsed time 185 seconds. Compile 10
++ elapsed=546
++ echo 'Elapsed time 546 seconds. Compile 10'
+Elapsed time 546 seconds. Compile 10
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=11
 + COMPILE_NR=11
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -130,10 +136,10 @@ Elapsed time 185 seconds. Compile 10
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -165,15 +171,15 @@ Elapsed time 185 seconds. Compile 10
 + TEST_NR=11
 + export JBNME=compile_11
 + JBNME=compile_11
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_11
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_11
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -186,42 +192,38 @@ Elapsed time 185 seconds. Compile 10
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105717
+Job id 128156
 TEST 11 compile is waiting to enter the queue
 1 min. TEST 11 compile is running,            Status: R
-2 min. TEST 11 compile is running,            Status: R
-3 min. TEST 11 compile is running,            Status: R
-4 min. TEST 11 compile is running,            Status: R
-5 min. TEST 11 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105717        COMPLETED compile_11 
-105717.batch  COMPLETED      batch 
-105717.exte+  COMPLETED     extern 
-6 min. TEST 11 compile is COMPLETED
+128156        COMPLETED compile_11 
+128156.batch  COMPLETED      batch 
+128156.exte+  COMPLETED     extern 
+2 min. TEST 11 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=365
-+ echo 'Elapsed time 365 seconds. Compile 11'
-Elapsed time 365 seconds. Compile 11
++ elapsed=125
++ echo 'Elapsed time 125 seconds. Compile 11'
+Elapsed time 125 seconds. Compile 11
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + export COMPILE_NR=12
 + COMPILE_NR=12
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -234,10 +236,10 @@ Elapsed time 365 seconds. Compile 11
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -269,15 +271,15 @@ Elapsed time 365 seconds. Compile 11
 + TEST_NR=12
 + export JBNME=compile_12
 + JBNME=compile_12
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_12
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_12
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -290,49 +292,43 @@ Elapsed time 365 seconds. Compile 11
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105737
+Job id 128155
 TEST 12 compile is waiting to enter the queue
-1 min. TEST 12 compile is pending,            Status: PD
-2 min. TEST 12 compile is pending,            Status: PD
-3 min. TEST 12 compile is pending,            Status: PD
-4 min. TEST 12 compile is pending,            Status: PD
-5 min. TEST 12 compile is pending,            Status: PD
+1 min. TEST 12 compile is running,            Status: R
+2 min. TEST 12 compile is running,            Status: R
+3 min. TEST 12 compile is running,            Status: R
+4 min. TEST 12 compile is running,            Status: R
+5 min. TEST 12 compile is running,            Status: R
 6 min. TEST 12 compile is running,            Status: R
-7 min. TEST 12 compile is running,            Status: R
-8 min. TEST 12 compile is running,            Status: R
-9 min. TEST 12 compile is running,            Status: R
-10 min. TEST 12 compile is running,            Status: R
-11 min. TEST 12 compile is running,            Status: R
-12 min. TEST 12 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105737        COMPLETED compile_12 
-105737.batch  COMPLETED      batch 
-105737.exte+  COMPLETED     extern 
-13 min. TEST 12 compile is COMPLETED
+128155        COMPLETED compile_12 
+128155.batch  COMPLETED      batch 
+128155.exte+  COMPLETED     extern 
+7 min. TEST 12 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=786
-+ echo 'Elapsed time 786 seconds. Compile 12'
-Elapsed time 786 seconds. Compile 12
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 12'
+Elapsed time 425 seconds. Compile 12
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=13
 + COMPILE_NR=13
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -345,10 +341,10 @@ Elapsed time 786 seconds. Compile 12
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -380,15 +376,15 @@ Elapsed time 786 seconds. Compile 12
 + TEST_NR=13
 + export JBNME=compile_13
 + JBNME=compile_13
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_13
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_13
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -401,48 +397,43 @@ Elapsed time 786 seconds. Compile 12
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105738
+Job id 128157
 TEST 13 compile is waiting to enter the queue
-1 min. TEST 13 compile is pending,            Status: PD
-2 min. TEST 13 compile is pending,            Status: PD
-3 min. TEST 13 compile is pending,            Status: PD
-4 min. TEST 13 compile is pending,            Status: PD
-5 min. TEST 13 compile is pending,            Status: PD
+1 min. TEST 13 compile is running,            Status: R
+2 min. TEST 13 compile is running,            Status: R
+3 min. TEST 13 compile is running,            Status: R
+4 min. TEST 13 compile is running,            Status: R
+5 min. TEST 13 compile is running,            Status: R
 6 min. TEST 13 compile is running,            Status: R
-7 min. TEST 13 compile is running,            Status: R
-8 min. TEST 13 compile is running,            Status: R
-9 min. TEST 13 compile is running,            Status: R
-10 min. TEST 13 compile is running,            Status: R
-11 min. TEST 13 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105738        COMPLETED compile_13 
-105738.batch  COMPLETED      batch 
-105738.exte+  COMPLETED     extern 
-12 min. TEST 13 compile is COMPLETED
+128157        COMPLETED compile_13 
+128157.batch  COMPLETED      batch 
+128157.exte+  COMPLETED     extern 
+7 min. TEST 13 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=726
-+ echo 'Elapsed time 726 seconds. Compile 13'
-Elapsed time 726 seconds. Compile 13
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 13'
+Elapsed time 425 seconds. Compile 13
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017'
 + export COMPILE_NR=1
 + COMPILE_NR=1
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -455,10 +446,10 @@ Elapsed time 726 seconds. Compile 13
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -490,15 +481,15 @@ Elapsed time 726 seconds. Compile 13
 + TEST_NR=1
 + export JBNME=compile_1
 + JBNME=compile_1
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_1
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_1
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -511,7 +502,7 @@ Elapsed time 726 seconds. Compile 13
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105666
+Job id 128080
 TEST 1 compile is waiting to enter the queue
 1 min. TEST 1 compile is running,            Status: R
 2 min. TEST 1 compile is running,            Status: R
@@ -520,9 +511,9 @@ TEST 1 compile is waiting to enter the queue
 5 min. TEST 1 compile is running,            Status: R
 6 min. TEST 1 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105666        COMPLETED  compile_1 
-105666.batch  COMPLETED      batch 
-105666.exte+  COMPLETED     extern 
+128080        COMPLETED  compile_1 
+128080.batch  COMPLETED      batch 
+128080.exte+  COMPLETED     extern 
 7 min. TEST 1 compile is COMPLETED
 COMPLETED
 COMPLETED
@@ -531,23 +522,23 @@ COMPLETED
 Elapsed time 425 seconds. Compile 1
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + export COMPILE_NR=2
 + COMPILE_NR=2
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -560,10 +551,10 @@ Elapsed time 425 seconds. Compile 1
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -595,15 +586,15 @@ Elapsed time 425 seconds. Compile 1
 + TEST_NR=2
 + export JBNME=compile_2
 + JBNME=compile_2
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_2
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_2
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -616,7 +607,7 @@ Elapsed time 425 seconds. Compile 1
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105667
+Job id 128082
 TEST 2 compile is waiting to enter the queue
 1 min. TEST 2 compile is running,            Status: R
 2 min. TEST 2 compile is running,            Status: R
@@ -625,39 +616,35 @@ TEST 2 compile is waiting to enter the queue
 5 min. TEST 2 compile is running,            Status: R
 6 min. TEST 2 compile is running,            Status: R
 7 min. TEST 2 compile is running,            Status: R
-8 min. TEST 2 compile is running,            Status: R
-9 min. TEST 2 compile is running,            Status: R
-10 min. TEST 2 compile is running,            Status: R
-11 min. TEST 2 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105667        COMPLETED  compile_2 
-105667.batch  COMPLETED      batch 
-105667.exte+  COMPLETED     extern 
-12 min. TEST 2 compile is COMPLETED
+128082        COMPLETED  compile_2 
+128082.batch  COMPLETED      batch 
+128082.exte+  COMPLETED     extern 
+8 min. TEST 2 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=725
-+ echo 'Elapsed time 725 seconds. Compile 2'
-Elapsed time 725 seconds. Compile 2
++ elapsed=486
++ echo 'Elapsed time 486 seconds. Compile 2'
+Elapsed time 486 seconds. Compile 2
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + export COMPILE_NR=3
 + COMPILE_NR=3
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -670,10 +657,10 @@ Elapsed time 725 seconds. Compile 2
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -705,15 +692,15 @@ Elapsed time 725 seconds. Compile 2
 + TEST_NR=3
 + export JBNME=compile_3
 + JBNME=compile_3
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_3
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_3
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -726,7 +713,7 @@ Elapsed time 725 seconds. Compile 2
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105664
+Job id 128078
 TEST 3 compile is waiting to enter the queue
 1 min. TEST 3 compile is running,            Status: R
 2 min. TEST 3 compile is running,            Status: R
@@ -735,41 +722,35 @@ TEST 3 compile is waiting to enter the queue
 5 min. TEST 3 compile is running,            Status: R
 6 min. TEST 3 compile is running,            Status: R
 7 min. TEST 3 compile is running,            Status: R
-8 min. TEST 3 compile is running,            Status: R
-9 min. TEST 3 compile is running,            Status: R
-10 min. TEST 3 compile is running,            Status: R
-11 min. TEST 3 compile is running,            Status: R
-12 min. TEST 3 compile is running,            Status: R
-13 min. TEST 3 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105664        COMPLETED  compile_3 
-105664.batch  COMPLETED      batch 
-105664.exte+  COMPLETED     extern 
-14 min. TEST 3 compile is COMPLETED
+128078        COMPLETED  compile_3 
+128078.batch  COMPLETED      batch 
+128078.exte+  COMPLETED     extern 
+8 min. TEST 3 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=846
-+ echo 'Elapsed time 846 seconds. Compile 3'
-Elapsed time 846 seconds. Compile 3
++ elapsed=486
++ echo 'Elapsed time 486 seconds. Compile 3'
+Elapsed time 486 seconds. Compile 3
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + export COMPILE_NR=4
 + COMPILE_NR=4
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -782,10 +763,10 @@ Elapsed time 846 seconds. Compile 3
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -817,15 +798,15 @@ Elapsed time 846 seconds. Compile 3
 + TEST_NR=4
 + export JBNME=compile_4
 + JBNME=compile_4
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_4
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_4
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -838,7 +819,7 @@ Elapsed time 846 seconds. Compile 3
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105670
+Job id 128083
 TEST 4 compile is waiting to enter the queue
 1 min. TEST 4 compile is running,            Status: R
 2 min. TEST 4 compile is running,            Status: R
@@ -847,43 +828,35 @@ TEST 4 compile is waiting to enter the queue
 5 min. TEST 4 compile is running,            Status: R
 6 min. TEST 4 compile is running,            Status: R
 7 min. TEST 4 compile is running,            Status: R
-8 min. TEST 4 compile is running,            Status: R
-9 min. TEST 4 compile is running,            Status: R
-10 min. TEST 4 compile is running,            Status: R
-11 min. TEST 4 compile is running,            Status: R
-12 min. TEST 4 compile is running,            Status: R
-13 min. TEST 4 compile is running,            Status: R
-14 min. TEST 4 compile is running,            Status: R
-15 min. TEST 4 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105670        COMPLETED  compile_4 
-105670.batch  COMPLETED      batch 
-105670.exte+  COMPLETED     extern 
-16 min. TEST 4 compile is COMPLETED
+128083        COMPLETED  compile_4 
+128083.batch  COMPLETED      batch 
+128083.exte+  COMPLETED     extern 
+8 min. TEST 4 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=966
-+ echo 'Elapsed time 966 seconds. Compile 4'
-Elapsed time 966 seconds. Compile 4
++ elapsed=486
++ echo 'Elapsed time 486 seconds. Compile 4'
+Elapsed time 486 seconds. Compile 4
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=5
 + COMPILE_NR=5
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -896,10 +869,10 @@ Elapsed time 966 seconds. Compile 4
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -931,15 +904,15 @@ Elapsed time 966 seconds. Compile 4
 + TEST_NR=5
 + export JBNME=compile_5
 + JBNME=compile_5
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_5
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_5
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -952,7 +925,7 @@ Elapsed time 966 seconds. Compile 4
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105669
+Job id 128079
 TEST 5 compile is waiting to enter the queue
 1 min. TEST 5 compile is running,            Status: R
 2 min. TEST 5 compile is running,            Status: R
@@ -961,37 +934,35 @@ TEST 5 compile is waiting to enter the queue
 5 min. TEST 5 compile is running,            Status: R
 6 min. TEST 5 compile is running,            Status: R
 7 min. TEST 5 compile is running,            Status: R
-8 min. TEST 5 compile is running,            Status: R
-9 min. TEST 5 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105669        COMPLETED  compile_5 
-105669.batch  COMPLETED      batch 
-105669.exte+  COMPLETED     extern 
-10 min. TEST 5 compile is COMPLETED
+128079        COMPLETED  compile_5 
+128079.batch  COMPLETED      batch 
+128079.exte+  COMPLETED     extern 
+8 min. TEST 5 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=605
-+ echo 'Elapsed time 605 seconds. Compile 5'
-Elapsed time 605 seconds. Compile 5
++ elapsed=486
++ echo 'Elapsed time 486 seconds. Compile 5'
+Elapsed time 486 seconds. Compile 5
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=6
 + COMPILE_NR=6
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1004,10 +975,10 @@ Elapsed time 605 seconds. Compile 5
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -1039,15 +1010,15 @@ Elapsed time 605 seconds. Compile 5
 + TEST_NR=6
 + export JBNME=compile_6
 + JBNME=compile_6
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_6
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_6
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1060,7 +1031,7 @@ Elapsed time 605 seconds. Compile 5
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105665
+Job id 128077
 TEST 6 compile is waiting to enter the queue
 1 min. TEST 6 compile is running,            Status: R
 2 min. TEST 6 compile is running,            Status: R
@@ -1069,9 +1040,9 @@ TEST 6 compile is waiting to enter the queue
 5 min. TEST 6 compile is running,            Status: R
 6 min. TEST 6 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105665        COMPLETED  compile_6 
-105665.batch  COMPLETED      batch 
-105665.exte+  COMPLETED     extern 
+128077        COMPLETED  compile_6 
+128077.batch  COMPLETED      batch 
+128077.exte+  COMPLETED     extern 
 7 min. TEST 6 compile is COMPLETED
 COMPLETED
 COMPLETED
@@ -1080,23 +1051,23 @@ COMPLETED
 Elapsed time 425 seconds. Compile 6
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf'
 + export COMPILE_NR=7
 + COMPILE_NR=7
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1109,10 +1080,10 @@ Elapsed time 425 seconds. Compile 6
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -1144,15 +1115,15 @@ Elapsed time 425 seconds. Compile 6
 + TEST_NR=7
 + export JBNME=compile_7
 + JBNME=compile_7
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_7
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_7
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1165,7 +1136,7 @@ Elapsed time 425 seconds. Compile 6
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105663
+Job id 128081
 TEST 7 compile is waiting to enter the queue
 1 min. TEST 7 compile is running,            Status: R
 2 min. TEST 7 compile is running,            Status: R
@@ -1174,41 +1145,35 @@ TEST 7 compile is waiting to enter the queue
 5 min. TEST 7 compile is running,            Status: R
 6 min. TEST 7 compile is running,            Status: R
 7 min. TEST 7 compile is running,            Status: R
-8 min. TEST 7 compile is running,            Status: R
-9 min. TEST 7 compile is running,            Status: R
-10 min. TEST 7 compile is running,            Status: R
-11 min. TEST 7 compile is running,            Status: R
-12 min. TEST 7 compile is running,            Status: R
-13 min. TEST 7 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105663        COMPLETED  compile_7 
-105663.batch  COMPLETED      batch 
-105663.exte+  COMPLETED     extern 
-14 min. TEST 7 compile is COMPLETED
+128081        COMPLETED  compile_7 
+128081.batch  COMPLETED      batch 
+128081.exte+  COMPLETED     extern 
+8 min. TEST 7 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=846
-+ echo 'Elapsed time 846 seconds. Compile 7'
-Elapsed time 846 seconds. Compile 7
++ elapsed=486
++ echo 'Elapsed time 486 seconds. Compile 7'
+Elapsed time 486 seconds. Compile 7
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + export COMPILE_NR=8
 + COMPILE_NR=8
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1221,10 +1186,10 @@ Elapsed time 846 seconds. Compile 7
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -1256,15 +1221,15 @@ Elapsed time 846 seconds. Compile 7
 + TEST_NR=8
 + export JBNME=compile_8
 + JBNME=compile_8
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_8
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_8
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1277,7 +1242,7 @@ Elapsed time 846 seconds. Compile 7
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105661
+Job id 128085
 TEST 8 compile is waiting to enter the queue
 1 min. TEST 8 compile is running,            Status: R
 2 min. TEST 8 compile is running,            Status: R
@@ -1285,36 +1250,35 @@ TEST 8 compile is waiting to enter the queue
 4 min. TEST 8 compile is running,            Status: R
 5 min. TEST 8 compile is running,            Status: R
 6 min. TEST 8 compile is running,            Status: R
-7 min. TEST 8 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105661        COMPLETED  compile_8 
-105661.batch  COMPLETED      batch 
-105661.exte+  COMPLETED     extern 
-8 min. TEST 8 compile is COMPLETED
+128085        COMPLETED  compile_8 
+128085.batch  COMPLETED      batch 
+128085.exte+  COMPLETED     extern 
+7 min. TEST 8 compile is COMPLETED
 COMPLETED
 COMPLETED
-+ elapsed=485
-+ echo 'Elapsed time 485 seconds. Compile 8'
-Elapsed time 485 seconds. Compile 8
++ elapsed=425
++ echo 'Elapsed time 425 seconds. Compile 8'
+Elapsed time 425 seconds. Compile 8
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
-+ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674
++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ export RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
++ RUNDIR_ROOT=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP'
 + export COMPILE_NR=9
 + COMPILE_NR=9
-+ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-+ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9.env ]]
-+ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9.env
++ cd /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
++ [[ -e /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9.env ]]
++ source /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9.env
 ++ export MACHINE_ID=orion.intel
 ++ MACHINE_ID=orion.intel
-++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests
-++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
-++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update
+++ export PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ PATHRT=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests
+++ export PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
+++ PATHTR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix
 ++ export SCHEDULER=slurm
 ++ SCHEDULER=slurm
 ++ export ACCNR=gsd-hpcs
@@ -1327,10 +1291,10 @@ Elapsed time 485 seconds. Compile 8
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/RegressionTests_orion.intel.log
-++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
-++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/log_orion.intel
+++ export REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ REGRESSIONTEST_LOG=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/RegressionTests_orion.intel.log
+++ export LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
+++ LOG_DIR=/work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/log_orion.intel
 + source default_vars.sh
 ++ '[' orion.intel = wcoss ']'
 ++ '[' orion.intel = wcoss_cray ']'
@@ -1362,15 +1326,15 @@ Elapsed time 485 seconds. Compile 8
 + TEST_NR=9
 + export JBNME=compile_9
 + JBNME=compile_9
-+ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9
-+ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9
++ export RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9
++ RUNDIR=/work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9
 + source rt_utils.sh
 ++ set -eu
-++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200616-jetbuild-heragnu-dycore-update/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /work/noaa/gmtb/dheinzel/ufs-weather-model/ufs-weather-model-emc-develop-20200624_dycore_mpifix/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9
-+ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/compile_9
++ mkdir -p /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9
++ cd /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/compile_9
 + [[ slurm = \s\l\u\r\m ]]
 + atparse
 + local __set_x
@@ -1383,7 +1347,7 @@ Elapsed time 485 seconds. Compile 8
 + '[' -o xtrace ']'
 + set_x='set -x'
 + set +x
-Job id 105668
+Job id 128084
 TEST 9 compile is waiting to enter the queue
 1 min. TEST 9 compile is running,            Status: R
 2 min. TEST 9 compile is running,            Status: R
@@ -1392,9 +1356,9 @@ TEST 9 compile is waiting to enter the queue
 5 min. TEST 9 compile is running,            Status: R
 6 min. TEST 9 compile is running,            Status: R
 Slurm unknown status -. Check sacct ...
-105668        COMPLETED  compile_9 
-105668.batch  COMPLETED      batch 
-105668.exte+  COMPLETED     extern 
+128084        COMPLETED  compile_9 
+128084.batch  COMPLETED      batch 
+128084.exte+  COMPLETED     extern 
 7 min. TEST 9 compile is COMPLETED
 COMPLETED
 COMPLETED

--- a/tests/Compile_wcoss_cray.log
+++ b/tests/Compile_wcoss_cray.log
@@ -1,246 +1,22 @@
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v16_csawmg'
-+ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v16_csawmg'
-+ export COMPILE_NR=10
-+ COMPILE_NR=10
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10.env
-++ export MACHINE_ID=wcoss_cray
-++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ export SCHEDULER=lsf
-++ SCHEDULER=lsf
-++ export ACCNR=GFS-DEV
-++ ACCNR=GFS-DEV
-++ export QUEUE=dev
-++ QUEUE=dev
-++ export PARTITION=
-++ PARTITION=
-++ export ROCOTO=false
-++ ROCOTO=false
-++ export ECFLOW=true
-++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-+ source default_vars.sh
-++ '[' wcoss_cray = wcoss ']'
-++ '[' wcoss_cray = wcoss_cray ']'
-++ TASKS_dflt=150
-++ TPN_dflt=24
-++ INPES_dflt=3
-++ JNPES_dflt=8
-++ TASKS_thrd=84
-++ TPN_thrd=12
-++ INPES_thrd=3
-++ JNPES_thrd=4
-++ TASKS_stretch=48
-++ TPN_stretch=24
-++ INPES_stretch=2
-++ JNPES_stretch=4
-++ TASKS_strnest=96
-++ TPN_strnest=24
-++ INPES_strnest=2
-++ JNPES_strnest=4
-++ COMPILER=intel
-++ [[ intel = gnu ]]
-++ [[ intel = pgi ]]
-++ WLCLK_dflt=15
-+ export TEST_NAME=compile
-+ TEST_NAME=compile
-+ export TEST_NR=10
-+ TEST_NR=10
-+ export JBNME=compile_10
-+ JBNME=compile_10
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10
-+ source rt_utils.sh
-++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
-++ UNIT_TEST=false
-+ source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_10
-+ [[ lsf = \s\l\u\r\m ]]
-+ [[ lsf = \l\s\f ]]
-+ atparse
-+ local __set_x
-+ '[' -o xtrace ']'
-+ __set_x='set -x'
-+ set +x
-+ [[ false = \f\a\l\s\e ]]
-+ submit_and_wait job_card
-+ [[ -z job_card ]]
-+ '[' -o xtrace ']'
-+ set_x='set -x'
-+ set +x
-ESUB: OMP_NUM_THREADS value changed to 1
-ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402169
-TEST 10 compile is waiting to enter the queue
-1 min. TEST 10 compile is waiting in a queue, Status: PEND
-2 min. TEST 10 compile is waiting in a queue, Status: PEND
-3 min. TEST 10 compile is waiting in a queue, Status: PEND
-4 min. TEST 10 compile is waiting in a queue, Status: PEND
-5 min. TEST 10 compile is running,            Status: RUN
-6 min. TEST 10 compile is running,            Status: RUN
-7 min. TEST 10 compile is running,            Status: RUN
-8 min. TEST 10 compile is running,            Status: RUN
-9 min. TEST 10 compile is running,            Status: RUN
-10 min. TEST 10 compile is running,            Status: RUN
-11 min. TEST 10 compile is running,            Status: RUN
-12 min. TEST 10 compile is running,            Status: RUN
-13 min. TEST 10 compile is running,            Status: RUN
-14 min. TEST 10 compile is running,            Status: RUN
-15 min. TEST 10 compile is running,            Status: RUN
-16 min. TEST 10 compile is running,            Status: RUN
-17 min. TEST 10 compile is running,            Status: RUN
-18 min. TEST 10 compile is running,            Status: RUN
-19 min. TEST 10 compile is finished,           Status: DONE
-+ elapsed=1146
-+ echo 'Elapsed time 1146 seconds. Compile 10'
-Elapsed time 1146 seconds. Compile 10
-+ SECONDS=0
-+ [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
-+ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
-+ export COMPILE_NR=11
-+ COMPILE_NR=11
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11.env
-++ export MACHINE_ID=wcoss_cray
-++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ export SCHEDULER=lsf
-++ SCHEDULER=lsf
-++ export ACCNR=GFS-DEV
-++ ACCNR=GFS-DEV
-++ export QUEUE=dev
-++ QUEUE=dev
-++ export PARTITION=
-++ PARTITION=
-++ export ROCOTO=false
-++ ROCOTO=false
-++ export ECFLOW=true
-++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-+ source default_vars.sh
-++ '[' wcoss_cray = wcoss ']'
-++ '[' wcoss_cray = wcoss_cray ']'
-++ TASKS_dflt=150
-++ TPN_dflt=24
-++ INPES_dflt=3
-++ JNPES_dflt=8
-++ TASKS_thrd=84
-++ TPN_thrd=12
-++ INPES_thrd=3
-++ JNPES_thrd=4
-++ TASKS_stretch=48
-++ TPN_stretch=24
-++ INPES_stretch=2
-++ JNPES_stretch=4
-++ TASKS_strnest=96
-++ TPN_strnest=24
-++ INPES_strnest=2
-++ JNPES_strnest=4
-++ COMPILER=intel
-++ [[ intel = gnu ]]
-++ [[ intel = pgi ]]
-++ WLCLK_dflt=15
-+ export TEST_NAME=compile
-+ TEST_NAME=compile
-+ export TEST_NR=11
-+ TEST_NR=11
-+ export JBNME=compile_11
-+ JBNME=compile_11
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11
-+ source rt_utils.sh
-++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
-++ UNIT_TEST=false
-+ source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_11
-+ [[ lsf = \s\l\u\r\m ]]
-+ [[ lsf = \l\s\f ]]
-+ atparse
-+ local __set_x
-+ '[' -o xtrace ']'
-+ __set_x='set -x'
-+ set +x
-+ [[ false = \f\a\l\s\e ]]
-+ submit_and_wait job_card
-+ [[ -z job_card ]]
-+ '[' -o xtrace ']'
-+ set_x='set -x'
-+ set +x
-ESUB: OMP_NUM_THREADS value changed to 1
-ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402278
-TEST 11 compile is waiting to enter the queue
-1 min. TEST 11 compile is waiting in a queue, Status: PEND
-2 min. TEST 11 compile is waiting in a queue, Status: PEND
-3 min. TEST 11 compile is waiting in a queue, Status: PEND
-4 min. TEST 11 compile is waiting in a queue, Status: PEND
-5 min. TEST 11 compile is waiting in a queue, Status: PEND
-6 min. TEST 11 compile is running,            Status: RUN
-7 min. TEST 11 compile is running,            Status: RUN
-8 min. TEST 11 compile is running,            Status: RUN
-9 min. TEST 11 compile is running,            Status: RUN
-10 min. TEST 11 compile is running,            Status: RUN
-11 min. TEST 11 compile is running,            Status: RUN
-12 min. TEST 11 compile is running,            Status: RUN
-13 min. TEST 11 compile is running,            Status: RUN
-14 min. TEST 11 compile is running,            Status: RUN
-15 min. TEST 11 compile is running,            Status: RUN
-16 min. TEST 11 compile is running,            Status: RUN
-17 min. TEST 11 compile is running,            Status: RUN
-18 min. TEST 11 compile is running,            Status: RUN
-19 min. TEST 11 compile is finished,           Status: DONE
-+ elapsed=1146
-+ echo 'Elapsed time 1146 seconds. Compile 11'
-Elapsed time 1146 seconds. Compile 11
-+ SECONDS=0
-+ [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017'
 + export COMPILE_NR=1
 + COMPILE_NR=1
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -253,10 +29,10 @@ Elapsed time 1146 seconds. Compile 11
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -286,15 +62,15 @@ Elapsed time 1146 seconds. Compile 11
 + TEST_NR=1
 + export JBNME=compile_1
 + JBNME=compile_1
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_1
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_1
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -310,51 +86,44 @@ Elapsed time 1146 seconds. Compile 11
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402173
+Job id 414597
 TEST 1 compile is waiting to enter the queue
-1 min. TEST 1 compile is waiting in a queue, Status: PEND
-2 min. TEST 1 compile is waiting in a queue, Status: PEND
-3 min. TEST 1 compile is waiting in a queue, Status: PEND
-4 min. TEST 1 compile is waiting in a queue, Status: PEND
-5 min. TEST 1 compile is waiting in a queue, Status: PEND
-6 min. TEST 1 compile is waiting in a queue, Status: PEND
-7 min. TEST 1 compile is waiting in a queue, Status: PEND
+1 min. TEST 1 compile is running,            Status: RUN
+2 min. TEST 1 compile is running,            Status: RUN
+3 min. TEST 1 compile is running,            Status: RUN
+4 min. TEST 1 compile is running,            Status: RUN
+5 min. TEST 1 compile is running,            Status: RUN
+6 min. TEST 1 compile is running,            Status: RUN
+7 min. TEST 1 compile is running,            Status: RUN
 8 min. TEST 1 compile is running,            Status: RUN
 9 min. TEST 1 compile is running,            Status: RUN
 10 min. TEST 1 compile is running,            Status: RUN
 11 min. TEST 1 compile is running,            Status: RUN
 12 min. TEST 1 compile is running,            Status: RUN
 13 min. TEST 1 compile is running,            Status: RUN
-14 min. TEST 1 compile is running,            Status: RUN
-15 min. TEST 1 compile is running,            Status: RUN
-16 min. TEST 1 compile is running,            Status: RUN
-17 min. TEST 1 compile is running,            Status: RUN
-18 min. TEST 1 compile is running,            Status: RUN
-19 min. TEST 1 compile is running,            Status: RUN
-20 min. TEST 1 compile is running,            Status: RUN
-21 min. TEST 1 compile is finished,           Status: DONE
-+ elapsed=1266
-+ echo 'Elapsed time 1266 seconds. Compile 1'
-Elapsed time 1266 seconds. Compile 1
+14 min. TEST 1 compile is finished,           Status: DONE
++ elapsed=848
++ echo 'Elapsed time 848 seconds. Compile 1'
+Elapsed time 848 seconds. Compile 1
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
-+ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
-+ export COMPILE_NR=2
-+ COMPILE_NR=2
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2.env
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v16_csawmg'
++ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v16_csawmg'
++ export COMPILE_NR=10
++ COMPILE_NR=10
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -367,10 +136,226 @@ Elapsed time 1266 seconds. Compile 1
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
++ source default_vars.sh
+++ '[' wcoss_cray = wcoss ']'
+++ '[' wcoss_cray = wcoss_cray ']'
+++ TASKS_dflt=150
+++ TPN_dflt=24
+++ INPES_dflt=3
+++ JNPES_dflt=8
+++ TASKS_thrd=84
+++ TPN_thrd=12
+++ INPES_thrd=3
+++ JNPES_thrd=4
+++ TASKS_stretch=48
+++ TPN_stretch=24
+++ INPES_stretch=2
+++ JNPES_stretch=4
+++ TASKS_strnest=96
+++ TPN_strnest=24
+++ INPES_strnest=2
+++ JNPES_strnest=4
+++ COMPILER=intel
+++ [[ intel = gnu ]]
+++ [[ intel = pgi ]]
+++ WLCLK_dflt=15
++ export TEST_NAME=compile
++ TEST_NAME=compile
++ export TEST_NR=10
++ TEST_NR=10
++ export JBNME=compile_10
++ JBNME=compile_10
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10
++ source rt_utils.sh
+++ set -eu
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ UNIT_TEST=false
++ source atparse.bash
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_10
++ [[ lsf = \s\l\u\r\m ]]
++ [[ lsf = \l\s\f ]]
++ atparse
++ local __set_x
++ '[' -o xtrace ']'
++ __set_x='set -x'
++ set +x
++ [[ false = \f\a\l\s\e ]]
++ submit_and_wait job_card
++ [[ -z job_card ]]
++ '[' -o xtrace ']'
++ set_x='set -x'
++ set +x
+ESUB: OMP_NUM_THREADS value changed to 1
+ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
+Job id 414595
+TEST 10 compile is waiting to enter the queue
+1 min. TEST 10 compile is running,            Status: RUN
+2 min. TEST 10 compile is running,            Status: RUN
+3 min. TEST 10 compile is running,            Status: RUN
+4 min. TEST 10 compile is running,            Status: RUN
+5 min. TEST 10 compile is running,            Status: RUN
+6 min. TEST 10 compile is running,            Status: RUN
+7 min. TEST 10 compile is running,            Status: RUN
+8 min. TEST 10 compile is running,            Status: RUN
+9 min. TEST 10 compile is running,            Status: RUN
+10 min. TEST 10 compile is running,            Status: RUN
+11 min. TEST 10 compile is running,            Status: RUN
+12 min. TEST 10 compile is running,            Status: RUN
+13 min. TEST 10 compile is running,            Status: RUN
+14 min. TEST 10 compile is running,            Status: RUN
+15 min. TEST 10 compile is finished,           Status: DONE
++ elapsed=908
++ echo 'Elapsed time 908 seconds. Compile 10'
+Elapsed time 908 seconds. Compile 10
++ SECONDS=0
++ [[ 4 != 4 ]]
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
++ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
++ export COMPILE_NR=11
++ COMPILE_NR=11
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11.env
+++ export MACHINE_ID=wcoss_cray
+++ MACHINE_ID=wcoss_cray
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ export SCHEDULER=lsf
+++ SCHEDULER=lsf
+++ export ACCNR=GFS-DEV
+++ ACCNR=GFS-DEV
+++ export QUEUE=dev
+++ QUEUE=dev
+++ export PARTITION=
+++ PARTITION=
+++ export ROCOTO=false
+++ ROCOTO=false
+++ export ECFLOW=true
+++ ECFLOW=true
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
++ source default_vars.sh
+++ '[' wcoss_cray = wcoss ']'
+++ '[' wcoss_cray = wcoss_cray ']'
+++ TASKS_dflt=150
+++ TPN_dflt=24
+++ INPES_dflt=3
+++ JNPES_dflt=8
+++ TASKS_thrd=84
+++ TPN_thrd=12
+++ INPES_thrd=3
+++ JNPES_thrd=4
+++ TASKS_stretch=48
+++ TPN_stretch=24
+++ INPES_stretch=2
+++ JNPES_stretch=4
+++ TASKS_strnest=96
+++ TPN_strnest=24
+++ INPES_strnest=2
+++ JNPES_strnest=4
+++ COMPILER=intel
+++ [[ intel = gnu ]]
+++ [[ intel = pgi ]]
+++ WLCLK_dflt=15
++ export TEST_NAME=compile
++ TEST_NAME=compile
++ export TEST_NR=11
++ TEST_NR=11
++ export JBNME=compile_11
++ JBNME=compile_11
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11
++ source rt_utils.sh
+++ set -eu
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ UNIT_TEST=false
++ source atparse.bash
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_11
++ [[ lsf = \s\l\u\r\m ]]
++ [[ lsf = \l\s\f ]]
++ atparse
++ local __set_x
++ '[' -o xtrace ']'
++ __set_x='set -x'
++ set +x
++ [[ false = \f\a\l\s\e ]]
++ submit_and_wait job_card
++ [[ -z job_card ]]
++ '[' -o xtrace ']'
++ set_x='set -x'
++ set +x
+ESUB: OMP_NUM_THREADS value changed to 1
+ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
+Job id 414736
+TEST 11 compile is waiting to enter the queue
+1 min. TEST 11 compile is running,            Status: RUN
+2 min. TEST 11 compile is running,            Status: RUN
+3 min. TEST 11 compile is running,            Status: RUN
+4 min. TEST 11 compile is running,            Status: RUN
+5 min. TEST 11 compile is running,            Status: RUN
+6 min. TEST 11 compile is running,            Status: RUN
+7 min. TEST 11 compile is running,            Status: RUN
+8 min. TEST 11 compile is running,            Status: RUN
+9 min. TEST 11 compile is running,            Status: RUN
+10 min. TEST 11 compile is running,            Status: RUN
+11 min. TEST 11 compile is running,            Status: RUN
+12 min. TEST 11 compile is running,            Status: RUN
+13 min. TEST 11 compile is running,            Status: RUN
+14 min. TEST 11 compile is running,            Status: RUN
+15 min. TEST 11 compile is finished,           Status: DONE
++ elapsed=906
++ echo 'Elapsed time 906 seconds. Compile 11'
+Elapsed time 906 seconds. Compile 11
++ SECONDS=0
++ [[ 4 != 4 ]]
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
++ MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
++ export COMPILE_NR=2
++ COMPILE_NR=2
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2.env
+++ export MACHINE_ID=wcoss_cray
+++ MACHINE_ID=wcoss_cray
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ export SCHEDULER=lsf
+++ SCHEDULER=lsf
+++ export ACCNR=GFS-DEV
+++ ACCNR=GFS-DEV
+++ export QUEUE=dev
+++ QUEUE=dev
+++ export PARTITION=
+++ PARTITION=
+++ export ROCOTO=false
+++ ROCOTO=false
+++ export ECFLOW=true
+++ ECFLOW=true
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -400,15 +385,15 @@ Elapsed time 1266 seconds. Compile 1
 + TEST_NR=2
 + export JBNME=compile_2
 + JBNME=compile_2
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_2
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_2
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -424,11 +409,11 @@ Elapsed time 1266 seconds. Compile 1
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402166
+Job id 414592
 TEST 2 compile is waiting to enter the queue
-1 min. TEST 2 compile is waiting in a queue, Status: PEND
-2 min. TEST 2 compile is waiting in a queue, Status: PEND
-3 min. TEST 2 compile is waiting in a queue, Status: PEND
+1 min. TEST 2 compile is running,            Status: RUN
+2 min. TEST 2 compile is running,            Status: RUN
+3 min. TEST 2 compile is running,            Status: RUN
 4 min. TEST 2 compile is running,            Status: RUN
 5 min. TEST 2 compile is running,            Status: RUN
 6 min. TEST 2 compile is running,            Status: RUN
@@ -446,31 +431,29 @@ TEST 2 compile is waiting to enter the queue
 18 min. TEST 2 compile is running,            Status: RUN
 19 min. TEST 2 compile is running,            Status: RUN
 20 min. TEST 2 compile is running,            Status: RUN
-21 min. TEST 2 compile is running,            Status: RUN
-22 min. TEST 2 compile is running,            Status: RUN
-23 min. TEST 2 compile is finished,           Status: DONE
-+ elapsed=1386
-+ echo 'Elapsed time 1386 seconds. Compile 2'
-Elapsed time 1386 seconds. Compile 2
+21 min. TEST 2 compile is finished,           Status: DONE
++ elapsed=1269
++ echo 'Elapsed time 1269 seconds. Compile 2'
+Elapsed time 1269 seconds. Compile 2
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + export COMPILE_NR=3
 + COMPILE_NR=3
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -483,10 +466,10 @@ Elapsed time 1386 seconds. Compile 2
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -516,15 +499,15 @@ Elapsed time 1386 seconds. Compile 2
 + TEST_NR=3
 + export JBNME=compile_3
 + JBNME=compile_3
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_3
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_3
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -540,11 +523,11 @@ Elapsed time 1386 seconds. Compile 2
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402167
+Job id 414594
 TEST 3 compile is waiting to enter the queue
-1 min. TEST 3 compile is waiting in a queue, Status: PEND
-2 min. TEST 3 compile is waiting in a queue, Status: PEND
-3 min. TEST 3 compile is waiting in a queue, Status: PEND
+1 min. TEST 3 compile is running,            Status: RUN
+2 min. TEST 3 compile is running,            Status: RUN
+3 min. TEST 3 compile is running,            Status: RUN
 4 min. TEST 3 compile is running,            Status: RUN
 5 min. TEST 3 compile is running,            Status: RUN
 6 min. TEST 3 compile is running,            Status: RUN
@@ -556,32 +539,29 @@ TEST 3 compile is waiting to enter the queue
 12 min. TEST 3 compile is running,            Status: RUN
 13 min. TEST 3 compile is running,            Status: RUN
 14 min. TEST 3 compile is running,            Status: RUN
-15 min. TEST 3 compile is running,            Status: RUN
-16 min. TEST 3 compile is running,            Status: RUN
-17 min. TEST 3 compile is running,            Status: RUN
-18 min. TEST 3 compile is finished,           Status: DONE
-+ elapsed=1086
-+ echo 'Elapsed time 1086 seconds. Compile 3'
-Elapsed time 1086 seconds. Compile 3
+15 min. TEST 3 compile is finished,           Status: DONE
++ elapsed=908
++ echo 'Elapsed time 908 seconds. Compile 3'
+Elapsed time 908 seconds. Compile 3
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + export COMPILE_NR=4
 + COMPILE_NR=4
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -594,10 +574,10 @@ Elapsed time 1086 seconds. Compile 3
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -627,15 +607,15 @@ Elapsed time 1086 seconds. Compile 3
 + TEST_NR=4
 + export JBNME=compile_4
 + JBNME=compile_4
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_4
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_4
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -651,13 +631,13 @@ Elapsed time 1086 seconds. Compile 3
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402171
+Job id 414590
 TEST 4 compile is waiting to enter the queue
-1 min. TEST 4 compile is waiting in a queue, Status: PEND
-2 min. TEST 4 compile is waiting in a queue, Status: PEND
-3 min. TEST 4 compile is waiting in a queue, Status: PEND
-4 min. TEST 4 compile is waiting in a queue, Status: PEND
-5 min. TEST 4 compile is waiting in a queue, Status: PEND
+1 min. TEST 4 compile is running,            Status: RUN
+2 min. TEST 4 compile is running,            Status: RUN
+3 min. TEST 4 compile is running,            Status: RUN
+4 min. TEST 4 compile is running,            Status: RUN
+5 min. TEST 4 compile is running,            Status: RUN
 6 min. TEST 4 compile is running,            Status: RUN
 7 min. TEST 4 compile is running,            Status: RUN
 8 min. TEST 4 compile is running,            Status: RUN
@@ -667,34 +647,29 @@ TEST 4 compile is waiting to enter the queue
 12 min. TEST 4 compile is running,            Status: RUN
 13 min. TEST 4 compile is running,            Status: RUN
 14 min. TEST 4 compile is running,            Status: RUN
-15 min. TEST 4 compile is running,            Status: RUN
-16 min. TEST 4 compile is running,            Status: RUN
-17 min. TEST 4 compile is running,            Status: RUN
-18 min. TEST 4 compile is running,            Status: RUN
-19 min. TEST 4 compile is running,            Status: RUN
-20 min. TEST 4 compile is finished,           Status: DONE
-+ elapsed=1206
-+ echo 'Elapsed time 1206 seconds. Compile 4'
-Elapsed time 1206 seconds. Compile 4
+15 min. TEST 4 compile is finished,           Status: DONE
++ elapsed=908
++ echo 'Elapsed time 908 seconds. Compile 4'
+Elapsed time 908 seconds. Compile 4
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=5
 + COMPILE_NR=5
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -707,10 +682,10 @@ Elapsed time 1206 seconds. Compile 4
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -740,15 +715,15 @@ Elapsed time 1206 seconds. Compile 4
 + TEST_NR=5
 + export JBNME=compile_5
 + JBNME=compile_5
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_5
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_5
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -764,42 +739,40 @@ Elapsed time 1206 seconds. Compile 4
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402165
+Job id 414591
 TEST 5 compile is waiting to enter the queue
-1 min. TEST 5 compile is waiting in a queue, Status: PEND
-2 min. TEST 5 compile is waiting in a queue, Status: PEND
-3 min. TEST 5 compile is waiting in a queue, Status: PEND
+1 min. TEST 5 compile is running,            Status: RUN
+2 min. TEST 5 compile is running,            Status: RUN
+3 min. TEST 5 compile is running,            Status: RUN
 4 min. TEST 5 compile is running,            Status: RUN
 5 min. TEST 5 compile is running,            Status: RUN
 6 min. TEST 5 compile is running,            Status: RUN
 7 min. TEST 5 compile is running,            Status: RUN
 8 min. TEST 5 compile is running,            Status: RUN
 9 min. TEST 5 compile is running,            Status: RUN
-10 min. TEST 5 compile is running,            Status: RUN
-11 min. TEST 5 compile is running,            Status: RUN
-12 min. TEST 5 compile is finished,           Status: DONE
-+ elapsed=726
-+ echo 'Elapsed time 726 seconds. Compile 5'
-Elapsed time 726 seconds. Compile 5
+10 min. TEST 5 compile is finished,           Status: DONE
++ elapsed=606
++ echo 'Elapsed time 606 seconds. Compile 5'
+Elapsed time 606 seconds. Compile 5
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=6
 + COMPILE_NR=6
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -812,10 +785,10 @@ Elapsed time 726 seconds. Compile 5
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -845,15 +818,15 @@ Elapsed time 726 seconds. Compile 5
 + TEST_NR=6
 + export JBNME=compile_6
 + JBNME=compile_6
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_6
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_6
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -869,52 +842,44 @@ Elapsed time 726 seconds. Compile 5
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402174
+Job id 414596
 TEST 6 compile is waiting to enter the queue
-1 min. TEST 6 compile is waiting in a queue, Status: PEND
-2 min. TEST 6 compile is waiting in a queue, Status: PEND
-3 min. TEST 6 compile is waiting in a queue, Status: PEND
-4 min. TEST 6 compile is waiting in a queue, Status: PEND
-5 min. TEST 6 compile is waiting in a queue, Status: PEND
-6 min. TEST 6 compile is waiting in a queue, Status: PEND
-7 min. TEST 6 compile is waiting in a queue, Status: PEND
+1 min. TEST 6 compile is running,            Status: RUN
+2 min. TEST 6 compile is running,            Status: RUN
+3 min. TEST 6 compile is running,            Status: RUN
+4 min. TEST 6 compile is running,            Status: RUN
+5 min. TEST 6 compile is running,            Status: RUN
+6 min. TEST 6 compile is running,            Status: RUN
+7 min. TEST 6 compile is running,            Status: RUN
 8 min. TEST 6 compile is running,            Status: RUN
 9 min. TEST 6 compile is running,            Status: RUN
 10 min. TEST 6 compile is running,            Status: RUN
 11 min. TEST 6 compile is running,            Status: RUN
 12 min. TEST 6 compile is running,            Status: RUN
 13 min. TEST 6 compile is running,            Status: RUN
-14 min. TEST 6 compile is running,            Status: RUN
-15 min. TEST 6 compile is running,            Status: RUN
-16 min. TEST 6 compile is running,            Status: RUN
-17 min. TEST 6 compile is running,            Status: RUN
-18 min. TEST 6 compile is running,            Status: RUN
-19 min. TEST 6 compile is running,            Status: RUN
-20 min. TEST 6 compile is running,            Status: RUN
-21 min. TEST 6 compile is running,            Status: RUN
-22 min. TEST 6 compile is finished,           Status: DONE
-+ elapsed=1326
-+ echo 'Elapsed time 1326 seconds. Compile 6'
-Elapsed time 1326 seconds. Compile 6
+14 min. TEST 6 compile is finished,           Status: DONE
++ elapsed=848
++ echo 'Elapsed time 848 seconds. Compile 6'
+Elapsed time 848 seconds. Compile 6
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + export COMPILE_NR=7
 + COMPILE_NR=7
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -927,10 +892,10 @@ Elapsed time 1326 seconds. Compile 6
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -960,15 +925,15 @@ Elapsed time 1326 seconds. Compile 6
 + TEST_NR=7
 + export JBNME=compile_7
 + JBNME=compile_7
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_7
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_7
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -984,14 +949,14 @@ Elapsed time 1326 seconds. Compile 6
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402172
+Job id 414589
 TEST 7 compile is waiting to enter the queue
-1 min. TEST 7 compile is waiting in a queue, Status: PEND
-2 min. TEST 7 compile is waiting in a queue, Status: PEND
-3 min. TEST 7 compile is waiting in a queue, Status: PEND
-4 min. TEST 7 compile is waiting in a queue, Status: PEND
-5 min. TEST 7 compile is waiting in a queue, Status: PEND
-6 min. TEST 7 compile is waiting in a queue, Status: PEND
+1 min. TEST 7 compile is running,            Status: RUN
+2 min. TEST 7 compile is running,            Status: RUN
+3 min. TEST 7 compile is running,            Status: RUN
+4 min. TEST 7 compile is running,            Status: RUN
+5 min. TEST 7 compile is running,            Status: RUN
+6 min. TEST 7 compile is running,            Status: RUN
 7 min. TEST 7 compile is running,            Status: RUN
 8 min. TEST 7 compile is running,            Status: RUN
 9 min. TEST 7 compile is running,            Status: RUN
@@ -1000,34 +965,29 @@ TEST 7 compile is waiting to enter the queue
 12 min. TEST 7 compile is running,            Status: RUN
 13 min. TEST 7 compile is running,            Status: RUN
 14 min. TEST 7 compile is running,            Status: RUN
-15 min. TEST 7 compile is running,            Status: RUN
-16 min. TEST 7 compile is running,            Status: RUN
-17 min. TEST 7 compile is running,            Status: RUN
-18 min. TEST 7 compile is running,            Status: RUN
-19 min. TEST 7 compile is running,            Status: RUN
-20 min. TEST 7 compile is finished,           Status: DONE
-+ elapsed=1206
-+ echo 'Elapsed time 1206 seconds. Compile 7'
-Elapsed time 1206 seconds. Compile 7
+15 min. TEST 7 compile is finished,           Status: DONE
++ elapsed=908
++ echo 'Elapsed time 908 seconds. Compile 7'
+Elapsed time 908 seconds. Compile 7
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + export COMPILE_NR=8
 + COMPILE_NR=8
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -1040,10 +1000,10 @@ Elapsed time 1206 seconds. Compile 7
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -1073,15 +1033,15 @@ Elapsed time 1206 seconds. Compile 7
 + TEST_NR=8
 + export JBNME=compile_8
 + JBNME=compile_8
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_8
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_8
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -1097,13 +1057,13 @@ Elapsed time 1206 seconds. Compile 7
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402170
+Job id 414588
 TEST 8 compile is waiting to enter the queue
-1 min. TEST 8 compile is waiting in a queue, Status: PEND
-2 min. TEST 8 compile is waiting in a queue, Status: PEND
-3 min. TEST 8 compile is waiting in a queue, Status: PEND
-4 min. TEST 8 compile is waiting in a queue, Status: PEND
-5 min. TEST 8 compile is waiting in a queue, Status: PEND
+1 min. TEST 8 compile is running,            Status: RUN
+2 min. TEST 8 compile is running,            Status: RUN
+3 min. TEST 8 compile is running,            Status: RUN
+4 min. TEST 8 compile is running,            Status: RUN
+5 min. TEST 8 compile is running,            Status: RUN
 6 min. TEST 8 compile is running,            Status: RUN
 7 min. TEST 8 compile is running,            Status: RUN
 8 min. TEST 8 compile is running,            Status: RUN
@@ -1113,34 +1073,29 @@ TEST 8 compile is waiting to enter the queue
 12 min. TEST 8 compile is running,            Status: RUN
 13 min. TEST 8 compile is running,            Status: RUN
 14 min. TEST 8 compile is running,            Status: RUN
-15 min. TEST 8 compile is running,            Status: RUN
-16 min. TEST 8 compile is running,            Status: RUN
-17 min. TEST 8 compile is running,            Status: RUN
-18 min. TEST 8 compile is running,            Status: RUN
-19 min. TEST 8 compile is running,            Status: RUN
-20 min. TEST 8 compile is finished,           Status: DONE
-+ elapsed=1206
-+ echo 'Elapsed time 1206 seconds. Compile 8'
-Elapsed time 1206 seconds. Compile 8
+15 min. TEST 8 compile is finished,           Status: DONE
++ elapsed=908
++ echo 'Elapsed time 908 seconds. Compile 8'
+Elapsed time 908 seconds. Compile 8
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
-+ RUNDIR_ROOT=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387
++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
++ RUNDIR_ROOT=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=9
 + COMPILE_NR=9
-+ cd /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9.env ]]
-+ source /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9.env
++ cd /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9.env ]]
++ source /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9.env
 ++ export MACHINE_ID=wcoss_cray
 ++ MACHINE_ID=wcoss_cray
-++ export PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -1153,10 +1108,10 @@ Elapsed time 1206 seconds. Compile 8
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
-++ export LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
-++ LOG_DIR=/gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_cray
+++ export REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ REGRESSIONTEST_LOG=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_cray.log
+++ export LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
+++ LOG_DIR=/gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_cray
 + source default_vars.sh
 ++ '[' wcoss_cray = wcoss ']'
 ++ '[' wcoss_cray = wcoss_cray ']'
@@ -1186,15 +1141,15 @@ Elapsed time 1206 seconds. Compile 8
 + TEST_NR=9
 + export JBNME=compile_9
 + JBNME=compile_9
-+ export RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9
-+ RUNDIR=/gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9
++ export RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9
++ RUNDIR=/gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/hps3/emc/meso/save/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/hps3/emc/global/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9
-+ cd /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/compile_9
++ mkdir -p /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9
++ cd /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/compile_9
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -1210,21 +1165,17 @@ Elapsed time 1206 seconds. Compile 8
 + set +x
 ESUB: OMP_NUM_THREADS value changed to 1
 ESUB: MEMORY LIMIT rusage set to "rusage[mem=500]" - with rusage set in shared job.
-Job id 402168
+Job id 414593
 TEST 9 compile is waiting to enter the queue
-1 min. TEST 9 compile is waiting in a queue, Status: PEND
-2 min. TEST 9 compile is waiting in a queue, Status: PEND
-3 min. TEST 9 compile is waiting in a queue, Status: PEND
-4 min. TEST 9 compile is waiting in a queue, Status: PEND
+1 min. TEST 9 compile is running,            Status: RUN
+2 min. TEST 9 compile is running,            Status: RUN
+3 min. TEST 9 compile is running,            Status: RUN
+4 min. TEST 9 compile is running,            Status: RUN
 5 min. TEST 9 compile is running,            Status: RUN
 6 min. TEST 9 compile is running,            Status: RUN
 7 min. TEST 9 compile is running,            Status: RUN
 8 min. TEST 9 compile is running,            Status: RUN
-9 min. TEST 9 compile is running,            Status: RUN
-10 min. TEST 9 compile is running,            Status: RUN
-11 min. TEST 9 compile is running,            Status: RUN
-12 min. TEST 9 compile is running,            Status: RUN
-13 min. TEST 9 compile is finished,           Status: DONE
-+ elapsed=786
-+ echo 'Elapsed time 786 seconds. Compile 9'
-Elapsed time 786 seconds. Compile 9
+9 min. TEST 9 compile is finished,           Status: DONE
++ elapsed=546
++ echo 'Elapsed time 546 seconds. Compile 9'
+Elapsed time 546 seconds. Compile 9

--- a/tests/Compile_wcoss_dell_p3.log
+++ b/tests/Compile_wcoss_dell_p3.log
@@ -1,22 +1,22 @@
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_v16_csawmg'
 + export COMPILE_NR=10
 + COMPILE_NR=10
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -29,10 +29,10 @@
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -63,15 +63,15 @@
 + TEST_NR=10
 + export JBNME=compile_10
 + JBNME=compile_10
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_10
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_10
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -86,7 +86,7 @@
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890272
+Job id 28796252
 TEST 10 compile is waiting to enter the queue
 1 min. TEST 10 compile is running,            Status: RUN
 2 min. TEST 10 compile is running,            Status: RUN
@@ -110,29 +110,30 @@ TEST 10 compile is waiting to enter the queue
 20 min. TEST 10 compile is running,            Status: RUN
 21 min. TEST 10 compile is running,            Status: RUN
 22 min. TEST 10 compile is running,            Status: RUN
-23 min. TEST 10 compile is finished,           Status: DONE
-+ elapsed=1387
-+ echo 'Elapsed time 1387 seconds. Compile 10'
-Elapsed time 1387 seconds. Compile 10
+23 min. TEST 10 compile is running,            Status: RUN
+24 min. TEST 10 compile is finished,           Status: DONE
++ elapsed=1447
++ echo 'Elapsed time 1447 seconds. Compile 10'
+Elapsed time 1447 seconds. Compile 10
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=11
 + COMPILE_NR=11
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -145,10 +146,10 @@ Elapsed time 1387 seconds. Compile 10
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -179,15 +180,15 @@ Elapsed time 1387 seconds. Compile 10
 + TEST_NR=11
 + export JBNME=compile_11
 + JBNME=compile_11
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_11
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_11
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -202,7 +203,7 @@ Elapsed time 1387 seconds. Compile 10
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890788
+Job id 28796980
 TEST 11 compile is waiting to enter the queue
 1 min. TEST 11 compile is running,            Status: RUN
 2 min. TEST 11 compile is running,            Status: RUN
@@ -226,29 +227,30 @@ TEST 11 compile is waiting to enter the queue
 20 min. TEST 11 compile is running,            Status: RUN
 21 min. TEST 11 compile is running,            Status: RUN
 22 min. TEST 11 compile is running,            Status: RUN
-23 min. TEST 11 compile is finished,           Status: DONE
-+ elapsed=1387
-+ echo 'Elapsed time 1387 seconds. Compile 11'
-Elapsed time 1387 seconds. Compile 11
+23 min. TEST 11 compile is running,            Status: RUN
+24 min. TEST 11 compile is finished,           Status: DONE
++ elapsed=1447
++ echo 'Elapsed time 1447 seconds. Compile 11'
+Elapsed time 1447 seconds. Compile 11
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017'
 + export COMPILE_NR=1
 + COMPILE_NR=1
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -261,10 +263,10 @@ Elapsed time 1387 seconds. Compile 11
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -295,15 +297,15 @@ Elapsed time 1387 seconds. Compile 11
 + TEST_NR=1
 + export JBNME=compile_1
 + JBNME=compile_1
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_1
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_1
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -318,7 +320,7 @@ Elapsed time 1387 seconds. Compile 11
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890278
+Job id 28796259
 TEST 1 compile is waiting to enter the queue
 1 min. TEST 1 compile is running,            Status: RUN
 2 min. TEST 1 compile is running,            Status: RUN
@@ -340,31 +342,29 @@ TEST 1 compile is waiting to enter the queue
 18 min. TEST 1 compile is running,            Status: RUN
 19 min. TEST 1 compile is running,            Status: RUN
 20 min. TEST 1 compile is running,            Status: RUN
-21 min. TEST 1 compile is running,            Status: RUN
-22 min. TEST 1 compile is running,            Status: RUN
-23 min. TEST 1 compile is finished,           Status: DONE
-+ elapsed=1387
-+ echo 'Elapsed time 1387 seconds. Compile 1'
-Elapsed time 1387 seconds. Compile 1
+21 min. TEST 1 compile is finished,           Status: DONE
++ elapsed=1267
++ echo 'Elapsed time 1267 seconds. Compile 1'
+Elapsed time 1267 seconds. Compile 1
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y'
 + export COMPILE_NR=2
 + COMPILE_NR=2
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -377,10 +377,10 @@ Elapsed time 1387 seconds. Compile 1
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -411,15 +411,15 @@ Elapsed time 1387 seconds. Compile 1
 + TEST_NR=2
 + export JBNME=compile_2
 + JBNME=compile_2
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_2
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_2
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -434,7 +434,7 @@ Elapsed time 1387 seconds. Compile 1
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890276
+Job id 28796255
 TEST 2 compile is waiting to enter the queue
 1 min. TEST 2 compile is running,            Status: RUN
 2 min. TEST 2 compile is running,            Status: RUN
@@ -467,29 +467,33 @@ TEST 2 compile is waiting to enter the queue
 29 min. TEST 2 compile is running,            Status: RUN
 30 min. TEST 2 compile is running,            Status: RUN
 31 min. TEST 2 compile is running,            Status: RUN
-32 min. TEST 2 compile is finished,           Status: DONE
-+ elapsed=1928
-+ echo 'Elapsed time 1928 seconds. Compile 2'
-Elapsed time 1928 seconds. Compile 2
+32 min. TEST 2 compile is running,            Status: RUN
+33 min. TEST 2 compile is running,            Status: RUN
+34 min. TEST 2 compile is running,            Status: RUN
+35 min. TEST 2 compile is running,            Status: RUN
+36 min. TEST 2 compile is finished,           Status: DONE
++ elapsed=2168
++ echo 'Elapsed time 2168 seconds. Compile 2'
+Elapsed time 2168 seconds. Compile 2
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y'
 + export COMPILE_NR=3
 + COMPILE_NR=3
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -502,10 +506,10 @@ Elapsed time 1928 seconds. Compile 2
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -536,15 +540,15 @@ Elapsed time 1928 seconds. Compile 2
 + TEST_NR=3
 + export JBNME=compile_3
 + JBNME=compile_3
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_3
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_3
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -559,7 +563,7 @@ Elapsed time 1928 seconds. Compile 2
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890279
+Job id 28796253
 TEST 3 compile is waiting to enter the queue
 1 min. TEST 3 compile is running,            Status: RUN
 2 min. TEST 3 compile is running,            Status: RUN
@@ -590,23 +594,23 @@ TEST 3 compile is waiting to enter the queue
 Elapsed time 1447 seconds. Compile 3
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y'
 + export COMPILE_NR=4
 + COMPILE_NR=4
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -619,10 +623,10 @@ Elapsed time 1447 seconds. Compile 3
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -653,15 +657,15 @@ Elapsed time 1447 seconds. Compile 3
 + TEST_NR=4
 + export JBNME=compile_4
 + JBNME=compile_4
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_4
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_4
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -676,7 +680,7 @@ Elapsed time 1447 seconds. Compile 3
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890275
+Job id 28796258
 TEST 4 compile is waiting to enter the queue
 1 min. TEST 4 compile is running,            Status: RUN
 2 min. TEST 4 compile is running,            Status: RUN
@@ -700,29 +704,34 @@ TEST 4 compile is waiting to enter the queue
 20 min. TEST 4 compile is running,            Status: RUN
 21 min. TEST 4 compile is running,            Status: RUN
 22 min. TEST 4 compile is running,            Status: RUN
-23 min. TEST 4 compile is finished,           Status: DONE
-+ elapsed=1387
-+ echo 'Elapsed time 1387 seconds. Compile 4'
-Elapsed time 1387 seconds. Compile 4
+23 min. TEST 4 compile is running,            Status: RUN
+24 min. TEST 4 compile is running,            Status: RUN
+25 min. TEST 4 compile is running,            Status: RUN
+26 min. TEST 4 compile is running,            Status: RUN
+27 min. TEST 4 compile is running,            Status: RUN
+28 min. TEST 4 compile is finished,           Status: DONE
++ elapsed=1688
++ echo 'Elapsed time 1688 seconds. Compile 4'
+Elapsed time 1688 seconds. Compile 4
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=5
 + COMPILE_NR=5
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -735,10 +744,10 @@ Elapsed time 1387 seconds. Compile 4
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -769,15 +778,15 @@ Elapsed time 1387 seconds. Compile 4
 + TEST_NR=5
 + export JBNME=compile_5
 + JBNME=compile_5
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_5
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_5
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -792,7 +801,7 @@ Elapsed time 1387 seconds. Compile 4
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890273
+Job id 28796260
 TEST 5 compile is waiting to enter the queue
 1 min. TEST 5 compile is running,            Status: RUN
 2 min. TEST 5 compile is running,            Status: RUN
@@ -800,29 +809,32 @@ TEST 5 compile is waiting to enter the queue
 4 min. TEST 5 compile is running,            Status: RUN
 5 min. TEST 5 compile is running,            Status: RUN
 6 min. TEST 5 compile is running,            Status: RUN
-7 min. TEST 5 compile is finished,           Status: DONE
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 5'
-Elapsed time 426 seconds. Compile 5
+7 min. TEST 5 compile is running,            Status: RUN
+8 min. TEST 5 compile is running,            Status: RUN
+9 min. TEST 5 compile is running,            Status: RUN
+10 min. TEST 5 compile is finished,           Status: DONE
++ elapsed=606
++ echo 'Elapsed time 606 seconds. Compile 5'
+Elapsed time 606 seconds. Compile 5
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp'
 + export COMPILE_NR=6
 + COMPILE_NR=6
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -835,10 +847,10 @@ Elapsed time 426 seconds. Compile 5
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -869,15 +881,15 @@ Elapsed time 426 seconds. Compile 5
 + TEST_NR=6
 + export JBNME=compile_6
 + JBNME=compile_6
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_6
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_6
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -892,7 +904,7 @@ Elapsed time 426 seconds. Compile 5
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890274
+Job id 28796254
 TEST 6 compile is waiting to enter the queue
 1 min. TEST 6 compile is running,            Status: RUN
 2 min. TEST 6 compile is running,            Status: RUN
@@ -916,29 +928,32 @@ TEST 6 compile is waiting to enter the queue
 20 min. TEST 6 compile is running,            Status: RUN
 21 min. TEST 6 compile is running,            Status: RUN
 22 min. TEST 6 compile is running,            Status: RUN
-23 min. TEST 6 compile is finished,           Status: DONE
-+ elapsed=1387
-+ echo 'Elapsed time 1387 seconds. Compile 6'
-Elapsed time 1387 seconds. Compile 6
+23 min. TEST 6 compile is running,            Status: RUN
+24 min. TEST 6 compile is running,            Status: RUN
+25 min. TEST 6 compile is running,            Status: RUN
+26 min. TEST 6 compile is finished,           Status: DONE
++ elapsed=1567
++ echo 'Elapsed time 1567 seconds. Compile 6'
+Elapsed time 1567 seconds. Compile 6
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq'
 + export COMPILE_NR=7
 + COMPILE_NR=7
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -951,10 +966,10 @@ Elapsed time 1387 seconds. Compile 6
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -985,15 +1000,15 @@ Elapsed time 1387 seconds. Compile 6
 + TEST_NR=7
 + export JBNME=compile_7
 + JBNME=compile_7
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_7
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_7
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -1008,7 +1023,7 @@ Elapsed time 1387 seconds. Compile 6
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890277
+Job id 28796256
 TEST 7 compile is waiting to enter the queue
 1 min. TEST 7 compile is running,            Status: RUN
 2 min. TEST 7 compile is running,            Status: RUN
@@ -1035,29 +1050,31 @@ TEST 7 compile is waiting to enter the queue
 23 min. TEST 7 compile is running,            Status: RUN
 24 min. TEST 7 compile is running,            Status: RUN
 25 min. TEST 7 compile is running,            Status: RUN
-26 min. TEST 7 compile is finished,           Status: DONE
-+ elapsed=1568
-+ echo 'Elapsed time 1568 seconds. Compile 7'
-Elapsed time 1568 seconds. Compile 7
+26 min. TEST 7 compile is running,            Status: RUN
+27 min. TEST 7 compile is running,            Status: RUN
+28 min. TEST 7 compile is finished,           Status: DONE
++ elapsed=1688
++ echo 'Elapsed time 1688 seconds. Compile 7'
+Elapsed time 1688 seconds. Compile 7
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y'
 + export COMPILE_NR=8
 + COMPILE_NR=8
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -1070,10 +1087,10 @@ Elapsed time 1568 seconds. Compile 7
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -1104,15 +1121,15 @@ Elapsed time 1568 seconds. Compile 7
 + TEST_NR=8
 + export JBNME=compile_8
 + JBNME=compile_8
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_8
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_8
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -1127,7 +1144,7 @@ Elapsed time 1568 seconds. Compile 7
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890280
+Job id 28796251
 TEST 8 compile is waiting to enter the queue
 1 min. TEST 8 compile is running,            Status: RUN
 2 min. TEST 8 compile is running,            Status: RUN
@@ -1155,29 +1172,30 @@ TEST 8 compile is waiting to enter the queue
 24 min. TEST 8 compile is running,            Status: RUN
 25 min. TEST 8 compile is running,            Status: RUN
 26 min. TEST 8 compile is running,            Status: RUN
-27 min. TEST 8 compile is finished,           Status: DONE
-+ elapsed=1628
-+ echo 'Elapsed time 1628 seconds. Compile 8'
-Elapsed time 1628 seconds. Compile 8
+27 min. TEST 8 compile is running,            Status: RUN
+28 min. TEST 8 compile is finished,           Status: DONE
++ elapsed=1688
++ echo 'Elapsed time 1688 seconds. Compile 8'
+Elapsed time 1688 seconds. Compile 8
 + SECONDS=0
 + [[ 4 != 4 ]]
-+ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
-+ RUNDIR_ROOT=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302
++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ export RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
++ RUNDIR_ROOT=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454
 + export 'MAKE_OPT=CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + MAKE_OPT='CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y'
 + export COMPILE_NR=9
 + COMPILE_NR=9
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-+ [[ -e /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9.env ]]
-+ source /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9.env
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
++ [[ -e /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9.env ]]
++ source /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9.env
 ++ export MACHINE_ID=wcoss_dell_p3
 ++ MACHINE_ID=wcoss_dell_p3
-++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests
-++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
-++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model
+++ export PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ PATHRT=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests
+++ export PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
+++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model
 ++ export SCHEDULER=lsf
 ++ SCHEDULER=lsf
 ++ export ACCNR=GFS-DEV
@@ -1190,10 +1208,10 @@ Elapsed time 1628 seconds. Compile 8
 ++ ROCOTO=false
 ++ export ECFLOW=true
 ++ ECFLOW=true
-++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
-++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
-++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/log_wcoss_dell_p3
+++ export REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ REGRESSIONTEST_LOG=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/RegressionTests_wcoss_dell_p3.log
+++ export LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
+++ LOG_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/log_wcoss_dell_p3
 + source default_vars.sh
 ++ '[' wcoss_dell_p3 = wcoss ']'
 ++ '[' wcoss_dell_p3 = wcoss_cray ']'
@@ -1224,15 +1242,15 @@ Elapsed time 1628 seconds. Compile 8
 + TEST_NR=9
 + export JBNME=compile_9
 + JBNME=compile_9
-+ export RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9
-+ RUNDIR=/gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9
++ export RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9
++ RUNDIR=/gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9
 + source rt_utils.sh
 ++ set -eu
-++ [[ /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr151/ufs-weather-model/tests/run_compile.sh = \r\t\_\u\t\i\l\s\.\s\h ]]
+++ [[ /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/20200629/ufs-weather-model/tests/run_compile.sh = \.\/\r\t\_\u\t\i\l\s\.\s\h ]]
 ++ UNIT_TEST=false
 + source atparse.bash
-+ mkdir -p /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9
-+ cd /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/compile_9
++ mkdir -p /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9
++ cd /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/compile_9
 + [[ lsf = \s\l\u\r\m ]]
 + [[ lsf = \l\s\f ]]
 + atparse
@@ -1247,7 +1265,7 @@ Elapsed time 1628 seconds. Compile 8
 + set_x='set -x'
 + set +x
 ESUB: MEMORY LIMIT RLIMIT_RSS set to 8192 - with rusage set in shared job.
-Job id 26890281
+Job id 28796257
 TEST 9 compile is waiting to enter the queue
 1 min. TEST 9 compile is running,            Status: RUN
 2 min. TEST 9 compile is running,            Status: RUN
@@ -1255,7 +1273,13 @@ TEST 9 compile is waiting to enter the queue
 4 min. TEST 9 compile is running,            Status: RUN
 5 min. TEST 9 compile is running,            Status: RUN
 6 min. TEST 9 compile is running,            Status: RUN
-7 min. TEST 9 compile is finished,           Status: DONE
-+ elapsed=426
-+ echo 'Elapsed time 426 seconds. Compile 9'
-Elapsed time 426 seconds. Compile 9
+7 min. TEST 9 compile is running,            Status: RUN
+8 min. TEST 9 compile is running,            Status: RUN
+9 min. TEST 9 compile is running,            Status: RUN
+10 min. TEST 9 compile is running,            Status: RUN
+11 min. TEST 9 compile is running,            Status: RUN
+12 min. TEST 9 compile is running,            Status: RUN
+13 min. TEST 9 compile is finished,           Status: DONE
++ elapsed=787
++ echo 'Elapsed time 787 seconds. Compile 9'
+Elapsed time 787 seconds. Compile 9

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Fri Jun 19 21:24:32 UTC 2020
+Fri Jun 26 14:05:55 UTC 2020
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gfs_v16beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -187,7 +187,7 @@ Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_rrtmgp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_rrtmgp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_rrtmgp_prod
 Checking test 004 fv3_ccpp_rrtmgp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -255,7 +255,7 @@ Test 004 fv3_ccpp_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gsd_prod
 Checking test 005 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -347,7 +347,7 @@ Test 005 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_thompson_prod
 Checking test 006 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -415,7 +415,7 @@ Test 006 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_thompson_no_aero_prod
 Checking test 007 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -483,13 +483,13 @@ Test 007 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_control_debug_prod
 Checking test 008 fv3_ccpp_control_debug results ....
 Test 008 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 009 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -557,7 +557,7 @@ Test 009 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 010 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -625,7 +625,7 @@ Test 010 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/GNU/fv3_rrtmgp_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_225252/fv3_ccpp_rrtmgp_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_247707/fv3_ccpp_rrtmgp_debug_prod
 Checking test 011 fv3_ccpp_rrtmgp_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -693,5 +693,5 @@ Test 011 fv3_ccpp_rrtmgp_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 19 21:58:27 UTC 2020
-Elapsed time: 00h:33m:56s. Have a nice day!
+Fri Jun 26 14:35:45 UTC 2020
+Elapsed time: 00h:29m:51s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Fri Jun 19 20:12:53 UTC 2020
+Fri Jun 26 14:05:51 UTC 2020
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_read_inc_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -651,7 +651,7 @@ Test 011 fv3_ccpp_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_iau_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -719,7 +719,7 @@ Test 012 fv3_ccpp_iau PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -787,7 +787,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_lheatstrg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_lheatstrg_prod
 Checking test 014 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmprad_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmprad_prod
 Checking test 015 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,7 +884,7 @@ Test 015 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 016 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 017 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_control_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1050,7 +1050,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_stretched_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1106,7 +1106,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_stretched_nest_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1173,7 +1173,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1184,7 +1184,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1193,7 +1193,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_regional_quilt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1204,7 +1204,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_regional_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_regional_c768_prod
 Checking test 024 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1215,19 +1215,19 @@ Test 024 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
 Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
 Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1275,7 +1275,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1323,7 +1323,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1371,7 +1371,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmp_hwrfsas_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmp_hwrfsas_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmp_hwrfsas_prod
 Checking test 030 fv3_ccpp_gfdlmp_hwrfsas results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1419,7 +1419,7 @@ Test 030 fv3_ccpp_gfdlmp_hwrfsas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_csawmg_prod
 Checking test 031 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1467,7 +1467,7 @@ Test 031 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_satmedmf_prod
 Checking test 032 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1515,7 +1515,7 @@ Test 032 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_satmedmfq_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_satmedmfq_prod
 Checking test 033 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1563,7 +1563,7 @@ Test 033 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 034 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1611,7 +1611,7 @@ Test 034 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 035 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1663,7 +1663,7 @@ Test 035 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_cpt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_cpt_prod
 Checking test 036 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1717,7 +1717,7 @@ Test 036 fv3_ccpp_cpt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gsd_prod
 Checking test 037 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1809,7 +1809,7 @@ Test 037 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_thompson_prod
 Checking test 038 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1877,7 +1877,7 @@ Test 038 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_thompson_no_aero_prod
 Checking test 039 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1945,7 +1945,7 @@ Test 039 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfs_v15p2_prod
 Checking test 040 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2013,7 +2013,7 @@ Test 040 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfs_v16beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfs_v16beta_prod
 Checking test 041 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2081,7 +2081,7 @@ Test 041 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_rrtmgp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_rrtmgp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_rrtmgp_prod
 Checking test 042 fv3_ccpp_rrtmgp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2149,7 +2149,7 @@ Test 042 fv3_ccpp_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 043 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2217,7 +2217,7 @@ Test 043 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2285,7 +2285,7 @@ Test 044 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_rrtmgp_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_rrtmgp_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_rrtmgp_debug_prod
 Checking test 045 fv3_ccpp_rrtmgp_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2353,7 +2353,7 @@ Test 045 fv3_ccpp_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gsd_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gsd_debug_prod
 Checking test 046 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2421,7 +2421,7 @@ Test 046 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_thompson_debug_prod
 Checking test 047 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2489,7 +2489,7 @@ Test 047 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 048 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2557,7 +2557,7 @@ Test 048 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2605,7 +2605,7 @@ Test 049 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2653,7 +2653,7 @@ Test 050 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_273349/fv3_ccpp_gocart_clm_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_35237/fv3_ccpp_gocart_clm_prod
 Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2701,5 +2701,5 @@ Test 051 fv3_ccpp_gocart_clm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 19 20:45:04 UTC 2020
-Elapsed time: 00h:32m:12s. Have a nice day!
+Fri Jun 26 14:52:56 UTC 2020
+Elapsed time: 00h:47m:06s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Fri Jun 19 16:09:47 CDT 2020
+Fri Jun 26 10:43:27 CDT 2020
 Start Regression test
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_read_inc_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 008 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_stochy_prod
 Checking test 010 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -603,7 +603,7 @@ Test 010 fv3_ccpp_stochy PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_iau_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_iau_prod
 Checking test 011 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -671,7 +671,7 @@ Test 011 fv3_ccpp_iau PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_ca_prod
 Checking test 012 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -739,7 +739,7 @@ Test 012 fv3_ccpp_ca PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmprad_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmprad_prod
 Checking test 013 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -788,7 +788,7 @@ Test 013 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 014 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -837,7 +837,7 @@ Test 014 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 015 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -886,7 +886,7 @@ Test 015 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_control_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_control_32bit_prod
 Checking test 016 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -954,7 +954,7 @@ Test 016 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_stretched_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_stretched_prod
 Checking test 017 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1010,7 +1010,7 @@ Test 017 fv3_ccpp_stretched PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_stretched_nest_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_stretched_nest_prod
 Checking test 018 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1077,7 +1077,7 @@ Test 018 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_regional_control_prod
 Checking test 019 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1088,7 +1088,7 @@ Test 019 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_regional_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_regional_restart_prod
 Checking test 020 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1097,7 +1097,7 @@ Test 020 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_regional_quilt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_regional_quilt_prod
 Checking test 021 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1108,7 +1108,7 @@ Test 021 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_regional_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_regional_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_regional_c768_prod
 Checking test 022 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1119,19 +1119,19 @@ Test 022 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_control_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_control_debug_prod
 Checking test 023 fv3_ccpp_control_debug results ....
 Test 023 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_stretched_nest_debug_prod
 Checking test 024 fv3_ccpp_stretched_nest_debug results ....
 Test 024 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1179,7 +1179,7 @@ Test 025 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1227,7 +1227,7 @@ Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1275,7 +1275,7 @@ Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1323,7 +1323,7 @@ Test 028 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1371,7 +1371,7 @@ Test 029 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 030 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1419,7 +1419,7 @@ Test 030 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 031 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1471,7 +1471,7 @@ Test 031 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_cpt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_cpt_prod
 Checking test 032 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1525,7 +1525,7 @@ Test 032 fv3_ccpp_cpt PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gsd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gsd_prod
 Checking test 033 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1617,7 +1617,7 @@ Test 033 fv3_ccpp_gsd PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_thompson_prod
 Checking test 034 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1685,7 +1685,7 @@ Test 034 fv3_ccpp_thompson PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_thompson_no_aero_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_thompson_no_aero_prod
 Checking test 035 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1753,7 +1753,7 @@ Test 035 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfs_v15p2_prod
 Checking test 036 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1821,7 +1821,7 @@ Test 036 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfs_v16beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfs_v16beta_prod
 Checking test 037 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1889,7 +1889,7 @@ Test 037 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_rrtmgp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_rrtmgp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_rrtmgp_prod
 Checking test 038 fv3_ccpp_rrtmgp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1957,7 +1957,7 @@ Test 038 fv3_ccpp_rrtmgp PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 039 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2025,7 +2025,7 @@ Test 039 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 040 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2093,7 +2093,7 @@ Test 040 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_rrtmgp_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_rrtmgp_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_rrtmgp_debug_prod
 Checking test 041 fv3_ccpp_rrtmgp_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2161,7 +2161,7 @@ Test 041 fv3_ccpp_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gsd_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gsd_debug_prod
 Checking test 042 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2229,7 +2229,7 @@ Test 042 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_thompson_debug_prod
 Checking test 043 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2297,7 +2297,7 @@ Test 043 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 044 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2365,7 +2365,7 @@ Test 044 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 045 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2413,7 +2413,7 @@ Test 045 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 046 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2461,7 +2461,7 @@ Test 046 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/fv3-cam/djovic/RT/NEMSfv3gfs/develop-20200611/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_117674/fv3_ccpp_gocart_clm_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_308770/fv3_ccpp_gocart_clm_prod
 Checking test 047 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2509,5 +2509,5 @@ Test 047 fv3_ccpp_gocart_clm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 19 17:21:49 CDT 2020
-Elapsed time: 01h:12m:04s. Have a nice day!
+Fri Jun 26 11:21:29 CDT 2020
+Elapsed time: 00h:38m:03s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Fri Jun 19 21:11:16 UTC 2020
+Mon Jun 29 13:57:22 UTC 2020
 Start Regression test
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_control_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_decomp_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_2threads_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_restart_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_stochy_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -651,7 +651,7 @@ Test 011 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_iau_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -719,7 +719,7 @@ Test 012 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_lheatstrg_prod
 Checking test 013 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmprad_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmprad_prod
 Checking test 014 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,7 +816,7 @@ Test 014 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 015 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -865,7 +865,7 @@ Test 015 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_control_32bit_prod
 Checking test 016 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_stretched_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_stretched_prod
 Checking test 017 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -989,7 +989,7 @@ Test 017 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_stretched_nest_prod
 Checking test 018 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1056,7 +1056,7 @@ Test 018 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_regional_control_prod
 Checking test 019 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1067,7 +1067,7 @@ Test 019 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_regional_restart_prod
 Checking test 020 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1076,7 +1076,7 @@ Test 020 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_regional_quilt_prod
 Checking test 021 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1087,19 +1087,19 @@ Test 021 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_control_debug_prod
 Checking test 022 fv3_ccpp_control_debug results ....
 Test 022 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_stretched_nest_debug_prod
 Checking test 023 fv3_ccpp_stretched_nest_debug results ....
 Test 023 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmp_prod
 Checking test 024 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1147,7 +1147,7 @@ Test 024 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1195,7 +1195,7 @@ Test 025 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1243,7 +1243,7 @@ Test 026 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_hwrfsas_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmp_hwrfsas_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmp_hwrfsas_prod
 Checking test 027 fv3_ccpp_gfdlmp_hwrfsas results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1291,7 +1291,7 @@ Test 027 fv3_ccpp_gfdlmp_hwrfsas PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1339,7 +1339,7 @@ Test 028 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1387,7 +1387,7 @@ Test 029 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1435,7 +1435,7 @@ Test 030 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1483,7 +1483,7 @@ Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1535,7 +1535,7 @@ Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_cpt_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_cpt_prod
 Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1589,7 +1589,7 @@ Test 033 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gsd_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gsd_prod
 Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1681,7 +1681,7 @@ Test 034 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_thompson_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_thompson_prod
 Checking test 035 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1749,7 +1749,7 @@ Test 035 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_thompson_no_aero_prod
 Checking test 036 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1817,7 +1817,7 @@ Test 036 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gsd_debug_prod
 Checking test 037 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1885,7 +1885,7 @@ Test 037 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_thompson_debug_prod
 Checking test 038 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1953,7 +1953,7 @@ Test 038 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 039 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2021,7 +2021,7 @@ Test 039 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 040 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2069,7 +2069,7 @@ Test 040 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 041 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2117,7 +2117,7 @@ Test 041 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_32387/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_15948/fv3_ccpp_gocart_clm_prod
 Checking test 042 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2165,5 +2165,5 @@ Test 042 fv3_ccpp_gocart_clm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 19 22:21:25 UTC 2020
-Elapsed time: 01h:10m:10s. Have a nice day!
+Mon Jun 29 14:40:00 UTC 2020
+Elapsed time: 00h:42m:39s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Fri Jun 19 21:10:59 UTC 2020
+Mon Jun 29 13:57:39 UTC 2020
 Start Regression test
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_control_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_restart_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -651,7 +651,7 @@ Test 011 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_iau_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -719,7 +719,7 @@ Test 012 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_lheatstrg_prod
 Checking test 013 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmprad_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmprad_prod
 Checking test 014 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,7 +816,7 @@ Test 014 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 015 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -865,7 +865,7 @@ Test 015 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_control_32bit_prod
 Checking test 016 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_stretched_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_stretched_prod
 Checking test 017 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -989,7 +989,7 @@ Test 017 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_stretched_nest_prod
 Checking test 018 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1056,7 +1056,7 @@ Test 018 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_regional_control_prod
 Checking test 019 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1067,7 +1067,7 @@ Test 019 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_regional_restart_prod
 Checking test 020 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1076,7 +1076,7 @@ Test 020 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_regional_quilt_prod
 Checking test 021 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1087,7 +1087,7 @@ Test 021 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_regional_c768_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_regional_c768_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_regional_c768_prod
 Checking test 022 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1098,19 +1098,19 @@ Test 022 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_control_debug_prod
 Checking test 023 fv3_ccpp_control_debug results ....
 Test 023 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_stretched_nest_debug_prod
 Checking test 024 fv3_ccpp_stretched_nest_debug results ....
 Test 024 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1158,7 +1158,7 @@ Test 025 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1206,7 +1206,7 @@ Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1254,7 +1254,7 @@ Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_hwrfsas_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmp_hwrfsas_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmp_hwrfsas_prod
 Checking test 028 fv3_ccpp_gfdlmp_hwrfsas results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1302,7 +1302,7 @@ Test 028 fv3_ccpp_gfdlmp_hwrfsas PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_csawmg_prod
 Checking test 029 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1350,7 +1350,7 @@ Test 029 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_satmedmf_prod
 Checking test 030 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1398,7 +1398,7 @@ Test 030 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_satmedmfq_prod
 Checking test 031 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1446,7 +1446,7 @@ Test 031 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1494,7 +1494,7 @@ Test 032 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1546,7 +1546,7 @@ Test 033 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_cpt_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_cpt_prod
 Checking test 034 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1600,7 +1600,7 @@ Test 034 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gsd_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gsd_prod
 Checking test 035 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1692,7 +1692,7 @@ Test 035 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_thompson_prod
 Checking test 036 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1760,7 +1760,7 @@ Test 036 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_thompson_no_aero_prod
 Checking test 037 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1828,7 +1828,7 @@ Test 037 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gsd_debug_prod
 Checking test 038 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1896,7 +1896,7 @@ Test 038 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_thompson_debug_prod
 Checking test 039 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1964,7 +1964,7 @@ Test 039 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 040 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2032,7 +2032,7 @@ Test 040 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 041 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2080,7 +2080,7 @@ Test 041 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 042 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2128,7 +2128,7 @@ Test 042 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20200611/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_53302/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_131454/fv3_ccpp_gocart_clm_prod
 Checking test 043 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2176,5 +2176,5 @@ Test 043 fv3_ccpp_gocart_clm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 19 22:08:41 UTC 2020
-Elapsed time: 00h:57m:45s. Have a nice day!
+Mon Jun 29 14:42:50 UTC 2020
+Elapsed time: 00h:45m:15s. Have a nice day!


### PR DESCRIPTION
This PR only updates the submodule pointers for fv3atm / GFDL_atmos_cubed_sphere to fix issue NOAA-EMC/GFDL_atmos_cubed_sphere#24.

Associated PRs:
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/25
https://github.com/NOAA-EMC/fv3atm/pull/133
https://github.com/ufs-community/ufs-weather-model/pull/155

For regression testing, see below.