### PR TITLE
tests/rt_cheyenne.conf: update RRTMGP regression tests

### DIFF
--- a/tests/rt_cheyenne.conf
+++ b/tests/rt_cheyenne.conf
@@ -56,11 +56,12 @@ RUN     | fv3_ccpp_cpt                                                          
 RUN     | fv3_ccpp_gsd                                                                                                                   | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_rrfs_v1beta                                                                                                           | standard    | cheyenne.intel | fv3         |
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP                                                                | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_v15p2_RRTMGP,FV3_GFS_v16beta_RRTMGP                                        | standard    | cheyenne.intel | fv3         |
 
 RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_rrtmgp                                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v15p2_RRTMGP                                                                                                      | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta_RRTMGP                                                                                                    | standard    | cheyenne.intel | fv3         |
 
 COMPILE | CCPP=Y SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y                                                                        | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_multigases                                                                                                            | standard    | cheyenne.intel | fv3         |
@@ -76,11 +77,12 @@ COMPILE | CCPP=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y     
 RUN     | fv3_ccpp_control_debug                                                                                                         | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_stretched_nest_debug                                                                                                  | standard    | cheyenne.intel | fv3         |
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y                                                        | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_v15p2_RRTMGP,FV3_GFS_v16beta_RRTMGP DEBUG=Y                                | standard    | cheyenne.intel | fv3         |
 
 RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                       | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta_debug                                                                                                     | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_rrtmgp_debug                                                                                                          | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v15p2_RRTMGP_debug                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta_RRTMGP_debug                                                                                              | standard    | cheyenne.intel | fv3         |
 
 COMPILE | CCPP=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  | standard    | cheyenne.intel | fv3         |
 


### PR DESCRIPTION
## Description

This is a tiny bugfix following the RRTMGP regression test updates in the previous PR. This change affects file `tests/rt_cheyenne.conf` only and can be merged anytime, preferably as soon as possible, without having to run the tests on the tier-1 platforms.

### Issue(s) addressed

Running regression tests on cheyenne.intel using `rt_cheyenne.conf` fails because the old rrtmgp regression tests no longer exist (replaced by two new tests with different names).

## Testing

Tested on cheyenne.intel using `rt.sh -l rt_cheyenne.conf ...`

## Dependencies

n/a