### PR TITLE
update the GFS_typesdef.meta in FV3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = develop
+	url = https://github.com/XiaSun-NOAA/fv3atm
+	branch = gfsmeta
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description
Add the active attribute to the vars wherever needed in the GFS_typesdef.meta file.
All the vars that are allocated in the GFS_typesdef.F90 based on `if `conditions were added an extra active attribute, except for `phy_fctd`.
In GFS_typesdef.F90: 
```
    if (Model%nctp > 0 .and. Model%cscnv) then
      allocate (Tbd%phy_fctd (IM,Model%nctp))
      Tbd%phy_fctd = clear_val
    endif
```
When 
`active = (number_of_cloud_types_CS > 0 .and. flag_for_Chikira_Sugiyama_deep_convection) `
is added to `phy_fctd `in GFS_typesdef.meta, error message is `'Exception: Variable number_of_cloud_types_cs used in conditional for cloud_base_mass_flux not known to host model`

Further inspection reveals that this is related to the upper case used in the active attribute. Somehow items = FORTRAN_CONDITIONAL_REGEX.findall(var.active.lower()) in the mkstatic.py only returns lower case strings. I have tried items = FORTRAN_CONDITIONAL_REGEX.findall(var.active), then print (items), they are still lower case string.

Currently, the active attribute needed for phy_fctd is not included yet.


## Testing
All 57 regression tests passed on Hera using the intel compiler with the current updated GFS_typesdef.meta file


## Dependencies
[NOAA-EMC/fv3atm#156
](https://github.com/NOAA-EMC/fv3atm/pull/156)