### PR TITLE
release/public-v1: update ccpp-physics (fix unicode errors), downgrade Intel compiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v1
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v1
+	url = https://github.com/climbfuji/fv3atm
+	branch = fix_unicode_errors_ccpp_physics
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v1
-	url = https://github.com/climbfuji/fv3atm
-	branch = fix_unicode_errors_ccpp_physics
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v1
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/modulefiles/cheyenne.intel/fv3
+++ b/modulefiles/cheyenne.intel/fv3
@@ -16,7 +16,7 @@ module-whatis "loads NEMS FV3 prerequisites for Cheyenne/Intel"
 ## this typically includes compiler, MPI and job scheduler
 ##
 module load ncarenv/1.3
-module load intel/19.0.5
+module load intel/18.0.5
 module load mpt/2.19
 module load ncarcompilers/0.5.0
 module load netcdf/4.7.3
@@ -24,7 +24,7 @@ module load netcdf/4.7.3
 ##
 ## use pre-compiled EMSF library and NCEP libraries for above compiler / MPI combination
 ##
-module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19
+module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-18.0.5/mpt-2.19
 module load  NCEPlibs/1.1.0
 
 ##

--- a/modulefiles/gaea.intel/fv3
+++ b/modulefiles/gaea.intel/fv3
@@ -17,7 +17,7 @@ module-whatis "loads NEMS FV3 prerequisites for Gaea/Intel"
 ##
 module load PrgEnv-intel/6.0.5
 module unload intel
-module load intel/19.0.5.281
+module load intel/18.0.6.288
 module unload cray-mpich
 module load cray-mpich/7.7.11
 module unload cray-netcdf
@@ -26,7 +26,7 @@ module load cmake/3.17.0
 ##
 ## use pre-compiled EMSF library and NCEP libraries for above compiler / MPI combination
 ##
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-19.0.5.281/cray-mpich-7.7.11
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-18.0.6.288/cray-mpich-7.7.11
 module load NCEPlibs/1.1.0
 
 ## Needed at runtime:


### PR DESCRIPTION
For a description of the problem and how it is solved, see https://github.com/NCAR/ccpp-physics/pull/499. This PR only updates the submodule pointer for ccpp-physics.

Other changes:
- downgrade Intel compiler on Cheyenne and Gaeaa from 19.x.y to 18.m.n, since this seems to address issues with `chgres_cube.exe` (see https://github.com/ufs-community/ufs-mrweather-app/issues/190)

Note that we will need to retag ufs-weather-model v1.1.0 after this PR is merged.

## Testing

Regression tests will be run against existing baselines (simply copy to new date tag) on hera.intel and cheyenne.gnu; new baselines will be created for cheyenne.intel

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/499
https://github.com/NOAA-EMC/fv3atm/pull/172
https://github.com/ufs-community/ufs-weather-model/pull/204