### PR TITLE
GFS.v16: Update libs to use release version and the operational version on wcoss  

### DIFF
--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -48,8 +48,8 @@ module load post/8.0.10
 ## load ESMF library for above compiler / MPI combination
 ## use pre-compiled EMSF library for above compiler / MPI combination
 ##
-/scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles/
-module load netcdf-parallel/4.7.4.release
+module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles/
+module load netcdf_parallel/4.7.4.release
 module load hdf5_parallel/1.10.6.release
 module load esmf/8.0.1_ParallelNetCDF.release
 

--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -48,13 +48,10 @@ module load post/8.0.10
 ## load ESMF library for above compiler / MPI combination
 ## use pre-compiled EMSF library for above compiler / MPI combination
 ##
-#module load netcdf_parallel/4.7.4
-#module load esmf/8.0.1bs08
-module use -a /scratch1/NCEPDEV/global/gwv/lp/lib/modulefiles
-module load netcdfp/4.7.4
-module load esmflocal/8.0.1.08bs
-module use -a /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
-module load hdf5_parallel/1.10.6
+/scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles/
+module load netcdf-parallel/4.7.4.release
+module load hdf5_parallel/1.10.6.release
+module load esmf/8.0.1_ParallelNetCDF.release
 
 ##
 ## load cmake

--- a/modulefiles/orion.intel/fv3
+++ b/modulefiles/orion.intel/fv3
@@ -43,7 +43,7 @@ module load post/8.0.10
 ## load ESMF library for above compiler / MPI combination
 ## use pre-compiled EMSF library for above compiler / MPI combination
 ##
-/apps/contrib/NCEPLIBS/lib/modulefiles
+module use /apps/contrib/NCEPLIBS/lib/modulefiles
 module load netcdfp/4.7.4.release
 module load esmflocal/8_0_1.release
 

--- a/modulefiles/orion.intel/fv3
+++ b/modulefiles/orion.intel/fv3
@@ -43,10 +43,9 @@ module load post/8.0.10
 ## load ESMF library for above compiler / MPI combination
 ## use pre-compiled EMSF library for above compiler / MPI combination
 ##
-setenv NCEPLIBS /work/noaa/noaatest/gwv/l530/lib/
-module use /work/noaa/noaatest/gwv/l530/lib/modulefiles
-module load netcdfp/4.7.4
-module load esmflocal/8_0_1
+/apps/contrib/NCEPLIBS/lib/modulefiles
+module load netcdfp/4.7.4.release
+module load esmflocal/8_0_1.release
 
 ##
 ## load cmake

--- a/modulefiles/wcoss_cray/fv3
+++ b/modulefiles/wcoss_cray/fv3
@@ -17,21 +17,23 @@ module-whatis "loads NEMS FV3 prerequisites on Surge and Luna"
 ##
 module load PrgEnv-intel
 module rm intel
+module load intel/18.1.163
 module rm NetCDF-intel-sandybridge/4.2
-module load intel/16.3.210
-module load cray-netcdf/4.3.3.1
-module load cray-hdf5/1.8.14
 module load xt-lsfhpc/9.1.3
 module load craype-haswell
 module load python/2.7.14
-module load cmake/3.6.2
+module load cmake/3.16.2
+module load gcc/5.3.0
+#
+module use /usrx/local/dev/modulefiles
+module load NetCDF-intel-sandybridge/4.7.4
+module load HDF5-parallel-intel-sandybridge/1.10.6
 #
 ## WCOSS cray for WW3
-module load gcc/4.9.2
 module load jasper-gnu-sandybridge/1.900.1
 module load png-intel-sandybridge/1.2.49
 module load zlib-intel-sandybridge/1.2.7
-module load crtm-intel/2.2.6
+setenv PNG_ROOT /usrx/local/prod//png/1.2.49/intel/sandybridge
 
 module use /gpfs/hps/usrx/local/nceplibs/NCEPLIBS/modulefiles
 module load g2/3.1.1
@@ -57,15 +59,16 @@ module load gni-headers
 module load udreg
 module load ugni
 
-module use /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
-module load esmf/8.0.0
+module use /usrx/local/dev/modulefiles
+module load ESMF-intel-sandybridge/8.0.1
+module load NetCDF-intel-sandybridge/4.7.4
+module load HDF5-parallel-intel-sandybridge/1.10.6
 
 module swap pmi pmi/5.0.11
 
 ##
 ## load cmake
 ##
-module load cmake/3.6.2
 setenv CMAKE_C_COMPILER cc
 setenv CMAKE_CXX_COMPILER CC
 setenv CMAKE_Fortran_COMPILER ftn

--- a/modulefiles/wcoss_cray/fv3
+++ b/modulefiles/wcoss_cray/fv3
@@ -17,17 +17,17 @@ module-whatis "loads NEMS FV3 prerequisites on Surge and Luna"
 ##
 module load PrgEnv-intel
 module rm intel
-module load intel/18.1.163
 module rm NetCDF-intel-sandybridge/4.2
+module load intel/18.1.163
 module load xt-lsfhpc/9.1.3
 module load craype-haswell
 module load python/2.7.14
 module load cmake/3.16.2
 module load gcc/5.3.0
 #
-module use /usrx/local/dev/modulefiles
 module load NetCDF-intel-sandybridge/4.7.4
 module load HDF5-parallel-intel-sandybridge/1.10.6
+module load ESMF-intel-sandybridge/8.0.1
 #
 ## WCOSS cray for WW3
 module load jasper-gnu-sandybridge/1.900.1
@@ -35,21 +35,21 @@ module load png-intel-sandybridge/1.2.49
 module load zlib-intel-sandybridge/1.2.7
 setenv PNG_ROOT /usrx/local/prod//png/1.2.49/intel/sandybridge
 
-module use /gpfs/hps/usrx/local/nceplibs/NCEPLIBS/modulefiles
-module load g2/3.1.1
-module load g2tmpl/1.6.0
 ##
 ## load ncelibs libraries
 ##
-module load bacio/2.0.3
-module load ip/3.0.2
-module load sp/2.0.3
-module load w3nco/2.0.7
-module load w3emc/2.3.1
-module load nemsio/2.2.4
+module load bacio-intel/2.0.3
+module load ip-intel/3.0.2
+module load sp-intel/2.0.3
+module load w3nco-intel/2.2.0
+module load w3emc-intel/2.4.0
+module load nemsio-intel/2.2.4
+module load g2-intel/3.2.0
+module load g2tmpl-intel/1.6.0
+module load crtm-intel/2.3.0
 
-#post lib
-module load post/8.0.5
+module use /gpfs/hps/nco/ops/nwtest/lib/modulefiles
+module load post-intel/8.0.11
 
 ## WCOSS Cray execution prereqs:
 module load rca
@@ -58,11 +58,6 @@ module load xpmem
 module load gni-headers
 module load udreg
 module load ugni
-
-module use /usrx/local/dev/modulefiles
-module load ESMF-intel-sandybridge/8.0.1
-module load NetCDF-intel-sandybridge/4.7.4
-module load HDF5-parallel-intel-sandybridge/1.10.6
 
 module swap pmi pmi/5.0.11
 

--- a/modulefiles/wcoss_dell_p3/fv3
+++ b/modulefiles/wcoss_dell_p3/fv3
@@ -42,7 +42,7 @@ module load zlib/1.2.11
 # load post lib
 module load post/8.0.10
 
-module use /usrx/local/dev/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1
+module use /usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1
 module load NetCDF-parallel/4.7.4
 module load ESMF/8.0.1
 module load HDF5-parallel/1.10.6

--- a/modulefiles/wcoss_dell_p3/fv3
+++ b/modulefiles/wcoss_dell_p3/fv3
@@ -42,10 +42,10 @@ module load zlib/1.2.11
 # load post lib
 module load post/8.0.10
 
-module use /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles
-module load hdf5_parallel/1.10.6
-module load netcdf_parallel/4.7.4  
-module load esmf/8.0.1bs08
+module use /usrx/local/dev/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1
+module load NetCDF-parallel/4.7.4
+module load ESMF/8.0.1
+module load HDF5-parallel/1.10.6
 
 ##
 ## load cmake

--- a/modulefiles/wcoss_dell_p3/fv3
+++ b/modulefiles/wcoss_dell_p3/fv3
@@ -21,31 +21,31 @@ module load lsf/10.1
 module load cmake/3.10.0
 module load lsf/10.1
 
-module use -a /usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
 
 # other nceplibs
 module load bacio/2.0.3
 module load ip/3.0.2
 module load sp/2.0.3
-module load w3nco/2.0.7
-module load w3emc/2.3.1
+module load w3nco/2.2.0
+module load w3emc/2.4.0
 module load nemsio/2.2.4
-module load g2/3.1.1
 module load g2tmpl/1.6.0
-module load crtm/2.2.6
+module load crtm/2.3.0
+module load g2/3.2.0
 
 # WW3 grib encoding
 module load jasper/1.900.29
 module load libpng/1.2.59
 module load zlib/1.2.11
 
-# load post lib
-module load post/8.0.10
-
-module use /usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1
+# netcdf, esmf, hdf5
 module load NetCDF-parallel/4.7.4
 module load ESMF/8.0.1
 module load HDF5-parallel/1.10.6
+
+# load post lib
+module use -a /gpfs/dell1/nco/ops/nwtest/modulefiles/compiler_prod/ips/18.0.1
+module load post/8.0.11
 
 ##
 ## load cmake

--- a/tests/Compile_wcoss_dell_p3.log
+++ b/tests/Compile_wcoss_dell_p3.log
@@ -1,2054 +1,330 @@
 + SECONDS=0
-+++ readlink -f /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-++ dirname /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-+ readonly MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ readonly ARGC=4
-+ ARGC=4
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ [[ 4 -eq 0 ]]
 + [[ 4 -lt 2 ]]
-+ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model
-+ MACHINE_ID=wcoss_dell_p3
-+ MAKE_OPT=
++ readonly PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3
++ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3
++ readonly BUILD_TARGET=wcoss_dell_p3
++ BUILD_TARGET=wcoss_dell_p3
++ readonly 'MAKE_OPT=32BIT=Y WW3=Y'
++ MAKE_OPT='32BIT=Y WW3=Y'
++ readonly BUILD_NAME=fv3_1
 + BUILD_NAME=fv3_1
++ readonly clean_before=YES
 + clean_before=YES
++ readonly clean_after=YES
 + clean_after=YES
-+ BUILD_DIR=build_fv3_1
-+ [[ wcoss_dell_p3 == cheyenne.* ]]
-+ [[ wcoss_dell_p3 == wcoss_dell_p3 ]]
-+ MAKE_THREADS=4
-+ MAKE_THREADS=4
 + hostname
-m72a2
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ echo 'Compiling  into fv3_1.exe on wcoss_dell_p3'
-Compiling  into fv3_1.exe on wcoss_dell_p3
+m71a1
++ echo 'Compiling 32BIT=Y WW3=Y into fv3_1.exe on wcoss_dell_p3'
+Compiling 32BIT=Y WW3=Y into fv3_1.exe on wcoss_dell_p3
++ gnu_make=gmake
++ which gmake
+/usr/bin/gmake
++ [[ wcoss_dell_p3 == cheyenne.* ]]
++ [[ wcoss_dell_p3 == stampede.* ]]
++ MAKE_THREADS=8
++ [[ 8 -gt 1 ]]
++ echo Using '$MAKE_THREADS=8' threads to build FV3 and FMS.
+Using $MAKE_THREADS=8 threads to build FV3 and FMS.
++ echo Consider reducing '$MAKE_THREADS' if you hit memory or process limits.
+Consider reducing $MAKE_THREADS if you hit memory or process limits.
++ gnu_make='gmake -j 8'
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../NEMS
++ COMPONENTS=FMS,FV3
++ [[ 32BIT=Y WW3=Y == *\C\C\P\P\=\Y* ]]
++ [[ 32BIT=Y WW3=Y == *\W\W\3\=\Y* ]]
++ COMPONENTS=WW3,FMS,FV3
++ [[ 32BIT=Y WW3=Y == *\D\E\B\U\G\=\Y* ]]
++ [[ 32BIT=Y WW3=Y == *\D\E\B\U\G\=\Y* ]]
++ [[ 32BIT=Y WW3=Y == *\R\E\P\R\O\=\Y* ]]
++ NEMS_BUILDOPT=
 + '[' YES = YES ']'
-+ rm -rf build_fv3_1
-+ mkdir -p build_fv3_1
-+ CCPP_CMAKE_FLAGS=
-+ [[ '' == *\D\E\B\U\G\=\Y* ]]
-+ [[ '' == *\R\E\P\R\O\=\Y* ]]
-+ [[ '' == *\3\2\B\I\T\=\Y* ]]
-+ [[ '' == *\O\P\E\N\M\P\=\N* ]]
-+ [[ '' == *\C\C\P\P\=\Y* ]]
-+ [[ '' == *\N\A\M\_\p\h\y\s\=\Y* ]]
-+ [[ '' == *\W\W\3\=\Y* ]]
-++ trim ''
-++ local var=
-++ var=
-++ var=
-++ echo -n ''
-+ CCPP_CMAKE_FLAGS=
-+ source /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/NEMS/src/conf/module-setup.sh.inc
-++ __ms_function_name=setup__test_function__20095
-++ eval 'setup__test_function__20095() { /bin/true ; }'
-+++ eval '__text="text" ; if [[ $__text =~ ^(t).* ]] ; then printf "%s" ${.sh.match[1]} ; fi'
-+++ cat
-++ __ms_ksh_test=
-+++ eval 'if ( set | grep setup__test_function__20095 | grep -v name > /dev/null 2>&1 ) ; then echo t ; fi '
-+++ cat
-++ __ms_bash_test=t
-++ [[ ! -z '' ]]
-++ [[ ! -z t ]]
-++ __ms_shell=bash
-++ [[ -d /lfs3 ]]
-++ [[ -d /scratch1 ]]
-++ [[ -d /gpfs/hps ]]
-++ [[ -e /etc/SuSE-release ]]
-++ [[ -d /dcom ]]
-++ [[ -L /usrx ]]
-+++ readlink /usrx
-++ [[ /gpfs/dell1/usrx =~ dell ]]
-++ eval module help
-++ module purge
-+++ /usrx/local/prod/lmod/lmod/libexec/lmod bash purge
-++ eval unset 'ADVISOR_2018_DIR;' unset 'BACIO_LIB4;' unset 'BACIO_LIB8;' unset 'BACIO_SRC;' unset 'BACIO_VER;' unset 'BINARY_TYPE_HPC;' unset '__LMOD_REF_COUNT_CLASSPATH;' unset 'CLASSPATH;' unset 'CLCK_ROOT;' unset 'CMAKE_CXX_COMPILER;' unset 'CMAKE_C_COMPILER;' unset 'CMAKE_Fortran_COMPILER;' unset 'CMAKE_Platform;' unset 'COMP;' unset '__LMOD_REF_COUNT_CPATH;' unset 'CPATH;' unset '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' unset 'CPLUS_INCLUDE_PATH;' unset 'CRTM_FIX;' unset 'CRTM_INC;' unset 'CRTM_LIB;' unset 'CRTM_SRC;' unset 'CRTM_VER;' unset 'DAALROOT;' unset 'ECF_HOSTFILE;' unset 'ECF_PORT;' unset 'ECF_ROOT;' unset 'ESMFMKFILE;' unset 'G2TMPL_INC;' unset 'G2TMPL_LIB;' unset 'G2TMPL_SRC;' unset 'G2TMPL_VER;' unset 'G2_INC4;' unset 'G2_INCd;' unset 'G2_LIB4;' unset 'G2_LIBd;' unset 'G2_SRC;' unset 'G2_VER;' unset 'GDBSERVER_MIC;' unset 'GDB_CROSS;' unset 'HDF5;' unset 'HDF5_CFLAGS;' unset 'HDF5_CXXFLAGS;' unset 'HDF5_FFLAGS;' unset 'HDF5_INCLUDE;' unset 'HDF5_LDFLAGS;' unset 'HDF5_LDFLAGS_C;' unset 'HDF5_LDFLAGS_CXX;' unset 'HDF5_LDFLAGS_F;' unset '__LMOD_REF_COUNT_INFOPATH;' unset 'INFOPATH;' unset 'INSPECTOR_2018_DIR;' unset 'INTEL_LICENSE_FILE;' unset 'INTEL_PYTHONHOME;' unset 'IPPROOT;' unset 'IP_INC4;' unset 'IP_INC8;' unset 'IP_INCd;' unset 'IP_LIB4;' unset 'IP_LIB8;' unset 'IP_LIBd;' unset 'IP_SRC;' unset 'IP_VER;' unset 'I_MPI_CC;' unset 'I_MPI_CXX;' unset 'I_MPI_EXTRA_FILESYSTEM;' unset 'I_MPI_EXTRA_FILESYSTEM_LIST;' unset 'I_MPI_F77;' unset 'I_MPI_F90;' unset 'I_MPI_FC;' unset 'I_MPI_HYDRA_BOOTSTRAP;' unset 'I_MPI_HYDRA_IFACE;' unset 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' unset 'I_MPI_ROOT;' unset 'JASPER_INC;' unset 'JASPER_LIB;' unset 'JASPER_LIBDIR;' unset 'JASPER_SRC;' unset 'JASPER_VER;' unset 'KMP_AFFINITY;' unset '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' unset 'LD_LIBRARY_PATH;' unset '__LMOD_REF_COUNT_LIBRARY_PATH;' unset 'LIBRARY_PATH;' unset 'LIB_NAME;' unset 'LMOD_FAMILY_COMPILER;' unset 'LMOD_FAMILY_COMPILER_VERSION;' unset 'LMOD_FAMILY_MPI;' unset 'LMOD_FAMILY_MPI_VERSION;' unset '__LMOD_REF_COUNT_LOADEDMODULES;' unset 'LOADEDMODULES;' unset 'LSF_BINDIR;' unset 'LSF_ENVDIR;' unset 'LSF_LIBDIR;' unset 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/prod/lmod/lmod/share/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/prod/lmod/lmod/share/man::";' export 'MANPATH;' unset 'MKLROOT;' 'MODULEPATH="/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' unset 'MPM_LAUNCHER;' unset 'NEMSIO_INC;' unset 'NEMSIO_LIB;' unset 'NEMSIO_SRC;' unset 'NEMSIO_VER;' unset 'NETCDF;' unset 'NETCDF_CFLAGS;' unset 'NETCDF_CXX4FLAGS;' unset 'NETCDF_CXXFLAGS;' unset 'NETCDF_FFLAGS;' unset 'NETCDF_INC;' unset 'NETCDF_INCLUDE;' unset 'NETCDF_LDFLAGS;' unset 'NETCDF_LDFLAGS_C;' unset 'NETCDF_LDFLAGS_CXX;' unset 'NETCDF_LDFLAGS_CXX4;' unset 'NETCDF_LDFLAGS_F;' unset 'NETCDF_LIB;' unset 'NETCDF_ROOT;' unset '__LMOD_REF_COUNT_NLSPATH;' unset 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin";' export 'PATH;' unset 'PKG_CONFIG_PATH;' unset 'PNG_INC;' unset 'PNG_LIB;' unset 'PNG_LIB12;' unset 'PNG_LIBDIR;' unset 'PNG_LIBso;' unset 'PNG_SRC;' unset 'PNG_VER;' unset 'POST_INC;' unset 'POST_LIB;' unset 'POST_SRC;' unset 'POST_VER;' unset 'PSTLROOT;' unset 'PYTHONPATH;' unset '__LMOD_REF_COUNT_QT_PLUGIN_PATH;' unset 'QT_PLUGIN_PATH;' unset 'SP_LIB4;' unset 'SP_LIB8;' unset 'SP_LIBd;' unset 'SP_SRC;' unset 'SP_VER;' unset 'TBBROOT;' unset 'VT_ADD_LIBS;' unset 'VT_ARCH;' unset 'VT_LIB_DIR;' unset 'VT_MPI;' unset 'VT_ROOT;' unset 'VT_SLIB_DIR;' unset 'W3EMC_INC4;' unset 'W3EMC_INC8;' unset 'W3EMC_INCd;' unset 'W3EMC_LIB4;' unset 'W3EMC_LIB8;' unset 'W3EMC_LIBd;' unset 'W3EMC_SRC;' unset 'W3EMC_VER;' unset 'W3NCO_INC4;' unset 'W3NCO_INC8;' unset 'W3NCO_INCd;' unset 'W3NCO_LIB4;' unset 'W3NCO_LIB8;' unset 'W3NCO_LIBd;' unset 'W3NCO_SRC;' unset 'W3NCO_VER;' unset 'XLSF_UIDDIR;' unset 'Z_INC;' unset 'Z_LIB;' unset 'Z_SRC;' unset 'Z_VER;' unset '__LMOD_REF_COUNT__LMFILES_;' unset '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;' unset '_ModuleTable004_;' unset '_ModuleTable005_;' unset '_ModuleTable006_;' unset '_ModuleTable007_;' unset '_ModuleTable008_;' unset '_ModuleTable009_;' unset '_ModuleTable010_;' unset '_ModuleTable011_;' unset '_ModuleTable012_;' unset '_ModuleTable013_;' unset '_ModuleTable014_;' unset '_ModuleTable015_;' unset '_ModuleTable016_;' unset '_ModuleTable017_;'
-+++ unset ADVISOR_2018_DIR
-+++ unset BACIO_LIB4
-+++ unset BACIO_LIB8
-+++ unset BACIO_SRC
-+++ unset BACIO_VER
-+++ unset BINARY_TYPE_HPC
-+++ unset __LMOD_REF_COUNT_CLASSPATH
-+++ unset CLASSPATH
-+++ unset CLCK_ROOT
-+++ unset CMAKE_CXX_COMPILER
-+++ unset CMAKE_C_COMPILER
-+++ unset CMAKE_Fortran_COMPILER
-+++ unset CMAKE_Platform
-+++ unset COMP
-+++ unset __LMOD_REF_COUNT_CPATH
-+++ unset CPATH
-+++ unset __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-+++ unset CPLUS_INCLUDE_PATH
-+++ unset CRTM_FIX
-+++ unset CRTM_INC
-+++ unset CRTM_LIB
-+++ unset CRTM_SRC
-+++ unset CRTM_VER
-+++ unset DAALROOT
-+++ unset ECF_HOSTFILE
-+++ unset ECF_PORT
-+++ unset ECF_ROOT
-+++ unset ESMFMKFILE
-+++ unset G2TMPL_INC
-+++ unset G2TMPL_LIB
-+++ unset G2TMPL_SRC
-+++ unset G2TMPL_VER
-+++ unset G2_INC4
-+++ unset G2_INCd
-+++ unset G2_LIB4
-+++ unset G2_LIBd
-+++ unset G2_SRC
-+++ unset G2_VER
-+++ unset GDBSERVER_MIC
-+++ unset GDB_CROSS
-+++ unset HDF5
-+++ unset HDF5_CFLAGS
-+++ unset HDF5_CXXFLAGS
-+++ unset HDF5_FFLAGS
-+++ unset HDF5_INCLUDE
-+++ unset HDF5_LDFLAGS
-+++ unset HDF5_LDFLAGS_C
-+++ unset HDF5_LDFLAGS_CXX
-+++ unset HDF5_LDFLAGS_F
-+++ unset __LMOD_REF_COUNT_INFOPATH
-+++ unset INFOPATH
-+++ unset INSPECTOR_2018_DIR
-+++ unset INTEL_LICENSE_FILE
-+++ unset INTEL_PYTHONHOME
-+++ unset IPPROOT
-+++ unset IP_INC4
-+++ unset IP_INC8
-+++ unset IP_INCd
-+++ unset IP_LIB4
-+++ unset IP_LIB8
-+++ unset IP_LIBd
-+++ unset IP_SRC
-+++ unset IP_VER
-+++ unset I_MPI_CC
-+++ unset I_MPI_CXX
-+++ unset I_MPI_EXTRA_FILESYSTEM
-+++ unset I_MPI_EXTRA_FILESYSTEM_LIST
-+++ unset I_MPI_F77
-+++ unset I_MPI_F90
-+++ unset I_MPI_FC
-+++ unset I_MPI_HYDRA_BOOTSTRAP
-+++ unset I_MPI_HYDRA_IFACE
-+++ unset I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-+++ unset I_MPI_ROOT
-+++ unset JASPER_INC
-+++ unset JASPER_LIB
-+++ unset JASPER_LIBDIR
-+++ unset JASPER_SRC
-+++ unset JASPER_VER
-+++ unset KMP_AFFINITY
-+++ unset __LMOD_REF_COUNT_LD_LIBRARY_PATH
-+++ unset LD_LIBRARY_PATH
-+++ unset __LMOD_REF_COUNT_LIBRARY_PATH
-+++ unset LIBRARY_PATH
-+++ unset LIB_NAME
-+++ unset LMOD_FAMILY_COMPILER
-+++ unset LMOD_FAMILY_COMPILER_VERSION
-+++ unset LMOD_FAMILY_MPI
-+++ unset LMOD_FAMILY_MPI_VERSION
-+++ unset __LMOD_REF_COUNT_LOADEDMODULES
-+++ unset LOADEDMODULES
-+++ unset LSF_BINDIR
-+++ unset LSF_ENVDIR
-+++ unset LSF_LIBDIR
-+++ unset LSF_SERVERDIR
-+++ __LMOD_REF_COUNT_MANPATH=/usrx/local/prod/lmod/lmod/share/man:1
-+++ export __LMOD_REF_COUNT_MANPATH
-+++ MANPATH=/usrx/local/prod/lmod/lmod/share/man::
-+++ export MANPATH
-+++ unset MKLROOT
-+++ MODULEPATH=/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-+++ export MODULEPATH
-+++ unset MPM_LAUNCHER
-+++ unset NEMSIO_INC
-+++ unset NEMSIO_LIB
-+++ unset NEMSIO_SRC
-+++ unset NEMSIO_VER
-+++ unset NETCDF
-+++ unset NETCDF_CFLAGS
-+++ unset NETCDF_CXX4FLAGS
-+++ unset NETCDF_CXXFLAGS
-+++ unset NETCDF_FFLAGS
-+++ unset NETCDF_INC
-+++ unset NETCDF_INCLUDE
-+++ unset NETCDF_LDFLAGS
-+++ unset NETCDF_LDFLAGS_C
-+++ unset NETCDF_LDFLAGS_CXX
-+++ unset NETCDF_LDFLAGS_CXX4
-+++ unset NETCDF_LDFLAGS_F
-+++ unset NETCDF_LIB
-+++ unset NETCDF_ROOT
-+++ unset __LMOD_REF_COUNT_NLSPATH
-+++ unset NLSPATH
-+++ __LMOD_REF_COUNT_PATH='/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1'
-+++ export __LMOD_REF_COUNT_PATH
-+++ PATH=/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin
-+++ export PATH
-+++ unset PKG_CONFIG_PATH
-+++ unset PNG_INC
-+++ unset PNG_LIB
-+++ unset PNG_LIB12
-+++ unset PNG_LIBDIR
-+++ unset PNG_LIBso
-+++ unset PNG_SRC
-+++ unset PNG_VER
-+++ unset POST_INC
-+++ unset POST_LIB
-+++ unset POST_SRC
-+++ unset POST_VER
-+++ unset PSTLROOT
-+++ unset PYTHONPATH
-+++ unset __LMOD_REF_COUNT_QT_PLUGIN_PATH
-+++ unset QT_PLUGIN_PATH
-+++ unset SP_LIB4
-+++ unset SP_LIB8
-+++ unset SP_LIBd
-+++ unset SP_SRC
-+++ unset SP_VER
-+++ unset TBBROOT
-+++ unset VT_ADD_LIBS
-+++ unset VT_ARCH
-+++ unset VT_LIB_DIR
-+++ unset VT_MPI
-+++ unset VT_ROOT
-+++ unset VT_SLIB_DIR
-+++ unset W3EMC_INC4
-+++ unset W3EMC_INC8
-+++ unset W3EMC_INCd
-+++ unset W3EMC_LIB4
-+++ unset W3EMC_LIB8
-+++ unset W3EMC_LIBd
-+++ unset W3EMC_SRC
-+++ unset W3EMC_VER
-+++ unset W3NCO_INC4
-+++ unset W3NCO_INC8
-+++ unset W3NCO_INCd
-+++ unset W3NCO_LIB4
-+++ unset W3NCO_LIB8
-+++ unset W3NCO_LIBd
-+++ unset W3NCO_SRC
-+++ unset W3NCO_VER
-+++ unset XLSF_UIDDIR
-+++ unset Z_INC
-+++ unset Z_LIB
-+++ unset Z_SRC
-+++ unset Z_VER
-+++ unset __LMOD_REF_COUNT__LMFILES_
-+++ unset _LMFILES_
-+++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-+++ export _ModuleTable001_
-+++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-+++ export _ModuleTable002_
-+++ _ModuleTable_Sz_=2
-+++ export _ModuleTable_Sz_
-+++ unset _ModuleTable004_
-+++ unset _ModuleTable005_
-+++ unset _ModuleTable006_
-+++ unset _ModuleTable007_
-+++ unset _ModuleTable008_
-+++ unset _ModuleTable009_
-+++ unset _ModuleTable010_
-+++ unset _ModuleTable011_
-+++ unset _ModuleTable012_
-+++ unset _ModuleTable013_
-+++ unset _ModuleTable014_
-+++ unset _ModuleTable015_
-+++ unset _ModuleTable016_
-+++ unset _ModuleTable017_
-+++ : -s sh
-++ eval
-++ unset __ms_shell
-++ unset __ms_ksh_test
-++ unset __ms_bash_test
-++ unset setup__test_function__20095
-++ unset __ms_function_name
-+ [[ wcoss_dell_p3 == macosx.* ]]
-+ [[ wcoss_dell_p3 == linux.* ]]
-+ module use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-++ export _ModuleTable001_
-++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-++ export _ModuleTable002_
-++ _ModuleTable_Sz_=2
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module load fv3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash load fv3
-+ eval 'ADVISOR_2018_DIR="/usrx/local/prod/intel/2018UP01/advisor_2018";' export 'ADVISOR_2018_DIR;' 'BACIO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a";' export 'BACIO_LIB4;' 'BACIO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a";' export 'BACIO_LIB8;' 'BACIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3";' export 'BACIO_SRC;' 'BACIO_VER="v2.0.3";' export 'BACIO_VER;' 'BINARY_TYPE_HPC="";' export 'BINARY_TYPE_HPC;' '__LMOD_REF_COUNT_CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1";' export '__LMOD_REF_COUNT_CLASSPATH;' 'CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar";' export 'CLASSPATH;' 'CLCK_ROOT="/usrx/local/prod/intel/2018UP01/clck_latest";' export 'CLCK_ROOT;' 'CMAKE_CXX_COMPILER="mpiicpc";' export 'CMAKE_CXX_COMPILER;' 'CMAKE_C_COMPILER="mpiicc";' export 'CMAKE_C_COMPILER;' 'CMAKE_Fortran_COMPILER="mpiifort";' export 'CMAKE_Fortran_COMPILER;' 'CMAKE_Platform="wcoss_dell_p3";' export 'CMAKE_Platform;' 'COMP="ips";' export 'COMP;' '__LMOD_REF_COUNT_CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1";' export '__LMOD_REF_COUNT_CPATH;' 'CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include";' export 'CPATH;' '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include:1";' export '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' 'CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include";' export 'CPLUS_INCLUDE_PATH;' 'CRTM_FIX="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix";' export 'CRTM_FIX;' 'CRTM_INC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6";' export 'CRTM_INC;' 'CRTM_LIB="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a";' export 'CRTM_LIB;' 'CRTM_SRC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src";' export 'CRTM_SRC;' 'CRTM_VER="v2.2.6";' export 'CRTM_VER;' 'DAALROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal";' export 'DAALROOT;' 'ESMFMKFILE="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk";' export 'ESMFMKFILE;' 'G2TMPL_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0";' export 'G2TMPL_INC;' 'G2TMPL_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a";' export 'G2TMPL_LIB;' 'G2TMPL_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src";' export 'G2TMPL_SRC;' 'G2TMPL_VER="v1.6.0";' export 'G2TMPL_VER;' 'G2_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4";' export 'G2_INC4;' 'G2_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d";' export 'G2_INCd;' 'G2_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a";' export 'G2_LIB4;' 'G2_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a";' export 'G2_LIBd;' 'G2_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1";' export 'G2_SRC;' 'G2_VER="v3.1.1";' export 'G2_VER;' 'GDBSERVER_MIC="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver";' export 'GDBSERVER_MIC;' 'GDB_CROSS="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia";' export 'GDB_CROSS;' 'HDF5="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'HDF5;' 'HDF5_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CFLAGS;' 'HDF5_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CXXFLAGS;' 'HDF5_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_FFLAGS;' 'HDF5_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_INCLUDE;' 'HDF5_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran -lhdf5 '-lhdf5_fortran";' export 'HDF5_LDFLAGS;' 'HDF5_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl '-lhdf5";' export 'HDF5_LDFLAGS_C;' 'HDF5_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -hdf5_hl_cpp -lhdf5 '-lhdf5_cpp";' export 'HDF5_LDFLAGS_CXX;' 'HDF5_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran '-lhdf5";' export 'HDF5_LDFLAGS_F;' '__LMOD_REF_COUNT_INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1";' export '__LMOD_REF_COUNT_INFOPATH;' 'INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx";' export 'INFOPATH;' 'INSPECTOR_2018_DIR="/usrx/local/prod/intel/2018UP01/inspector_2018";' export 'INSPECTOR_2018_DIR;' 'INTEL_LICENSE_FILE="/usrx/local/prod/intel/licenses";' export 'INTEL_LICENSE_FILE;' 'INTEL_PYTHONHOME="/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64";' export 'INTEL_PYTHONHOME;' 'IPPROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp";' export 'IPPROOT;' 'IP_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4";' export 'IP_INC4;' 'IP_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8";' export 'IP_INC8;' 'IP_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d";' export 'IP_INCd;' 'IP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a";' export 'IP_LIB4;' 'IP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a";' export 'IP_LIB8;' 'IP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a";' export 'IP_LIBd;' 'IP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2";' export 'IP_SRC;' 'IP_VER="v3.0.2";' export 'IP_VER;' 'I_MPI_CC="icc";' export 'I_MPI_CC;' 'I_MPI_CXX="icpc";' export 'I_MPI_CXX;' 'I_MPI_EXTRA_FILESYSTEM="yes";' export 'I_MPI_EXTRA_FILESYSTEM;' 'I_MPI_EXTRA_FILESYSTEM_LIST="gpfs";' export 'I_MPI_EXTRA_FILESYSTEM_LIST;' 'I_MPI_F77="ifort";' export 'I_MPI_F77;' 'I_MPI_F90="ifort";' export 'I_MPI_F90;' 'I_MPI_FC="ifort";' export 'I_MPI_FC;' 'I_MPI_HYDRA_BOOTSTRAP="lsf";' export 'I_MPI_HYDRA_BOOTSTRAP;' 'I_MPI_HYDRA_IFACE="ib0";' export 'I_MPI_HYDRA_IFACE;' 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH="1";' export 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' 'I_MPI_ROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi";' export 'I_MPI_ROOT;' 'JASPER_INC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include";' export 'JASPER_INC;' 'JASPER_LIB="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a";' export 'JASPER_LIB;' 'JASPER_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib";' export 'JASPER_LIBDIR;' 'JASPER_SRC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29";' export 'JASPER_SRC;' 'JASPER_VER="1.900.29";' export 'JASPER_VER;' 'KMP_AFFINITY="scatter";' export 'KMP_AFFINITY;' unset 'LAUNCH;' '__LMOD_REF_COUNT_LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' 'LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LD_LIBRARY_PATH;' '__LMOD_REF_COUNT_LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LIBRARY_PATH;' 'LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LIBRARY_PATH;' 'LIB_NAME="POST";' export 'LIB_NAME;' 'LMOD_FAMILY_COMPILER="ips";' export 'LMOD_FAMILY_COMPILER;' 'LMOD_FAMILY_COMPILER_VERSION="18.0.1.163";' export 'LMOD_FAMILY_COMPILER_VERSION;' 'LMOD_FAMILY_MPI="impi";' export 'LMOD_FAMILY_MPI;' 'LMOD_FAMILY_MPI_VERSION="18.0.1";' export 'LMOD_FAMILY_MPI_VERSION;' '__LMOD_REF_COUNT_LOADEDMODULES="ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1";' export '__LMOD_REF_COUNT_LOADEDMODULES;' 'LOADEDMODULES="ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3";' export 'LOADEDMODULES;' 'LSF_BINDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin";' export 'LSF_BINDIR;' 'LSF_ENVDIR="/gpfs/lsf/conf";' export 'LSF_ENVDIR;' 'LSF_LIBDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib";' export 'LSF_LIBDIR;' 'LSF_SERVERDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc";' export 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man";' export 'MANPATH;' 'MKLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl";' export 'MKLROOT;' 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' 'MPM_LAUNCHER="/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh";' export 'MPM_LAUNCHER;' 'NEMSIO_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4";' export 'NEMSIO_INC;' 'NEMSIO_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a";' export 'NEMSIO_LIB;' 'NEMSIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4";' export 'NEMSIO_SRC;' 'NEMSIO_VER="v2.2.4";' export 'NEMSIO_VER;' 'NETCDF="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF;' 'NETCDF_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CFLAGS;' 'NETCDF_CXX4FLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXX4FLAGS;' 'NETCDF_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXXFLAGS;' 'NETCDF_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_FFLAGS;' 'NETCDF_INC="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INC;' 'NETCDF_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INCLUDE;' 'NETCDF_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS;' 'NETCDF_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdf";' export 'NETCDF_LDFLAGS_C;' 'NETCDF_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++";' export 'NETCDF_LDFLAGS_CXX;' 'NETCDF_LDFLAGS_CXX4="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++4";' export 'NETCDF_LDFLAGS_CXX4;' 'NETCDF_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS_F;' 'NETCDF_LIB="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib";' export 'NETCDF_LIB;' 'NETCDF_ROOT="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF_ROOT;' '__LMOD_REF_COUNT_NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1";' export '__LMOD_REF_COUNT_NLSPATH;' 'NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N";' export 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'PATH;' 'PKG_CONFIG_PATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig";' export 'PKG_CONFIG_PATH;' 'PNG_INC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include";' export 'PNG_INC;' 'PNG_LIB="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a";' export 'PNG_LIB;' 'PNG_LIB12="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a";' export 'PNG_LIB12;' 'PNG_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib";' export 'PNG_LIBDIR;' 'PNG_LIBso="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so";' export 'PNG_LIBso;' 'PNG_SRC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59";' export 'PNG_SRC;' 'PNG_VER="1.2.59";' export 'PNG_VER;' 'POST_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4";' export 'POST_INC;' 'POST_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a";' export 'POST_LIB;' 'POST_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5";' export 'POST_SRC;' 'POST_VER="v8.0.5";' export 'POST_VER;' 'PSTLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl";' export 'PSTLROOT;' 'PYTHONPATH="/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi";' export 'PYTHONPATH;' 'SP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a";' export 'SP_LIB4;' 'SP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a";' export 'SP_LIB8;' 'SP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a";' export 'SP_LIBd;' 'SP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3";' export 'SP_SRC;' 'SP_VER="v2.0.3";' export 'SP_VER;' 'TBBROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb";' export 'TBBROOT;' 'VT_ADD_LIBS="-ldwarf' -lelf -lvtunwind -lm '-lpthread";' export 'VT_ADD_LIBS;' 'VT_ARCH="intel64";' export 'VT_ARCH;' 'VT_LIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/lib";' export 'VT_LIB_DIR;' 'VT_MPI="impi4";' export 'VT_MPI;' 'VT_ROOT="/usrx/local/prod/intel/2018UP01/itac_latest";' export 'VT_ROOT;' 'VT_SLIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/slib";' export 'VT_SLIB_DIR;' 'W3EMC_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4";' export 'W3EMC_INC4;' 'W3EMC_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8";' export 'W3EMC_INC8;' 'W3EMC_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d";' export 'W3EMC_INCd;' 'W3EMC_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a";' export 'W3EMC_LIB4;' 'W3EMC_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a";' export 'W3EMC_LIB8;' 'W3EMC_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a";' export 'W3EMC_LIBd;' 'W3EMC_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1";' export 'W3EMC_SRC;' 'W3EMC_VER="v2.3.1";' export 'W3EMC_VER;' 'W3NCO_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4";' export 'W3NCO_INC4;' 'W3NCO_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8";' export 'W3NCO_INC8;' 'W3NCO_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d";' export 'W3NCO_INCd;' 'W3NCO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a";' export 'W3NCO_LIB4;' 'W3NCO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a";' export 'W3NCO_LIB8;' 'W3NCO_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a";' export 'W3NCO_LIBd;' 'W3NCO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7";' export 'W3NCO_SRC;' 'W3NCO_VER="v2.0.7";' export 'W3NCO_VER;' 'XLSF_UIDDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid";' export 'XLSF_UIDDIR;' 'Z_INC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'Z_INC;' 'Z_LIB="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a";' export 'Z_LIB;' 'Z_SRC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src";' export 'Z_SRC;' 'Z_VER="1.2.11";' export 'Z_VER;' '__LMOD_REF_COUNT__LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1";' export '__LMOD_REF_COUNT__LMFILES_;' '_LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3";' export '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ ADVISOR_2018_DIR=/usrx/local/prod/intel/2018UP01/advisor_2018
-++ export ADVISOR_2018_DIR
-++ BACIO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a
-++ export BACIO_LIB4
-++ BACIO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a
-++ export BACIO_LIB8
-++ BACIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3
-++ export BACIO_SRC
-++ BACIO_VER=v2.0.3
-++ export BACIO_VER
-++ BINARY_TYPE_HPC=
-++ export BINARY_TYPE_HPC
-++ __LMOD_REF_COUNT_CLASSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1'
-++ export __LMOD_REF_COUNT_CLASSPATH
-++ CLASSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar
-++ export CLASSPATH
-++ CLCK_ROOT=/usrx/local/prod/intel/2018UP01/clck_latest
-++ export CLCK_ROOT
-++ CMAKE_CXX_COMPILER=mpiicpc
-++ export CMAKE_CXX_COMPILER
-++ CMAKE_C_COMPILER=mpiicc
-++ export CMAKE_C_COMPILER
-++ CMAKE_Fortran_COMPILER=mpiifort
-++ export CMAKE_Fortran_COMPILER
-++ CMAKE_Platform=wcoss_dell_p3
-++ export CMAKE_Platform
-++ COMP=ips
-++ export COMP
-++ __LMOD_REF_COUNT_CPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1'
-++ export __LMOD_REF_COUNT_CPATH
-++ CPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include
-++ export CPATH
-++ __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include:1
-++ export __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-++ CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include
-++ export CPLUS_INCLUDE_PATH
-++ CRTM_FIX=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix
-++ export CRTM_FIX
-++ CRTM_INC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6
-++ export CRTM_INC
-++ CRTM_LIB=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a
-++ export CRTM_LIB
-++ CRTM_SRC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src
-++ export CRTM_SRC
-++ CRTM_VER=v2.2.6
-++ export CRTM_VER
-++ DAALROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal
-++ export DAALROOT
-++ ESMFMKFILE=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
-++ export ESMFMKFILE
-++ G2TMPL_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0
-++ export G2TMPL_INC
-++ G2TMPL_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a
-++ export G2TMPL_LIB
-++ G2TMPL_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src
-++ export G2TMPL_SRC
-++ G2TMPL_VER=v1.6.0
-++ export G2TMPL_VER
-++ G2_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4
-++ export G2_INC4
-++ G2_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d
-++ export G2_INCd
-++ G2_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a
-++ export G2_LIB4
-++ G2_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a
-++ export G2_LIBd
-++ G2_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1
-++ export G2_SRC
-++ G2_VER=v3.1.1
-++ export G2_VER
-++ GDBSERVER_MIC=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver
-++ export GDBSERVER_MIC
-++ GDB_CROSS=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia
-++ export GDB_CROSS
-++ HDF5=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export HDF5
-++ HDF5_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CFLAGS
-++ HDF5_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CXXFLAGS
-++ HDF5_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_FFLAGS
-++ HDF5_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_INCLUDE
-++ HDF5_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5 -lhdf5_fortran'
-++ export HDF5_LDFLAGS
-++ HDF5_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5'
-++ export HDF5_LDFLAGS_C
-++ HDF5_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -hdf5_hl_cpp -lhdf5 -lhdf5_cpp'
-++ export HDF5_LDFLAGS_CXX
-++ HDF5_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5'
-++ export HDF5_LDFLAGS_F
-++ __LMOD_REF_COUNT_INFOPATH='/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1'
-++ export __LMOD_REF_COUNT_INFOPATH
-++ INFOPATH=/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx
-++ export INFOPATH
-++ INSPECTOR_2018_DIR=/usrx/local/prod/intel/2018UP01/inspector_2018
-++ export INSPECTOR_2018_DIR
-++ INTEL_LICENSE_FILE=/usrx/local/prod/intel/licenses
-++ export INTEL_LICENSE_FILE
-++ INTEL_PYTHONHOME=/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64
-++ export INTEL_PYTHONHOME
-++ IPPROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp
-++ export IPPROOT
-++ IP_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4
-++ export IP_INC4
-++ IP_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8
-++ export IP_INC8
-++ IP_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d
-++ export IP_INCd
-++ IP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a
-++ export IP_LIB4
-++ IP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a
-++ export IP_LIB8
-++ IP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a
-++ export IP_LIBd
-++ IP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2
-++ export IP_SRC
-++ IP_VER=v3.0.2
-++ export IP_VER
-++ I_MPI_CC=icc
-++ export I_MPI_CC
-++ I_MPI_CXX=icpc
-++ export I_MPI_CXX
-++ I_MPI_EXTRA_FILESYSTEM=yes
-++ export I_MPI_EXTRA_FILESYSTEM
-++ I_MPI_EXTRA_FILESYSTEM_LIST=gpfs
-++ export I_MPI_EXTRA_FILESYSTEM_LIST
-++ I_MPI_F77=ifort
-++ export I_MPI_F77
-++ I_MPI_F90=ifort
-++ export I_MPI_F90
-++ I_MPI_FC=ifort
-++ export I_MPI_FC
-++ I_MPI_HYDRA_BOOTSTRAP=lsf
-++ export I_MPI_HYDRA_BOOTSTRAP
-++ I_MPI_HYDRA_IFACE=ib0
-++ export I_MPI_HYDRA_IFACE
-++ I_MPI_LSF_USE_COLLECTIVE_LAUNCH=1
-++ export I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-++ I_MPI_ROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi
-++ export I_MPI_ROOT
-++ JASPER_INC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include
-++ export JASPER_INC
-++ JASPER_LIB=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a
-++ export JASPER_LIB
-++ JASPER_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib
-++ export JASPER_LIBDIR
-++ JASPER_SRC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29
-++ export JASPER_SRC
-++ JASPER_VER=1.900.29
-++ export JASPER_VER
-++ KMP_AFFINITY=scatter
-++ export KMP_AFFINITY
-++ unset LAUNCH
-++ __LMOD_REF_COUNT_LD_LIBRARY_PATH='/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LD_LIBRARY_PATH
-++ LD_LIBRARY_PATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LD_LIBRARY_PATH
-++ __LMOD_REF_COUNT_LIBRARY_PATH='/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LIBRARY_PATH
-++ LIBRARY_PATH=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LIBRARY_PATH
-++ LIB_NAME=POST
-++ export LIB_NAME
-++ LMOD_FAMILY_COMPILER=ips
-++ export LMOD_FAMILY_COMPILER
-++ LMOD_FAMILY_COMPILER_VERSION=18.0.1.163
-++ export LMOD_FAMILY_COMPILER_VERSION
-++ LMOD_FAMILY_MPI=impi
-++ export LMOD_FAMILY_MPI
-++ LMOD_FAMILY_MPI_VERSION=18.0.1
-++ export LMOD_FAMILY_MPI_VERSION
-++ __LMOD_REF_COUNT_LOADEDMODULES='ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1'
-++ export __LMOD_REF_COUNT_LOADEDMODULES
-++ LOADEDMODULES=ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3
-++ export LOADEDMODULES
-++ LSF_BINDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin
-++ export LSF_BINDIR
-++ LSF_ENVDIR=/gpfs/lsf/conf
-++ export LSF_ENVDIR
-++ LSF_LIBDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib
-++ export LSF_LIBDIR
-++ LSF_SERVERDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc
-++ export LSF_SERVERDIR
-++ __LMOD_REF_COUNT_MANPATH='/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1'
-++ export __LMOD_REF_COUNT_MANPATH
-++ MANPATH=/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man
-++ export MANPATH
-++ MKLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl
-++ export MKLROOT
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ MPM_LAUNCHER=/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh
-++ export MPM_LAUNCHER
-++ NEMSIO_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4
-++ export NEMSIO_INC
-++ NEMSIO_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a
-++ export NEMSIO_LIB
-++ NEMSIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4
-++ export NEMSIO_SRC
-++ NEMSIO_VER=v2.2.4
-++ export NEMSIO_VER
-++ NETCDF=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF
-++ NETCDF_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CFLAGS
-++ NETCDF_CXX4FLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXX4FLAGS
-++ NETCDF_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXXFLAGS
-++ NETCDF_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_FFLAGS
-++ NETCDF_INC=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INC
-++ NETCDF_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INCLUDE
-++ NETCDF_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS
-++ NETCDF_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf'
-++ export NETCDF_LDFLAGS_C
-++ NETCDF_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++'
-++ export NETCDF_LDFLAGS_CXX
-++ NETCDF_LDFLAGS_CXX4='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++4'
-++ export NETCDF_LDFLAGS_CXX4
-++ NETCDF_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS_F
-++ NETCDF_LIB=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib
-++ export NETCDF_LIB
-++ NETCDF_ROOT=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF_ROOT
-++ __LMOD_REF_COUNT_NLSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1'
-++ export __LMOD_REF_COUNT_NLSPATH
-++ NLSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N
-++ export NLSPATH
-++ __LMOD_REF_COUNT_PATH='/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1'
-++ export __LMOD_REF_COUNT_PATH
-++ PATH=/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export PATH
-++ PKG_CONFIG_PATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig
-++ export PKG_CONFIG_PATH
-++ PNG_INC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include
-++ export PNG_INC
-++ PNG_LIB=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a
-++ export PNG_LIB
-++ PNG_LIB12=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a
-++ export PNG_LIB12
-++ PNG_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib
-++ export PNG_LIBDIR
-++ PNG_LIBso=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so
-++ export PNG_LIBso
-++ PNG_SRC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59
-++ export PNG_SRC
-++ PNG_VER=1.2.59
-++ export PNG_VER
-++ POST_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4
-++ export POST_INC
-++ POST_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a
-++ export POST_LIB
-++ POST_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5
-++ export POST_SRC
-++ POST_VER=v8.0.5
-++ export POST_VER
-++ PSTLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl
-++ export PSTLROOT
-++ PYTHONPATH=/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi
-++ export PYTHONPATH
-++ SP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a
-++ export SP_LIB4
-++ SP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a
-++ export SP_LIB8
-++ SP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a
-++ export SP_LIBd
-++ SP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3
-++ export SP_SRC
-++ SP_VER=v2.0.3
-++ export SP_VER
-++ TBBROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb
-++ export TBBROOT
-++ VT_ADD_LIBS='-ldwarf -lelf -lvtunwind -lm -lpthread'
-++ export VT_ADD_LIBS
-++ VT_ARCH=intel64
-++ export VT_ARCH
-++ VT_LIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/lib
-++ export VT_LIB_DIR
-++ VT_MPI=impi4
-++ export VT_MPI
-++ VT_ROOT=/usrx/local/prod/intel/2018UP01/itac_latest
-++ export VT_ROOT
-++ VT_SLIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/slib
-++ export VT_SLIB_DIR
-++ W3EMC_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4
-++ export W3EMC_INC4
-++ W3EMC_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8
-++ export W3EMC_INC8
-++ W3EMC_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d
-++ export W3EMC_INCd
-++ W3EMC_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a
-++ export W3EMC_LIB4
-++ W3EMC_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a
-++ export W3EMC_LIB8
-++ W3EMC_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a
-++ export W3EMC_LIBd
-++ W3EMC_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1
-++ export W3EMC_SRC
-++ W3EMC_VER=v2.3.1
-++ export W3EMC_VER
-++ W3NCO_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4
-++ export W3NCO_INC4
-++ W3NCO_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8
-++ export W3NCO_INC8
-++ W3NCO_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d
-++ export W3NCO_INCd
-++ W3NCO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a
-++ export W3NCO_LIB4
-++ W3NCO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a
-++ export W3NCO_LIB8
-++ W3NCO_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a
-++ export W3NCO_LIBd
-++ W3NCO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7
-++ export W3NCO_SRC
-++ W3NCO_VER=v2.0.7
-++ export W3NCO_VER
-++ XLSF_UIDDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid
-++ export XLSF_UIDDIR
-++ Z_INC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export Z_INC
-++ Z_LIB=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a
-++ export Z_LIB
-++ Z_SRC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src
-++ export Z_SRC
-++ Z_VER=1.2.11
-++ export Z_VER
-++ __LMOD_REF_COUNT__LMFILES_='/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1'
-++ export __LMOD_REF_COUNT__LMFILES_
-++ _LMFILES_=/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3
-++ export _LMFILES_
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module list
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash list
++ gmake -j 8 -k COMPONENTS=WW3,FMS,FV3 TEST_BUILD_NAME=fv3_1 BUILD_ENV=wcoss_dell_p3 'FV3_MAKEOPT=32BIT=Y WW3=Y' NEMS_BUILDOPT= distclean
+Will copy modules.nems and NEMS.x as fv3_1 under tests/
+NOTE: Skipping appbuilder.mk creation; no appbuilder file in use.
+echo 'FMS WW3 FV3' > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/components.mk"
+Adding FV3 makeopts to FMS makeopts
+cat /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs/makefile | sed 's,^include,#include,g'   \
+  > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs/makefile.temp.clean
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs                                       ; \
+    exec gmake 32BIT=Y WW3=Y -f makefile.temp.clean clean
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+Cleaning fms ... 
+
+cd .. ; \
+ls -1 */*.a */*.o */*.mod */depend \
+  | grep -vE 'INSTALL|\.git' | xargs rm -f || true ; \
+rm -rf FMS_INSTALL || true
+ls: cannot access */*.a: No such file or directory
+ls: cannot access */*.o: No such file or directory
+ls: cannot access */*.mod: No such file or directory
+ls: cannot access */depend: No such file or directory
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+rm -rf /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs/makefile.temp.clean
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf                ; \
+export COMP_SRCDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model" COMP_BINDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL" WW3_COMP="wcoss_dell_p3"                                  ; \
+export ESMFMKFILE=/dev/null                             ; \
+exec gmake distclean
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
+
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
 
 Currently Loaded Modules:
   1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
-  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.5
-  3) lsf/10.1        10) g2/3.1.1         17) hdf5_parallel/1.10.6
-  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) netcdf_parallel/4.7.4
-  5) ip/3.0.2        12) crtm/2.2.6       19) esmf/8.0.0_ParallelNetCDF
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
   6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
-  7) w3nco/2.0.7     14) libpng/1.2.59    21) fv3
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
 
  
 
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ cd build_fv3_1
-+ cmake /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model
--- The C compiler identification is Intel 18.0.1.20171018
--- The CXX compiler identification is Intel 18.0.1.20171018
--- The Fortran compiler identification is Intel 18.0.1.20171018
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc -- works
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Detecting C compile features
--- Detecting C compile features - done
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc -- works
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort  -- works
--- Detecting Fortran compiler ABI info
--- Detecting Fortran compiler ABI info - done
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90 -- yes
--- Found MPI_C: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc (found version "3.1") 
--- Found MPI_CXX: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc (found version "3.1") 
--- Found MPI_Fortran: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort (found version "3.1") 
--- Found MPI: TRUE (found version "3.1")  
-ESMFMKFILE:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
- Found ESMF:
-ESMF_VERSION_MAJOR:     8
-ESMF_F90COMPILEPATHS:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-ESMF_F90ESMFLINKRPATHS: -Wl,-rpath,/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib
-ESMF_F90ESMFLINKLIBS:   -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf
--- Found ESMF: /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include (found version "8.0.0") 
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/exe/ww3_multi_esmf *.o *.mod
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_clean -c
+ 
+                *****************************
+              ***   WAVEWATCH III clean     ***
+                *****************************
+ 
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/aux
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/../regtests
+\rm -fr /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/wwatch3.env
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+cd "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model"                                      ; \
+rm -rf exe mod* obj* tmp ftn/makefile ftn/makefile_DIST   \
+   ftn/makefile_SHRD esmf/wwatch3.env aux/makefile        \
+   bin/link bin/comp                                    ; \
+find . -name '*.o' -o -name '*.mod' -o -name '*.a'        \
+  | xargs rm -f
+rm -rf /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk
+cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/configure.fv3
+cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/modules.fv3
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 ; exec gmake          \
+  -k cleanall FMS_DIR=/dev/null
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+Cleaning ... 
 
-Setting configuration for wcoss_dell_p3
+(cd gfsphysics     && make clean)
 
-C       compiler: Intel 18.0.1.20171018 (mpiicc)
-CXX     compiler: Intel 18.0.1.20171018 (mpiicpc)
-Fortran compiler: Intel 18.0.1.20171018 (mpiifort)
+Build standalone FV3 gfsphysics ...
 
-DEBUG  is      disabled
-REPRO  is      disabled
-32BIT  is      disabled
-OPENMP is      ENABLED
-AVX2 is        disabled
-INLINE_POST is ENABLED
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+makefile:278: depend: No such file or directory
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Building dependencies ...
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
 
+Build standalone FV3 gfsphysics ...
 
-Selected physics package: gfs
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+Cleaning gfsphysics  ... 
 
--- Configuring done
--- Generating done
--- Build files have been written to: /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/build_fv3_1
-+ make -j 4
-Scanning dependencies of target fv3cpl
-[  0%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cplfields.F90.o
-[  1%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cap_cpl.F90.o
-Scanning dependencies of target gfsphysics
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/machine.F.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/co2hc.f.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_composition.f.o
-[  1%] Linking Fortran static library libfv3cpl.a
-[  2%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/efield.f.o
-[  2%] Built target fv3cpl
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wam_f107_kp_mod.f90.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mersenne_twister.f.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/GFDL_parse_tracers.F90.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iounitdef.f.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/namelist_soilveg.f.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_wrf_utl.f90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/noahmp_tables.f90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_radar.F90.o
-Scanning dependencies of target fms
-[  5%] Building Fortran object CMakeFiles/fms.dir/FMS/platform/platform.F90.o
-[  5%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_parameter.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  6%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physcons.F90.o
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_core.F90.o
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_input.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/cloud_interpolator.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/date_def.f.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progtm_module.f.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_io.F90.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerclm_def.f.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2o_def.f.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/MersenneTwister.F90.o
-[  8%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres_k.F90.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physparam.f.o
-[  9%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozne_def.f.o
-[ 10%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfs_phy_tracer_config.F.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_data.F90.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/constants/constants.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 10%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/surface_perturbation.F90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmp_glacier.f90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmplsm.f90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccn_def.f.o
-[ 11%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp.F90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg_utils.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfdl_cloud_microphys.F90.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/funcphys.f90.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tracer_const_h.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_initialize.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_astronomy.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_surface.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_parameters.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aer_cloud.F.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_thompson_gfs.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_wsm6_fv3.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs_fv3.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_cice.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diff.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_module.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rascnvv2.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_aerosols.f.o
-ifort: command line warning #10121: overriding '-xHOST' with '-xCORE-AVX-I'
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_bfmicrophysics.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_gases.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_datatb.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_datatb.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_water_prop.f90.o
-[ 14%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_efp.F90.o
-[ 14%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_memutils.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wv_saturation.F.o
-[ 15%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_pset.F90.o
-[ 16%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cs_conv.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 17%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_type.F90.o
-[ 18%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/gradient.F90.o
-[ 19%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_domains.F90.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diag.f.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_drv.f.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_ocean.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_sice.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_typedefs.F90.o
-[ 22%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_clouds.f.o
-[ 23%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_main.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 24%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_main.f.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_model.f90.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldmacro.F.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldwat2m_micro.F.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg2_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg3_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_radiation_driver.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_diagnostics.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_nst.f.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_physics_driver.F90.o
-[ 28%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_restart.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_io.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_comm.F90.o
-Compiling in MPI mode (with or without MPP) 
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/memutils/memutils.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms_io.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 30%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms.F90.o
-[ 30%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bicubic.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/time_manager.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bilinear.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_conserve.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_spherical.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/axis_utils/axis_utils.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_grid.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/field_manager.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/mosaic.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/gaussian_topog.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/get_cal_time.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp.F90.o
-[ 32%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp.F90.o
-[ 32%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_data.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 33%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_types.F90.o
-[ 34%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_axis.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manifest.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/fm_util.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/xbt_drop_rate_adjust.f90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/write_ocean_data.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp_external.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_output.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_util.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_table.F90.o
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manager.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/data_override/data_override.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 37%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/stock_constants.F90.o
-[ 37%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/coupler_types.F90.o
-[ 37%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_driver.F90.o
-[ 37%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_solar_heating.f.o
-[ 37%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_abstraction_layer.F90.o
-[ 38%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2oc.f.o
-[ 38%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_tracer.f.o
-[ 38%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ideaca.f.o
-[ 39%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfcsub.F.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ugwp_driver_v0.f.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cnvc90.f.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.f.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.pre.rad.f.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs.f.o
-[ 40%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gocart_tracer_config_stub.f.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/amip_interp/amip_interp.F90.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/astronomy/astronomy.F90.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/block_control/block_control.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscond.f.o
-[ 43%] Building Fortran object CMakeFiles/fms.dir/FMS/column_diagnostics/column_diagnostics.F90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscondp.f.o
-[ 43%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/atmos_ocean_fluxes.F90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdc.f.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdps.f.o
-[ 43%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/ensemble_manager.F90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_orowam2017.f.o
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters.F90.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ohdc.f.o
-Compiling in MPI mode (with or without MPP) 
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/xgrid.F90.o
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft.F90.o
-[ 45%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ophys.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft99.F90.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_co2.f.o
-[ 46%] Building Fortran object CMakeFiles/fms.dir/FMS/interpolator/interpolator.F90.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_dissipation.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 46%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/grid.F90.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_h2o.f.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_ion.f.o
-[ 47%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_utilities.F90.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_o2_o3.f.o
-[ 47%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core.F90.o
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_phys.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/lrgsclr.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbl.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpblt.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbltq.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscu.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscuq.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf_hafs.f.o
-[ 50%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core_ecda.F90.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp.f.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp1.f.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq.f.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq1.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninshoc.f.o
-[ 52%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/random_numbers.F90.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadb.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn.f.o
-[ 52%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres.F90.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn2.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstcnv.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys.f.o
-[ 54%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys_2015.f.o
-[ 54%] Building Fortran object CMakeFiles/fms.dir/FMS/station_data/station_data.F90.o
-[ 54%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd.f.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd_shoc.f.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpdp.f.o
-[ 56%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/topography.F90.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progt2.f.o
-[ 56%] Building Fortran object CMakeFiles/fms.dir/FMS/tracer_manager/tracer_manager.F90.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rad_initialize.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp_mesopause.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfaerosols.f.o
-[ 58%] Building Fortran object CMakeFiles/fms.dir/FMS/tridiagonal/tridiagonal.F90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfdeepcnv.f.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfshalcnv.f.o
-[ 60%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/quicksort.F90.o
-[ 60%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnv.f.o
-[ 61%] Building C object CMakeFiles/fms.dir/FMS/memutils/memuse.c.o
-[ 61%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnvn.f.o
-[ 61%] Building C object CMakeFiles/fms.dir/FMS/mosaic/create_xgrid.c.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdif.f.o
-[ 62%] Building C object CMakeFiles/fms.dir/FMS/mosaic/gradient_c2l.c.o
-[ 63%] Building C object CMakeFiles/fms.dir/FMS/mosaic/interp.c.o
-[ 63%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdifq.f.o
-[ 63%] Building C object CMakeFiles/fms.dir/FMS/mosaic/mosaic_util.c.o
-[ 63%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/set_soilveg.f.o
-[ 63%] Building C object CMakeFiles/fms.dir/FMS/mosaic/read_mosaic.c.o
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_noahmp_drv.f.o
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sflx.f.o
-[ 64%] Building C object CMakeFiles/fms.dir/FMS/affinity/affinity.c.o
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcnv.f.o
-[ 65%] Building C object CMakeFiles/fms.dir/FMS/mpp/nsclock.c.o
-[ 65%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv.f.o
-[ 65%] Building C object CMakeFiles/fms.dir/FMS/mpp/threadloc.c.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_1lyr.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_fixdp.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_opr.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tridi2t3.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/calpreciptype.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcm_shoc.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ointerp.f90.o
-[ 67%] Linking Fortran static library FMS/libfms.a
-[ 67%] Built target fms
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozinterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccninterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerinterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/num_parthds.F.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcycle.F90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_utils.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_triggers.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_solvers.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_lsatdis.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_orodis.F90.o
-[ 69%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_wmsdis.F90.o
-[ 69%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/m_micro_driver.F90.o
-[ 69%] Linking Fortran static library libgfsphysics.a
-[ 69%] Built target gfsphysics
-Scanning dependencies of target ipd
-[ 69%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_typedefs.F90.o
-[ 69%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_driver.F90.o
-[ 69%] Linking Fortran static library libipd.a
-[ 69%] Built target ipd
-Scanning dependencies of target io
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_fv3_io_def.F90.o
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_internal_state.F90.o
-[ 70%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_nemsio.F90.o
-[ 70%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf.F90.o
-Scanning dependencies of target fv3core
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_arrays.F90.o
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_sst.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 70%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf_parallel.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_fill.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_gfs.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sim_nc_mod.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/DYCORE_typedefs.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_mp_mod.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sorted_index.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_eta.F90.o
-[ 73%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_cmp.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_timing.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_sg.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_grid_utils.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/boundary.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 74%] Building Fortran object FV3/io/CMakeFiles/io.dir/FV3GFS_io.F90.o
-[ 75%] Building Fortran object FV3/io/CMakeFiles/io.dir/ffsync.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_wrt_grid_comp.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_nems_routines.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/a2b_edge.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_mapz.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_surf_map.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/tp_core.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_grid_tools.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/init_hydro.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_treat_da_inc.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/sw_core.F90.o
-[ 78%] Linking Fortran static library libio.a
-[ 78%] Built target io
-[ 78%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_iau_mod.F90.o
-[ 79%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_io.F90.o
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_diagnostics.F90.o
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_utils.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_core.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_nudge.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/test_cases.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_regional_bc.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_tracer2d.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_update_phys.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/dyn_core.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_ic.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_restart.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_nesting.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_control.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_dynamics.F90.o
-[ 84%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/multi_gases.F90.o
-[ 85%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 85%] Linking Fortran static library libfv3core.a
-[ 85%] Built target fv3core
-Scanning dependencies of target stochastic_physics
-[ 85%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_resol_def.f.o
-[ 85%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/update_ca.f90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/spectral_layout.F90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_gg_def.f.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_layout_lag.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/glats_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_namelist_def.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/compns_stochy.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_lag_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/epslon_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_lats_node_a_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_ls_node_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/gozrineo_stochy.f.o
-[ 89%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/pln2eo_stochy.f.o
-[ 90%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_a_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_internal_state_mod.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dezouv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dozeuv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/four_to_grid_stochy.F.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_patterngenerator.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/sumfln_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_lag_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_spectral.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/initialize_spectral_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_data_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_stochy_pattern.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochastic_physics.F90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/cellular_automata.f90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/plumes.f90.o
-[ 94%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/num_parthds_stochy.f.o
-[ 95%] Linking Fortran static library libstochastic_physics.a
-[ 95%] Built target stochastic_physics
-Scanning dependencies of target fv3cap
-[ 95%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fv3_config.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/atmos_model.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fcst_grid_comp.F90.o
-[ 97%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/time_utils.F90.o
-[ 97%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/fv3_cap.F90.o
-[ 97%] Linking Fortran static library libfv3cap.a
-[ 97%] Built target fv3cap
-Scanning dependencies of target NEMS.exe
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/ENS_Cpl/ENS_CplComp_ESMFMod_STUB.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_methods.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_SpaceWeather.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_UTILS.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_Rusage.F90.o
-[ 98%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_GRID_COMP.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_GRID_COMP.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/MAIN_NEMS.F90.o
-[100%] Building C object CMakeFiles/NEMS.exe.dir/NEMS/src/nems_c_rusage.c.o
-[100%] Linking Fortran executable NEMS.exe
-/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a(jas_stream.o): In function `jas_stream_tmpfile':
-/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29/src/libjasper/base/jas_stream.c:520: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
-[100%] Built target NEMS.exe
-+ mv NEMS.exe ../fv3_1.exe
-+ cp /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3 ../modules.fv3_1
-+ cd ..
-+ '[' YES = YES ']'
-+ rm -rf build_fv3_1
-+ elapsed=527
-+ echo 'Elapsed time 527 seconds. Compiling  finished'
-Elapsed time 527 seconds. Compiling  finished
-+ SECONDS=0
-+++ readlink -f /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-++ dirname /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-+ readonly MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ readonly ARGC=4
-+ ARGC=4
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ [[ 4 -eq 0 ]]
-+ [[ 4 -lt 2 ]]
-+ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model
-+ MACHINE_ID=wcoss_dell_p3
-+ MAKE_OPT=WW3=Y
-+ BUILD_NAME=fv3_2
-+ clean_before=YES
-+ clean_after=YES
-+ BUILD_DIR=build_fv3_2
-+ [[ wcoss_dell_p3 == cheyenne.* ]]
-+ [[ wcoss_dell_p3 == wcoss_dell_p3 ]]
-+ MAKE_THREADS=4
-+ MAKE_THREADS=4
-+ hostname
-m72a2
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ echo 'Compiling WW3=Y into fv3_2.exe on wcoss_dell_p3'
-Compiling WW3=Y into fv3_2.exe on wcoss_dell_p3
-+ '[' YES = YES ']'
-+ rm -rf build_fv3_2
-+ mkdir -p build_fv3_2
-+ CCPP_CMAKE_FLAGS=
-+ [[ WW3=Y == *\D\E\B\U\G\=\Y* ]]
-+ [[ WW3=Y == *\R\E\P\R\O\=\Y* ]]
-+ [[ WW3=Y == *\3\2\B\I\T\=\Y* ]]
-+ [[ WW3=Y == *\O\P\E\N\M\P\=\N* ]]
-+ [[ WW3=Y == *\C\C\P\P\=\Y* ]]
-+ [[ WW3=Y == *\N\A\M\_\p\h\y\s\=\Y* ]]
-+ [[ WW3=Y == *\W\W\3\=\Y* ]]
-+ CCPP_CMAKE_FLAGS=' -DWW3=Y'
-++ trim ' -DWW3=Y'
-++ local 'var= -DWW3=Y'
-++ var=-DWW3=Y
-++ var=-DWW3=Y
-++ echo -n -DWW3=Y
-+ CCPP_CMAKE_FLAGS=-DWW3=Y
-+ source /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/NEMS/src/conf/module-setup.sh.inc
-++ __ms_function_name=setup__test_function__20096
-++ eval 'setup__test_function__20096() { /bin/true ; }'
-+++ eval '__text="text" ; if [[ $__text =~ ^(t).* ]] ; then printf "%s" ${.sh.match[1]} ; fi'
-+++ cat
-++ __ms_ksh_test=
-+++ eval 'if ( set | grep setup__test_function__20096 | grep -v name > /dev/null 2>&1 ) ; then echo t ; fi '
-+++ cat
-++ __ms_bash_test=t
-++ [[ ! -z '' ]]
-++ [[ ! -z t ]]
-++ __ms_shell=bash
-++ [[ -d /lfs3 ]]
-++ [[ -d /scratch1 ]]
-++ [[ -d /gpfs/hps ]]
-++ [[ -e /etc/SuSE-release ]]
-++ [[ -d /dcom ]]
-++ [[ -L /usrx ]]
-+++ readlink /usrx
-++ [[ /gpfs/dell1/usrx =~ dell ]]
-++ eval module help
-++ module purge
-+++ /usrx/local/prod/lmod/lmod/libexec/lmod bash purge
-++ eval unset 'ADVISOR_2018_DIR;' unset 'BACIO_LIB4;' unset 'BACIO_LIB8;' unset 'BACIO_SRC;' unset 'BACIO_VER;' unset 'BINARY_TYPE_HPC;' unset '__LMOD_REF_COUNT_CLASSPATH;' unset 'CLASSPATH;' unset 'CLCK_ROOT;' unset 'CMAKE_CXX_COMPILER;' unset 'CMAKE_C_COMPILER;' unset 'CMAKE_Fortran_COMPILER;' unset 'CMAKE_Platform;' unset 'COMP;' unset '__LMOD_REF_COUNT_CPATH;' unset 'CPATH;' unset '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' unset 'CPLUS_INCLUDE_PATH;' unset 'CRTM_FIX;' unset 'CRTM_INC;' unset 'CRTM_LIB;' unset 'CRTM_SRC;' unset 'CRTM_VER;' unset 'DAALROOT;' unset 'ECF_HOSTFILE;' unset 'ECF_PORT;' unset 'ECF_ROOT;' unset 'ESMFMKFILE;' unset 'G2TMPL_INC;' unset 'G2TMPL_LIB;' unset 'G2TMPL_SRC;' unset 'G2TMPL_VER;' unset 'G2_INC4;' unset 'G2_INCd;' unset 'G2_LIB4;' unset 'G2_LIBd;' unset 'G2_SRC;' unset 'G2_VER;' unset 'GDBSERVER_MIC;' unset 'GDB_CROSS;' unset 'HDF5;' unset 'HDF5_CFLAGS;' unset 'HDF5_CXXFLAGS;' unset 'HDF5_FFLAGS;' unset 'HDF5_INCLUDE;' unset 'HDF5_LDFLAGS;' unset 'HDF5_LDFLAGS_C;' unset 'HDF5_LDFLAGS_CXX;' unset 'HDF5_LDFLAGS_F;' unset '__LMOD_REF_COUNT_INFOPATH;' unset 'INFOPATH;' unset 'INSPECTOR_2018_DIR;' unset 'INTEL_LICENSE_FILE;' unset 'INTEL_PYTHONHOME;' unset 'IPPROOT;' unset 'IP_INC4;' unset 'IP_INC8;' unset 'IP_INCd;' unset 'IP_LIB4;' unset 'IP_LIB8;' unset 'IP_LIBd;' unset 'IP_SRC;' unset 'IP_VER;' unset 'I_MPI_CC;' unset 'I_MPI_CXX;' unset 'I_MPI_EXTRA_FILESYSTEM;' unset 'I_MPI_EXTRA_FILESYSTEM_LIST;' unset 'I_MPI_F77;' unset 'I_MPI_F90;' unset 'I_MPI_FC;' unset 'I_MPI_HYDRA_BOOTSTRAP;' unset 'I_MPI_HYDRA_IFACE;' unset 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' unset 'I_MPI_ROOT;' unset 'JASPER_INC;' unset 'JASPER_LIB;' unset 'JASPER_LIBDIR;' unset 'JASPER_SRC;' unset 'JASPER_VER;' unset 'KMP_AFFINITY;' unset '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' unset 'LD_LIBRARY_PATH;' unset '__LMOD_REF_COUNT_LIBRARY_PATH;' unset 'LIBRARY_PATH;' unset 'LIB_NAME;' unset 'LMOD_FAMILY_COMPILER;' unset 'LMOD_FAMILY_COMPILER_VERSION;' unset 'LMOD_FAMILY_MPI;' unset 'LMOD_FAMILY_MPI_VERSION;' unset '__LMOD_REF_COUNT_LOADEDMODULES;' unset 'LOADEDMODULES;' unset 'LSF_BINDIR;' unset 'LSF_ENVDIR;' unset 'LSF_LIBDIR;' unset 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/prod/lmod/lmod/share/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/prod/lmod/lmod/share/man::";' export 'MANPATH;' unset 'MKLROOT;' 'MODULEPATH="/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' unset 'MPM_LAUNCHER;' unset 'NEMSIO_INC;' unset 'NEMSIO_LIB;' unset 'NEMSIO_SRC;' unset 'NEMSIO_VER;' unset 'NETCDF;' unset 'NETCDF_CFLAGS;' unset 'NETCDF_CXX4FLAGS;' unset 'NETCDF_CXXFLAGS;' unset 'NETCDF_FFLAGS;' unset 'NETCDF_INC;' unset 'NETCDF_INCLUDE;' unset 'NETCDF_LDFLAGS;' unset 'NETCDF_LDFLAGS_C;' unset 'NETCDF_LDFLAGS_CXX;' unset 'NETCDF_LDFLAGS_CXX4;' unset 'NETCDF_LDFLAGS_F;' unset 'NETCDF_LIB;' unset 'NETCDF_ROOT;' unset '__LMOD_REF_COUNT_NLSPATH;' unset 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin";' export 'PATH;' unset 'PKG_CONFIG_PATH;' unset 'PNG_INC;' unset 'PNG_LIB;' unset 'PNG_LIB12;' unset 'PNG_LIBDIR;' unset 'PNG_LIBso;' unset 'PNG_SRC;' unset 'PNG_VER;' unset 'POST_INC;' unset 'POST_LIB;' unset 'POST_SRC;' unset 'POST_VER;' unset 'PSTLROOT;' unset 'PYTHONPATH;' unset '__LMOD_REF_COUNT_QT_PLUGIN_PATH;' unset 'QT_PLUGIN_PATH;' unset 'SP_LIB4;' unset 'SP_LIB8;' unset 'SP_LIBd;' unset 'SP_SRC;' unset 'SP_VER;' unset 'TBBROOT;' unset 'VT_ADD_LIBS;' unset 'VT_ARCH;' unset 'VT_LIB_DIR;' unset 'VT_MPI;' unset 'VT_ROOT;' unset 'VT_SLIB_DIR;' unset 'W3EMC_INC4;' unset 'W3EMC_INC8;' unset 'W3EMC_INCd;' unset 'W3EMC_LIB4;' unset 'W3EMC_LIB8;' unset 'W3EMC_LIBd;' unset 'W3EMC_SRC;' unset 'W3EMC_VER;' unset 'W3NCO_INC4;' unset 'W3NCO_INC8;' unset 'W3NCO_INCd;' unset 'W3NCO_LIB4;' unset 'W3NCO_LIB8;' unset 'W3NCO_LIBd;' unset 'W3NCO_SRC;' unset 'W3NCO_VER;' unset 'XLSF_UIDDIR;' unset 'Z_INC;' unset 'Z_LIB;' unset 'Z_SRC;' unset 'Z_VER;' unset '__LMOD_REF_COUNT__LMFILES_;' unset '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;' unset '_ModuleTable004_;' unset '_ModuleTable005_;' unset '_ModuleTable006_;' unset '_ModuleTable007_;' unset '_ModuleTable008_;' unset '_ModuleTable009_;' unset '_ModuleTable010_;' unset '_ModuleTable011_;' unset '_ModuleTable012_;' unset '_ModuleTable013_;' unset '_ModuleTable014_;' unset '_ModuleTable015_;' unset '_ModuleTable016_;' unset '_ModuleTable017_;'
-+++ unset ADVISOR_2018_DIR
-+++ unset BACIO_LIB4
-+++ unset BACIO_LIB8
-+++ unset BACIO_SRC
-+++ unset BACIO_VER
-+++ unset BINARY_TYPE_HPC
-+++ unset __LMOD_REF_COUNT_CLASSPATH
-+++ unset CLASSPATH
-+++ unset CLCK_ROOT
-+++ unset CMAKE_CXX_COMPILER
-+++ unset CMAKE_C_COMPILER
-+++ unset CMAKE_Fortran_COMPILER
-+++ unset CMAKE_Platform
-+++ unset COMP
-+++ unset __LMOD_REF_COUNT_CPATH
-+++ unset CPATH
-+++ unset __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-+++ unset CPLUS_INCLUDE_PATH
-+++ unset CRTM_FIX
-+++ unset CRTM_INC
-+++ unset CRTM_LIB
-+++ unset CRTM_SRC
-+++ unset CRTM_VER
-+++ unset DAALROOT
-+++ unset ECF_HOSTFILE
-+++ unset ECF_PORT
-+++ unset ECF_ROOT
-+++ unset ESMFMKFILE
-+++ unset G2TMPL_INC
-+++ unset G2TMPL_LIB
-+++ unset G2TMPL_SRC
-+++ unset G2TMPL_VER
-+++ unset G2_INC4
-+++ unset G2_INCd
-+++ unset G2_LIB4
-+++ unset G2_LIBd
-+++ unset G2_SRC
-+++ unset G2_VER
-+++ unset GDBSERVER_MIC
-+++ unset GDB_CROSS
-+++ unset HDF5
-+++ unset HDF5_CFLAGS
-+++ unset HDF5_CXXFLAGS
-+++ unset HDF5_FFLAGS
-+++ unset HDF5_INCLUDE
-+++ unset HDF5_LDFLAGS
-+++ unset HDF5_LDFLAGS_C
-+++ unset HDF5_LDFLAGS_CXX
-+++ unset HDF5_LDFLAGS_F
-+++ unset __LMOD_REF_COUNT_INFOPATH
-+++ unset INFOPATH
-+++ unset INSPECTOR_2018_DIR
-+++ unset INTEL_LICENSE_FILE
-+++ unset INTEL_PYTHONHOME
-+++ unset IPPROOT
-+++ unset IP_INC4
-+++ unset IP_INC8
-+++ unset IP_INCd
-+++ unset IP_LIB4
-+++ unset IP_LIB8
-+++ unset IP_LIBd
-+++ unset IP_SRC
-+++ unset IP_VER
-+++ unset I_MPI_CC
-+++ unset I_MPI_CXX
-+++ unset I_MPI_EXTRA_FILESYSTEM
-+++ unset I_MPI_EXTRA_FILESYSTEM_LIST
-+++ unset I_MPI_F77
-+++ unset I_MPI_F90
-+++ unset I_MPI_FC
-+++ unset I_MPI_HYDRA_BOOTSTRAP
-+++ unset I_MPI_HYDRA_IFACE
-+++ unset I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-+++ unset I_MPI_ROOT
-+++ unset JASPER_INC
-+++ unset JASPER_LIB
-+++ unset JASPER_LIBDIR
-+++ unset JASPER_SRC
-+++ unset JASPER_VER
-+++ unset KMP_AFFINITY
-+++ unset __LMOD_REF_COUNT_LD_LIBRARY_PATH
-+++ unset LD_LIBRARY_PATH
-+++ unset __LMOD_REF_COUNT_LIBRARY_PATH
-+++ unset LIBRARY_PATH
-+++ unset LIB_NAME
-+++ unset LMOD_FAMILY_COMPILER
-+++ unset LMOD_FAMILY_COMPILER_VERSION
-+++ unset LMOD_FAMILY_MPI
-+++ unset LMOD_FAMILY_MPI_VERSION
-+++ unset __LMOD_REF_COUNT_LOADEDMODULES
-+++ unset LOADEDMODULES
-+++ unset LSF_BINDIR
-+++ unset LSF_ENVDIR
-+++ unset LSF_LIBDIR
-+++ unset LSF_SERVERDIR
-+++ __LMOD_REF_COUNT_MANPATH=/usrx/local/prod/lmod/lmod/share/man:1
-+++ export __LMOD_REF_COUNT_MANPATH
-+++ MANPATH=/usrx/local/prod/lmod/lmod/share/man::
-+++ export MANPATH
-+++ unset MKLROOT
-+++ MODULEPATH=/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-+++ export MODULEPATH
-+++ unset MPM_LAUNCHER
-+++ unset NEMSIO_INC
-+++ unset NEMSIO_LIB
-+++ unset NEMSIO_SRC
-+++ unset NEMSIO_VER
-+++ unset NETCDF
-+++ unset NETCDF_CFLAGS
-+++ unset NETCDF_CXX4FLAGS
-+++ unset NETCDF_CXXFLAGS
-+++ unset NETCDF_FFLAGS
-+++ unset NETCDF_INC
-+++ unset NETCDF_INCLUDE
-+++ unset NETCDF_LDFLAGS
-+++ unset NETCDF_LDFLAGS_C
-+++ unset NETCDF_LDFLAGS_CXX
-+++ unset NETCDF_LDFLAGS_CXX4
-+++ unset NETCDF_LDFLAGS_F
-+++ unset NETCDF_LIB
-+++ unset NETCDF_ROOT
-+++ unset __LMOD_REF_COUNT_NLSPATH
-+++ unset NLSPATH
-+++ __LMOD_REF_COUNT_PATH='/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1'
-+++ export __LMOD_REF_COUNT_PATH
-+++ PATH=/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin
-+++ export PATH
-+++ unset PKG_CONFIG_PATH
-+++ unset PNG_INC
-+++ unset PNG_LIB
-+++ unset PNG_LIB12
-+++ unset PNG_LIBDIR
-+++ unset PNG_LIBso
-+++ unset PNG_SRC
-+++ unset PNG_VER
-+++ unset POST_INC
-+++ unset POST_LIB
-+++ unset POST_SRC
-+++ unset POST_VER
-+++ unset PSTLROOT
-+++ unset PYTHONPATH
-+++ unset __LMOD_REF_COUNT_QT_PLUGIN_PATH
-+++ unset QT_PLUGIN_PATH
-+++ unset SP_LIB4
-+++ unset SP_LIB8
-+++ unset SP_LIBd
-+++ unset SP_SRC
-+++ unset SP_VER
-+++ unset TBBROOT
-+++ unset VT_ADD_LIBS
-+++ unset VT_ARCH
-+++ unset VT_LIB_DIR
-+++ unset VT_MPI
-+++ unset VT_ROOT
-+++ unset VT_SLIB_DIR
-+++ unset W3EMC_INC4
-+++ unset W3EMC_INC8
-+++ unset W3EMC_INCd
-+++ unset W3EMC_LIB4
-+++ unset W3EMC_LIB8
-+++ unset W3EMC_LIBd
-+++ unset W3EMC_SRC
-+++ unset W3EMC_VER
-+++ unset W3NCO_INC4
-+++ unset W3NCO_INC8
-+++ unset W3NCO_INCd
-+++ unset W3NCO_LIB4
-+++ unset W3NCO_LIB8
-+++ unset W3NCO_LIBd
-+++ unset W3NCO_SRC
-+++ unset W3NCO_VER
-+++ unset XLSF_UIDDIR
-+++ unset Z_INC
-+++ unset Z_LIB
-+++ unset Z_SRC
-+++ unset Z_VER
-+++ unset __LMOD_REF_COUNT__LMFILES_
-+++ unset _LMFILES_
-+++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-+++ export _ModuleTable001_
-+++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-+++ export _ModuleTable002_
-+++ _ModuleTable_Sz_=2
-+++ export _ModuleTable_Sz_
-+++ unset _ModuleTable004_
-+++ unset _ModuleTable005_
-+++ unset _ModuleTable006_
-+++ unset _ModuleTable007_
-+++ unset _ModuleTable008_
-+++ unset _ModuleTable009_
-+++ unset _ModuleTable010_
-+++ unset _ModuleTable011_
-+++ unset _ModuleTable012_
-+++ unset _ModuleTable013_
-+++ unset _ModuleTable014_
-+++ unset _ModuleTable015_
-+++ unset _ModuleTable016_
-+++ unset _ModuleTable017_
-+++ : -s sh
-++ eval
-++ unset __ms_shell
-++ unset __ms_ksh_test
-++ unset __ms_bash_test
-++ unset setup__test_function__20096
-++ unset __ms_function_name
-+ [[ wcoss_dell_p3 == macosx.* ]]
-+ [[ wcoss_dell_p3 == linux.* ]]
-+ module use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-++ export _ModuleTable001_
-++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-++ export _ModuleTable002_
-++ _ModuleTable_Sz_=2
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module load fv3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash load fv3
-+ eval 'ADVISOR_2018_DIR="/usrx/local/prod/intel/2018UP01/advisor_2018";' export 'ADVISOR_2018_DIR;' 'BACIO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a";' export 'BACIO_LIB4;' 'BACIO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a";' export 'BACIO_LIB8;' 'BACIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3";' export 'BACIO_SRC;' 'BACIO_VER="v2.0.3";' export 'BACIO_VER;' 'BINARY_TYPE_HPC="";' export 'BINARY_TYPE_HPC;' '__LMOD_REF_COUNT_CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1";' export '__LMOD_REF_COUNT_CLASSPATH;' 'CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar";' export 'CLASSPATH;' 'CLCK_ROOT="/usrx/local/prod/intel/2018UP01/clck_latest";' export 'CLCK_ROOT;' 'CMAKE_CXX_COMPILER="mpiicpc";' export 'CMAKE_CXX_COMPILER;' 'CMAKE_C_COMPILER="mpiicc";' export 'CMAKE_C_COMPILER;' 'CMAKE_Fortran_COMPILER="mpiifort";' export 'CMAKE_Fortran_COMPILER;' 'CMAKE_Platform="wcoss_dell_p3";' export 'CMAKE_Platform;' 'COMP="ips";' export 'COMP;' '__LMOD_REF_COUNT_CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1";' export '__LMOD_REF_COUNT_CPATH;' 'CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include";' export 'CPATH;' '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include:1";' export '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' 'CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include";' export 'CPLUS_INCLUDE_PATH;' 'CRTM_FIX="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix";' export 'CRTM_FIX;' 'CRTM_INC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6";' export 'CRTM_INC;' 'CRTM_LIB="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a";' export 'CRTM_LIB;' 'CRTM_SRC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src";' export 'CRTM_SRC;' 'CRTM_VER="v2.2.6";' export 'CRTM_VER;' 'DAALROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal";' export 'DAALROOT;' 'ESMFMKFILE="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk";' export 'ESMFMKFILE;' 'G2TMPL_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0";' export 'G2TMPL_INC;' 'G2TMPL_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a";' export 'G2TMPL_LIB;' 'G2TMPL_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src";' export 'G2TMPL_SRC;' 'G2TMPL_VER="v1.6.0";' export 'G2TMPL_VER;' 'G2_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4";' export 'G2_INC4;' 'G2_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d";' export 'G2_INCd;' 'G2_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a";' export 'G2_LIB4;' 'G2_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a";' export 'G2_LIBd;' 'G2_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1";' export 'G2_SRC;' 'G2_VER="v3.1.1";' export 'G2_VER;' 'GDBSERVER_MIC="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver";' export 'GDBSERVER_MIC;' 'GDB_CROSS="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia";' export 'GDB_CROSS;' 'HDF5="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'HDF5;' 'HDF5_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CFLAGS;' 'HDF5_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CXXFLAGS;' 'HDF5_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_FFLAGS;' 'HDF5_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_INCLUDE;' 'HDF5_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran -lhdf5 '-lhdf5_fortran";' export 'HDF5_LDFLAGS;' 'HDF5_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl '-lhdf5";' export 'HDF5_LDFLAGS_C;' 'HDF5_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -hdf5_hl_cpp -lhdf5 '-lhdf5_cpp";' export 'HDF5_LDFLAGS_CXX;' 'HDF5_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran '-lhdf5";' export 'HDF5_LDFLAGS_F;' '__LMOD_REF_COUNT_INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1";' export '__LMOD_REF_COUNT_INFOPATH;' 'INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx";' export 'INFOPATH;' 'INSPECTOR_2018_DIR="/usrx/local/prod/intel/2018UP01/inspector_2018";' export 'INSPECTOR_2018_DIR;' 'INTEL_LICENSE_FILE="/usrx/local/prod/intel/licenses";' export 'INTEL_LICENSE_FILE;' 'INTEL_PYTHONHOME="/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64";' export 'INTEL_PYTHONHOME;' 'IPPROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp";' export 'IPPROOT;' 'IP_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4";' export 'IP_INC4;' 'IP_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8";' export 'IP_INC8;' 'IP_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d";' export 'IP_INCd;' 'IP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a";' export 'IP_LIB4;' 'IP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a";' export 'IP_LIB8;' 'IP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a";' export 'IP_LIBd;' 'IP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2";' export 'IP_SRC;' 'IP_VER="v3.0.2";' export 'IP_VER;' 'I_MPI_CC="icc";' export 'I_MPI_CC;' 'I_MPI_CXX="icpc";' export 'I_MPI_CXX;' 'I_MPI_EXTRA_FILESYSTEM="yes";' export 'I_MPI_EXTRA_FILESYSTEM;' 'I_MPI_EXTRA_FILESYSTEM_LIST="gpfs";' export 'I_MPI_EXTRA_FILESYSTEM_LIST;' 'I_MPI_F77="ifort";' export 'I_MPI_F77;' 'I_MPI_F90="ifort";' export 'I_MPI_F90;' 'I_MPI_FC="ifort";' export 'I_MPI_FC;' 'I_MPI_HYDRA_BOOTSTRAP="lsf";' export 'I_MPI_HYDRA_BOOTSTRAP;' 'I_MPI_HYDRA_IFACE="ib0";' export 'I_MPI_HYDRA_IFACE;' 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH="1";' export 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' 'I_MPI_ROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi";' export 'I_MPI_ROOT;' 'JASPER_INC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include";' export 'JASPER_INC;' 'JASPER_LIB="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a";' export 'JASPER_LIB;' 'JASPER_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib";' export 'JASPER_LIBDIR;' 'JASPER_SRC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29";' export 'JASPER_SRC;' 'JASPER_VER="1.900.29";' export 'JASPER_VER;' 'KMP_AFFINITY="scatter";' export 'KMP_AFFINITY;' unset 'LAUNCH;' '__LMOD_REF_COUNT_LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' 'LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LD_LIBRARY_PATH;' '__LMOD_REF_COUNT_LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LIBRARY_PATH;' 'LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LIBRARY_PATH;' 'LIB_NAME="POST";' export 'LIB_NAME;' 'LMOD_FAMILY_COMPILER="ips";' export 'LMOD_FAMILY_COMPILER;' 'LMOD_FAMILY_COMPILER_VERSION="18.0.1.163";' export 'LMOD_FAMILY_COMPILER_VERSION;' 'LMOD_FAMILY_MPI="impi";' export 'LMOD_FAMILY_MPI;' 'LMOD_FAMILY_MPI_VERSION="18.0.1";' export 'LMOD_FAMILY_MPI_VERSION;' '__LMOD_REF_COUNT_LOADEDMODULES="ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1";' export '__LMOD_REF_COUNT_LOADEDMODULES;' 'LOADEDMODULES="ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3";' export 'LOADEDMODULES;' 'LSF_BINDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin";' export 'LSF_BINDIR;' 'LSF_ENVDIR="/gpfs/lsf/conf";' export 'LSF_ENVDIR;' 'LSF_LIBDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib";' export 'LSF_LIBDIR;' 'LSF_SERVERDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc";' export 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man";' export 'MANPATH;' 'MKLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl";' export 'MKLROOT;' 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' 'MPM_LAUNCHER="/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh";' export 'MPM_LAUNCHER;' 'NEMSIO_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4";' export 'NEMSIO_INC;' 'NEMSIO_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a";' export 'NEMSIO_LIB;' 'NEMSIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4";' export 'NEMSIO_SRC;' 'NEMSIO_VER="v2.2.4";' export 'NEMSIO_VER;' 'NETCDF="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF;' 'NETCDF_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CFLAGS;' 'NETCDF_CXX4FLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXX4FLAGS;' 'NETCDF_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXXFLAGS;' 'NETCDF_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_FFLAGS;' 'NETCDF_INC="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INC;' 'NETCDF_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INCLUDE;' 'NETCDF_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS;' 'NETCDF_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdf";' export 'NETCDF_LDFLAGS_C;' 'NETCDF_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++";' export 'NETCDF_LDFLAGS_CXX;' 'NETCDF_LDFLAGS_CXX4="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++4";' export 'NETCDF_LDFLAGS_CXX4;' 'NETCDF_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS_F;' 'NETCDF_LIB="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib";' export 'NETCDF_LIB;' 'NETCDF_ROOT="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF_ROOT;' '__LMOD_REF_COUNT_NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1";' export '__LMOD_REF_COUNT_NLSPATH;' 'NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N";' export 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'PATH;' 'PKG_CONFIG_PATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig";' export 'PKG_CONFIG_PATH;' 'PNG_INC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include";' export 'PNG_INC;' 'PNG_LIB="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a";' export 'PNG_LIB;' 'PNG_LIB12="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a";' export 'PNG_LIB12;' 'PNG_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib";' export 'PNG_LIBDIR;' 'PNG_LIBso="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so";' export 'PNG_LIBso;' 'PNG_SRC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59";' export 'PNG_SRC;' 'PNG_VER="1.2.59";' export 'PNG_VER;' 'POST_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4";' export 'POST_INC;' 'POST_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a";' export 'POST_LIB;' 'POST_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5";' export 'POST_SRC;' 'POST_VER="v8.0.5";' export 'POST_VER;' 'PSTLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl";' export 'PSTLROOT;' 'PYTHONPATH="/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi";' export 'PYTHONPATH;' 'SP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a";' export 'SP_LIB4;' 'SP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a";' export 'SP_LIB8;' 'SP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a";' export 'SP_LIBd;' 'SP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3";' export 'SP_SRC;' 'SP_VER="v2.0.3";' export 'SP_VER;' 'TBBROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb";' export 'TBBROOT;' 'VT_ADD_LIBS="-ldwarf' -lelf -lvtunwind -lm '-lpthread";' export 'VT_ADD_LIBS;' 'VT_ARCH="intel64";' export 'VT_ARCH;' 'VT_LIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/lib";' export 'VT_LIB_DIR;' 'VT_MPI="impi4";' export 'VT_MPI;' 'VT_ROOT="/usrx/local/prod/intel/2018UP01/itac_latest";' export 'VT_ROOT;' 'VT_SLIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/slib";' export 'VT_SLIB_DIR;' 'W3EMC_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4";' export 'W3EMC_INC4;' 'W3EMC_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8";' export 'W3EMC_INC8;' 'W3EMC_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d";' export 'W3EMC_INCd;' 'W3EMC_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a";' export 'W3EMC_LIB4;' 'W3EMC_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a";' export 'W3EMC_LIB8;' 'W3EMC_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a";' export 'W3EMC_LIBd;' 'W3EMC_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1";' export 'W3EMC_SRC;' 'W3EMC_VER="v2.3.1";' export 'W3EMC_VER;' 'W3NCO_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4";' export 'W3NCO_INC4;' 'W3NCO_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8";' export 'W3NCO_INC8;' 'W3NCO_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d";' export 'W3NCO_INCd;' 'W3NCO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a";' export 'W3NCO_LIB4;' 'W3NCO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a";' export 'W3NCO_LIB8;' 'W3NCO_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a";' export 'W3NCO_LIBd;' 'W3NCO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7";' export 'W3NCO_SRC;' 'W3NCO_VER="v2.0.7";' export 'W3NCO_VER;' 'XLSF_UIDDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid";' export 'XLSF_UIDDIR;' 'Z_INC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'Z_INC;' 'Z_LIB="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a";' export 'Z_LIB;' 'Z_SRC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src";' export 'Z_SRC;' 'Z_VER="1.2.11";' export 'Z_VER;' '__LMOD_REF_COUNT__LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1";' export '__LMOD_REF_COUNT__LMFILES_;' '_LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3";' export '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ ADVISOR_2018_DIR=/usrx/local/prod/intel/2018UP01/advisor_2018
-++ export ADVISOR_2018_DIR
-++ BACIO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a
-++ export BACIO_LIB4
-++ BACIO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a
-++ export BACIO_LIB8
-++ BACIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3
-++ export BACIO_SRC
-++ BACIO_VER=v2.0.3
-++ export BACIO_VER
-++ BINARY_TYPE_HPC=
-++ export BINARY_TYPE_HPC
-++ __LMOD_REF_COUNT_CLASSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1'
-++ export __LMOD_REF_COUNT_CLASSPATH
-++ CLASSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar
-++ export CLASSPATH
-++ CLCK_ROOT=/usrx/local/prod/intel/2018UP01/clck_latest
-++ export CLCK_ROOT
-++ CMAKE_CXX_COMPILER=mpiicpc
-++ export CMAKE_CXX_COMPILER
-++ CMAKE_C_COMPILER=mpiicc
-++ export CMAKE_C_COMPILER
-++ CMAKE_Fortran_COMPILER=mpiifort
-++ export CMAKE_Fortran_COMPILER
-++ CMAKE_Platform=wcoss_dell_p3
-++ export CMAKE_Platform
-++ COMP=ips
-++ export COMP
-++ __LMOD_REF_COUNT_CPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1'
-++ export __LMOD_REF_COUNT_CPATH
-++ CPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include
-++ export CPATH
-++ __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include:1
-++ export __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-++ CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include
-++ export CPLUS_INCLUDE_PATH
-++ CRTM_FIX=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix
-++ export CRTM_FIX
-++ CRTM_INC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6
-++ export CRTM_INC
-++ CRTM_LIB=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a
-++ export CRTM_LIB
-++ CRTM_SRC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src
-++ export CRTM_SRC
-++ CRTM_VER=v2.2.6
-++ export CRTM_VER
-++ DAALROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal
-++ export DAALROOT
-++ ESMFMKFILE=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
-++ export ESMFMKFILE
-++ G2TMPL_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0
-++ export G2TMPL_INC
-++ G2TMPL_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a
-++ export G2TMPL_LIB
-++ G2TMPL_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src
-++ export G2TMPL_SRC
-++ G2TMPL_VER=v1.6.0
-++ export G2TMPL_VER
-++ G2_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4
-++ export G2_INC4
-++ G2_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d
-++ export G2_INCd
-++ G2_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a
-++ export G2_LIB4
-++ G2_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a
-++ export G2_LIBd
-++ G2_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1
-++ export G2_SRC
-++ G2_VER=v3.1.1
-++ export G2_VER
-++ GDBSERVER_MIC=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver
-++ export GDBSERVER_MIC
-++ GDB_CROSS=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia
-++ export GDB_CROSS
-++ HDF5=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export HDF5
-++ HDF5_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CFLAGS
-++ HDF5_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CXXFLAGS
-++ HDF5_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_FFLAGS
-++ HDF5_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_INCLUDE
-++ HDF5_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5 -lhdf5_fortran'
-++ export HDF5_LDFLAGS
-++ HDF5_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5'
-++ export HDF5_LDFLAGS_C
-++ HDF5_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -hdf5_hl_cpp -lhdf5 -lhdf5_cpp'
-++ export HDF5_LDFLAGS_CXX
-++ HDF5_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5'
-++ export HDF5_LDFLAGS_F
-++ __LMOD_REF_COUNT_INFOPATH='/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1'
-++ export __LMOD_REF_COUNT_INFOPATH
-++ INFOPATH=/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx
-++ export INFOPATH
-++ INSPECTOR_2018_DIR=/usrx/local/prod/intel/2018UP01/inspector_2018
-++ export INSPECTOR_2018_DIR
-++ INTEL_LICENSE_FILE=/usrx/local/prod/intel/licenses
-++ export INTEL_LICENSE_FILE
-++ INTEL_PYTHONHOME=/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64
-++ export INTEL_PYTHONHOME
-++ IPPROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp
-++ export IPPROOT
-++ IP_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4
-++ export IP_INC4
-++ IP_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8
-++ export IP_INC8
-++ IP_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d
-++ export IP_INCd
-++ IP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a
-++ export IP_LIB4
-++ IP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a
-++ export IP_LIB8
-++ IP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a
-++ export IP_LIBd
-++ IP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2
-++ export IP_SRC
-++ IP_VER=v3.0.2
-++ export IP_VER
-++ I_MPI_CC=icc
-++ export I_MPI_CC
-++ I_MPI_CXX=icpc
-++ export I_MPI_CXX
-++ I_MPI_EXTRA_FILESYSTEM=yes
-++ export I_MPI_EXTRA_FILESYSTEM
-++ I_MPI_EXTRA_FILESYSTEM_LIST=gpfs
-++ export I_MPI_EXTRA_FILESYSTEM_LIST
-++ I_MPI_F77=ifort
-++ export I_MPI_F77
-++ I_MPI_F90=ifort
-++ export I_MPI_F90
-++ I_MPI_FC=ifort
-++ export I_MPI_FC
-++ I_MPI_HYDRA_BOOTSTRAP=lsf
-++ export I_MPI_HYDRA_BOOTSTRAP
-++ I_MPI_HYDRA_IFACE=ib0
-++ export I_MPI_HYDRA_IFACE
-++ I_MPI_LSF_USE_COLLECTIVE_LAUNCH=1
-++ export I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-++ I_MPI_ROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi
-++ export I_MPI_ROOT
-++ JASPER_INC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include
-++ export JASPER_INC
-++ JASPER_LIB=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a
-++ export JASPER_LIB
-++ JASPER_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib
-++ export JASPER_LIBDIR
-++ JASPER_SRC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29
-++ export JASPER_SRC
-++ JASPER_VER=1.900.29
-++ export JASPER_VER
-++ KMP_AFFINITY=scatter
-++ export KMP_AFFINITY
-++ unset LAUNCH
-++ __LMOD_REF_COUNT_LD_LIBRARY_PATH='/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LD_LIBRARY_PATH
-++ LD_LIBRARY_PATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LD_LIBRARY_PATH
-++ __LMOD_REF_COUNT_LIBRARY_PATH='/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LIBRARY_PATH
-++ LIBRARY_PATH=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LIBRARY_PATH
-++ LIB_NAME=POST
-++ export LIB_NAME
-++ LMOD_FAMILY_COMPILER=ips
-++ export LMOD_FAMILY_COMPILER
-++ LMOD_FAMILY_COMPILER_VERSION=18.0.1.163
-++ export LMOD_FAMILY_COMPILER_VERSION
-++ LMOD_FAMILY_MPI=impi
-++ export LMOD_FAMILY_MPI
-++ LMOD_FAMILY_MPI_VERSION=18.0.1
-++ export LMOD_FAMILY_MPI_VERSION
-++ __LMOD_REF_COUNT_LOADEDMODULES='ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1'
-++ export __LMOD_REF_COUNT_LOADEDMODULES
-++ LOADEDMODULES=ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3
-++ export LOADEDMODULES
-++ LSF_BINDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin
-++ export LSF_BINDIR
-++ LSF_ENVDIR=/gpfs/lsf/conf
-++ export LSF_ENVDIR
-++ LSF_LIBDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib
-++ export LSF_LIBDIR
-++ LSF_SERVERDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc
-++ export LSF_SERVERDIR
-++ __LMOD_REF_COUNT_MANPATH='/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1'
-++ export __LMOD_REF_COUNT_MANPATH
-++ MANPATH=/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man
-++ export MANPATH
-++ MKLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl
-++ export MKLROOT
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ MPM_LAUNCHER=/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh
-++ export MPM_LAUNCHER
-++ NEMSIO_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4
-++ export NEMSIO_INC
-++ NEMSIO_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a
-++ export NEMSIO_LIB
-++ NEMSIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4
-++ export NEMSIO_SRC
-++ NEMSIO_VER=v2.2.4
-++ export NEMSIO_VER
-++ NETCDF=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF
-++ NETCDF_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CFLAGS
-++ NETCDF_CXX4FLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXX4FLAGS
-++ NETCDF_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXXFLAGS
-++ NETCDF_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_FFLAGS
-++ NETCDF_INC=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INC
-++ NETCDF_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INCLUDE
-++ NETCDF_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS
-++ NETCDF_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf'
-++ export NETCDF_LDFLAGS_C
-++ NETCDF_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++'
-++ export NETCDF_LDFLAGS_CXX
-++ NETCDF_LDFLAGS_CXX4='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++4'
-++ export NETCDF_LDFLAGS_CXX4
-++ NETCDF_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS_F
-++ NETCDF_LIB=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib
-++ export NETCDF_LIB
-++ NETCDF_ROOT=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF_ROOT
-++ __LMOD_REF_COUNT_NLSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1'
-++ export __LMOD_REF_COUNT_NLSPATH
-++ NLSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N
-++ export NLSPATH
-++ __LMOD_REF_COUNT_PATH='/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1'
-++ export __LMOD_REF_COUNT_PATH
-++ PATH=/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export PATH
-++ PKG_CONFIG_PATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig
-++ export PKG_CONFIG_PATH
-++ PNG_INC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include
-++ export PNG_INC
-++ PNG_LIB=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a
-++ export PNG_LIB
-++ PNG_LIB12=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a
-++ export PNG_LIB12
-++ PNG_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib
-++ export PNG_LIBDIR
-++ PNG_LIBso=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so
-++ export PNG_LIBso
-++ PNG_SRC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59
-++ export PNG_SRC
-++ PNG_VER=1.2.59
-++ export PNG_VER
-++ POST_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4
-++ export POST_INC
-++ POST_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a
-++ export POST_LIB
-++ POST_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5
-++ export POST_SRC
-++ POST_VER=v8.0.5
-++ export POST_VER
-++ PSTLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl
-++ export PSTLROOT
-++ PYTHONPATH=/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi
-++ export PYTHONPATH
-++ SP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a
-++ export SP_LIB4
-++ SP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a
-++ export SP_LIB8
-++ SP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a
-++ export SP_LIBd
-++ SP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3
-++ export SP_SRC
-++ SP_VER=v2.0.3
-++ export SP_VER
-++ TBBROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb
-++ export TBBROOT
-++ VT_ADD_LIBS='-ldwarf -lelf -lvtunwind -lm -lpthread'
-++ export VT_ADD_LIBS
-++ VT_ARCH=intel64
-++ export VT_ARCH
-++ VT_LIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/lib
-++ export VT_LIB_DIR
-++ VT_MPI=impi4
-++ export VT_MPI
-++ VT_ROOT=/usrx/local/prod/intel/2018UP01/itac_latest
-++ export VT_ROOT
-++ VT_SLIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/slib
-++ export VT_SLIB_DIR
-++ W3EMC_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4
-++ export W3EMC_INC4
-++ W3EMC_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8
-++ export W3EMC_INC8
-++ W3EMC_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d
-++ export W3EMC_INCd
-++ W3EMC_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a
-++ export W3EMC_LIB4
-++ W3EMC_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a
-++ export W3EMC_LIB8
-++ W3EMC_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a
-++ export W3EMC_LIBd
-++ W3EMC_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1
-++ export W3EMC_SRC
-++ W3EMC_VER=v2.3.1
-++ export W3EMC_VER
-++ W3NCO_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4
-++ export W3NCO_INC4
-++ W3NCO_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8
-++ export W3NCO_INC8
-++ W3NCO_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d
-++ export W3NCO_INCd
-++ W3NCO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a
-++ export W3NCO_LIB4
-++ W3NCO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a
-++ export W3NCO_LIB8
-++ W3NCO_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a
-++ export W3NCO_LIBd
-++ W3NCO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7
-++ export W3NCO_SRC
-++ W3NCO_VER=v2.0.7
-++ export W3NCO_VER
-++ XLSF_UIDDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid
-++ export XLSF_UIDDIR
-++ Z_INC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export Z_INC
-++ Z_LIB=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a
-++ export Z_LIB
-++ Z_SRC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src
-++ export Z_SRC
-++ Z_VER=1.2.11
-++ export Z_VER
-++ __LMOD_REF_COUNT__LMFILES_='/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1'
-++ export __LMOD_REF_COUNT__LMFILES_
-++ _LMFILES_=/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3
-++ export _LMFILES_
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module list
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash list
+rm -f -f libgfsphys.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend */*.tmp.f90
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+(cd ccpp/driver         && make clean)
+
+Build CCPP layer ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+makefile:67: depend: No such file or directory
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Building dependencies ...
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+
+Build CCPP layer ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+Cleaning CCPP_layer  ... 
+
+rm -f -f libccppdriver.a *__genmod.f90 *.tmp.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+(cd ipd                 && make clean)
+
+Build standalone FV3 gfsphysics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+makefile:54: depend: No such file or directory
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Building dependencies ...
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+
+Build standalone FV3 gfsphysics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+Cleaning ipd  ... 
+
+rm -f -f libipd.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+(cd ../stochastic_physics  && make clean)
+
+Build standalone FV3 stochastic_physics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+makefile:86: depend: No such file or directory
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Building dependencies ...
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+
+Build standalone FV3 stochastic_physics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+Cleaning stochastic_physics ... 
+
+rm -f -f libstochastic_physics.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+(cd io                  && make clean)
+
+Build standalone FV3 io ...
+
+$ESMF_INC is []
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning io ... 
+
+rm -f -f libfv3io.a *__genmod.f90 *.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+(cd atmos_cubed_sphere  && make clean)
+
+Build standalone FV3 fv3core ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning fv3core ... 
+
+rm -f -f libfv3core.a *__genmod.f90 */*.o */*/*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+(cd cpl                 && make clean)
+
+Build standalone FV3 io ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning io ... 
+
+rm -f -f libfv3cpl.a *.o *.mod *.lst *.i90 depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+rm -f -f fv3.exe libfv3cap.a *.o *.mod *.i90 *.lst depend
+rm -f -rf nems_dir fv3.mk FV3_INSTALL
+rm -f -f conf/modules.fv3
+rm -f -f conf/configure.fv3
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+rm -rf nems_dir FV3_INSTALL /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/configure.fv3 \
+    /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/modules.fv3
+rm -rf /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk
+if ! test -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC ; then       \
+  cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC       ; \
+  delete_nuopc=yes                                      ; \
+fi                                                      ; \
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src ; gmake "COMPONENTS=FMS WW3 FV3"    \
+  INCLUDES_ARE_OPTIONAL=YES clean                       ; \
+if [ "$delete_nuopc" = yes ] ; then                      \
+  rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC                 ; \
+fi
+Components in linker order: FV3 WW3 FMS
+FV3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
+GNUmakefile:70: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk: component FV3 makefile fragment is missing
+WW3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk
+GNUmakefile:70: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk: component WW3 makefile fragment is missing
+FMS: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk
+GNUmakefile:70: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk: component FMS makefile fragment is missing
+CPPFLAGS += ESMF_VERSION_STRING_GIT="ESMF_8_0_1"
+CPPFLAGS += ESMF_VERSION_MAJOR="8"
+CPPFLAGS += ESMF_VERSION_BETASNAPSHOT="'F'"
+CPPFLAGS += ESMF_VERSION_MINOR="0"
+CPPFLAGS += ESMF_VERSION_PATCHLEVEL="1"
+CPPFLAGS += ESMF_VERSION_STRING="8.0.1"
+CPPFLAGS += ESMF_VERSION_REVISION="1"
+CPPFLAGS += ESMF_VERSION_PUBLIC="'T'"
+rm -f -f *.tmp.f90 *.lst *.o *.mod lm map
+cd ENS_Cpl ; gmake clean
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+rm -f -f ENS_Cpl.a *.f90 *.o *.mod *.lst lm map depend
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
+rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC
+rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/externals.nems /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ESMFVersionDefine.h /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems.sh /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems.csh /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/test-results.mk
+rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/components.mk
+rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/test_results.mk
++ gmake -j 8 -k COMPONENTS=WW3,FMS,FV3 TEST_BUILD_NAME=fv3_1 BUILD_ENV=wcoss_dell_p3 'FV3_MAKEOPT=32BIT=Y WW3=Y' NEMS_BUILDOPT= build
+Will copy modules.nems and NEMS.x as fv3_1 under tests/
+NOTE: Skipping appbuilder.mk creation; no appbuilder file in use.
+echo 'FMS WW3 FV3' > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/components.mk"
+Adding FV3 makeopts to FMS makeopts
+cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/modulefiles/wcoss_dell_p3/fv3 /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems
+set -xe ; cp "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems" "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/tests/modules.fv3_1"
++ cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/tests/modules.fv3_1
+cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/conf/configure.fv3.wcoss_dell_p3 /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems
+cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/externals.nems
+cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ESMFVersionDefine_ESMF_NUOPC.h /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ESMFVersionDefine.h
+( echo '. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc' ; \
+echo 'module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf' ; \
+echo 'module load modules.nems' ) > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems.sh"
+( echo 'source /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.csh.inc' ; \
+echo 'module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf' ; \
+echo 'module load modules.nems' ) > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems.csh"
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/incmake/configure_rules.mk:3: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/test-results.mk: No such file or directory
+gmake -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/incmake/tests.mk    \
+      MODULE_LOGIC="  . /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack"           \
+      TARGET="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/test-results.mk" TEST
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS'
+if [ -f "/modules.nems" ] ; then \
+  . /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=unlimited                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s  ; \
+fi ; \
+( \
+echo "# Do not edit this file.  It is automatically generated from tests.mk." ; \
+echo "CASELESS_FILESYSTEM=NO" ; \
+if [ "Q$ESMFMKFILE" != Q ] ; then egrep 'VERSION|^ESMF_[A-Z]*DIR' < "$ESMFMKFILE" ; fi ; \
+) > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/test-results.mk"
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS'
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs                      ; \
+exec gmake 32BIT=Y WW3=Y all
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
+
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
 
 Currently Loaded Modules:
   1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
-  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.5
-  3) lsf/10.1        10) g2/3.1.1         17) hdf5_parallel/1.10.6
-  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) netcdf_parallel/4.7.4
-  5) ip/3.0.2        12) crtm/2.2.6       19) esmf/8.0.0_ParallelNetCDF
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
   6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
-  7) w3nco/2.0.7     14) libpng/1.2.59    21) fv3
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
 
  
 
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ cd build_fv3_2
-+ cmake /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model -DWW3=Y
--- The C compiler identification is Intel 18.0.1.20171018
--- The CXX compiler identification is Intel 18.0.1.20171018
--- The Fortran compiler identification is Intel 18.0.1.20171018
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc -- works
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Detecting C compile features
--- Detecting C compile features - done
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc -- works
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort  -- works
--- Detecting Fortran compiler ABI info
--- Detecting Fortran compiler ABI info - done
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90 -- yes
--- Found MPI_C: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc (found version "3.1") 
--- Found MPI_CXX: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc (found version "3.1") 
--- Found MPI_Fortran: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort (found version "3.1") 
--- Found MPI: TRUE (found version "3.1")  
-ESMFMKFILE:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
- Found ESMF:
-ESMF_VERSION_MAJOR:     8
-ESMF_F90COMPILEPATHS:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-ESMF_F90ESMFLINKRPATHS: -Wl,-rpath,/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib
-ESMF_F90ESMFLINKLIBS:   -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf
--- Found ESMF: /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include (found version "8.0.0") 
-
-Setting configuration for wcoss_dell_p3
-
-C       compiler: Intel 18.0.1.20171018 (mpiicc)
-CXX     compiler: Intel 18.0.1.20171018 (mpiicpc)
-Fortran compiler: Intel 18.0.1.20171018 (mpiifort)
-
-DEBUG  is      disabled
-REPRO  is      disabled
-32BIT  is      disabled
-OPENMP is      ENABLED
-AVX2 is        disabled
-INLINE_POST is ENABLED
-
-
-Selected physics package: gfs
-
-Build WW3:
-   run: /usr/bin/gmake WW3_PARCOMPN=4 WW3_COMP=wcoss_dell_p3 ww3_nems
-   in:  /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/WW3/model/esmf
-
--- Configuring done
--- Generating done
--- Build files have been written to: /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/build_fv3_2
-+ make -j 4
-Scanning dependencies of target ww3_nems
-Scanning dependencies of target fv3cpl
-[  1%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cap_cpl.F90.o
-Scanning dependencies of target gfsphysics
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/machine.F.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/co2hc.f.o
-[  1%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cplfields.F90.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_composition.f.o
-[  2%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/efield.f.o
-[  2%] Linking Fortran static library libfv3cpl.a
-Scanning dependencies of target fms
-[  3%] Building Fortran object CMakeFiles/fms.dir/FMS/platform/platform.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  3%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_parameter.F90.o
-[  3%] Built target fv3cpl
-[  3%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_core.F90.o
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+Building dependencies ...
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_parameter.F90 -o ../mpp/mpp_parameter.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../platform/platform.F90 -o ../platform/platform.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/cloud_interpolator.F90 -o ../drifters/cloud_interpolator.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/drifters_input.F90 -o ../drifters/drifters_input.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/drifters_io.F90 -o ../drifters/drifters_io.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/drifters_core.F90 -o ../drifters/drifters_core.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/quicksort.F90 -o ../drifters/quicksort.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../monin_obukhov/monin_obukhov_kernel.F90 -o ../monin_obukhov/monin_obukhov_kernel.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../random_numbers/MersenneTwister.F90 -o ../random_numbers/MersenneTwister.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
@@ -2057,116 +333,77 @@ Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wam_f107_kp_mod.f90.o
-[  4%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_input.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../sat_vapor_pres/sat_vapor_pres_k.F90 -o ../sat_vapor_pres/sat_vapor_pres_k.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mersenne_twister.f.o
-[  4%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/cloud_interpolator.F90.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[  4%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_io.F90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/GFDL_parse_tracers.F90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iounitdef.f.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/namelist_soilveg.f.o
-[  4%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/MersenneTwister.F90.o
-[  5%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_wrf_utl.f90.o
-[  5%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/noahmp_tables.f90.o
-[  5%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_radar.F90.o
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres_k.F90.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physcons.F90.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/constants/constants.F90.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/date_def.f.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progtm_module.f.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerclm_def.f.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2o_def.f.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physparam.f.o
-[  8%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_data.F90.o
-[  9%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozne_def.f.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../tridiagonal/tridiagonal.F90 -o ../tridiagonal/tridiagonal.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 10%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfs_phy_tracer_config.F.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp.F90.o
-[ 10%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/surface_perturbation.F90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmp_glacier.f90.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmplsm.f90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccn_def.f.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg_utils.F90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfdl_cloud_microphys.F90.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tracer_const_h.f.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/funcphys.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_initialize.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_astronomy.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_surface.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_parameters.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aer_cloud.F.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_thompson_gfs.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_wsm6_fv3.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs_fv3.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_cice.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diff.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_module.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rascnvv2.f.o
-[ 13%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_efp.F90.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../affinity/affinity.c -o ../affinity/affinity.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../memutils/memuse.c -o ../memutils/memuse.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mosaic/create_xgrid.c -o ../mosaic/create_xgrid.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mosaic/gradient_c2l.c -o ../mosaic/gradient_c2l.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mosaic/interp.c -o ../mosaic/interp.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mosaic/mosaic_util.c -o ../mosaic/mosaic_util.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mosaic/read_mosaic.c -o ../mosaic/read_mosaic.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mpp/nsclock.c -o ../mpp/nsclock.o
+mpiicc -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -xHOST -qno-opt-dynamic-align -D__IFC -sox -fp-model source -O2 -debug minimal -qopenmp   -c ../mpp/threadloc.c -o ../mpp/threadloc.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_data.F90 -o ../mpp/mpp_data.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../constants/constants.F90 -o ../constants/constants.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 13%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_memutils.F90.o
-[ 14%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_pset.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp.F90 -o ../mpp/mpp.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 15%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_type.F90.o
-[ 15%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_aerosols.f.o
-ifort: command line warning #10121: overriding '-xHOST' with '-xCORE-AVX-I'
-[ 16%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/gradient.F90.o
-[ 17%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_domains.F90.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_bfmicrophysics.f.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_gases.f.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_datatb.f.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_datatb.f.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_memutils.F90 -o ../mpp/mpp_memutils.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_pset.F90 -o ../mpp/mpp_pset.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_efp.F90 -o ../mpp/mpp_efp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp_type.F90 -o ../horiz_interp/horiz_interp_type.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mosaic/gradient.F90 -o ../mosaic/gradient.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../fft/fft99.F90 -o ../fft/fft99.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_utilities.F90 -o ../mpp/mpp_utilities.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_water_prop.f90.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wv_saturation.F.o
-[ 19%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cs_conv.F90.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diag.f.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_drv.f.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_ocean.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_sice.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_typedefs.F90.o
-[ 21%] Built target ww3_nems
-[ 22%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_clouds.f.o
-[ 23%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_main.f.o
-[ 24%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_main.f.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_model.f90.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldmacro.F.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldwat2m_micro.F.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg2_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg3_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_radiation_driver.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_diagnostics.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_nst.f.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_physics_driver.F90.o
-[ 28%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_restart.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_comm.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_io.F90.o
+Using 8-byte addressing
+Using pure routines.
+Using allocatable derived type array members.
+Using cray pointers.
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_domains.F90 -o ../mpp/mpp_domains.o
+Using 8-byte addressing
+Using pure routines.
+Using allocatable derived type array members.
+Using cray pointers.
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mpp/mpp_io.F90 -o ../mpp/mpp_io.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../block_control/block_control.F90 -o ../block_control/block_control.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/drifters_comm.F90 -o ../drifters/drifters_comm.o
+Using 8-byte addressing
+Using pure routines.
+Using allocatable derived type array members.
+Using cray pointers.
+Compiling in MPI mode (with or without MPP) 
+Using 8-byte addressing
+Using pure routines.
+Using allocatable derived type array members.
+Using cray pointers.
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../drifters/drifters.F90 -o ../drifters/drifters.o
 Compiling in MPI mode (with or without MPP) 
 Using 8-byte addressing
 Using pure routines.
@@ -2176,1616 +413,1687 @@ Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms_io.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/memutils/memutils.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../memutils/memutils.F90 -o ../memutils/memutils.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../fms/fms_io.F90 -o ../fms/fms_io.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 30%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms.F90.o
-[ 30%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bicubic.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/time_manager.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bilinear.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../fms/fms.F90 -o ../fms/fms.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../time_manager/time_manager.F90 -o ../time_manager/time_manager.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../affinity/fms_affinity.F90 -o ../affinity/fms_affinity.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp_conserve.F90 -o ../horiz_interp/horiz_interp_conserve.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp_bicubic.F90 -o ../horiz_interp/horiz_interp_bicubic.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp_bilinear.F90 -o ../horiz_interp/horiz_interp_bilinear.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp_spherical.F90 -o ../horiz_interp/horiz_interp_spherical.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../axis_utils/axis_utils.F90 -o ../axis_utils/axis_utils.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_grid.F90 -o ../diag_manager/diag_grid.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_conserve.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_spherical.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../field_manager/field_manager.F90 -o ../field_manager/field_manager.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/axis_utils/axis_utils.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_grid.F90.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/field_manager.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/mosaic.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/gaussian_topog.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/get_cal_time.F90.o
-[ 31%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp.F90.o
-[ 32%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp.F90.o
-[ 32%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_data.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../coupler/ensemble_manager.F90 -o ../coupler/ensemble_manager.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mosaic/mosaic.F90 -o ../mosaic/mosaic.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../fft/fft.F90 -o ../fft/fft.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../monin_obukhov/monin_obukhov.F90 -o ../monin_obukhov/monin_obukhov.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../sat_vapor_pres/sat_vapor_pres.F90 -o ../sat_vapor_pres/sat_vapor_pres.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../topography/gaussian_topog.F90 -o ../topography/gaussian_topog.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../oda_tools/oda_types.F90 -o ../oda_tools/oda_types.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../time_manager/get_cal_time.F90 -o ../time_manager/get_cal_time.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../time_interp/time_interp.F90 -o ../time_interp/time_interp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../astronomy/astronomy.F90 -o ../astronomy/astronomy.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../column_diagnostics/column_diagnostics.F90 -o ../column_diagnostics/column_diagnostics.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_data.F90 -o ../diag_manager/diag_data.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_integral/diag_integral.F90 -o ../diag_integral/diag_integral.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 33%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_types.F90.o
-[ 34%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_axis.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../mosaic/grid.F90 -o ../mosaic/grid.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../oda_tools/write_ocean_data.F90 -o ../oda_tools/write_ocean_data.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manifest.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/xbt_drop_rate_adjust.f90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/write_ocean_data.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp_external.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../random_numbers/random_numbers.F90 -o ../random_numbers/random_numbers.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../oda_tools/xbt_drop_rate_adjust.f90 -o ../oda_tools/xbt_drop_rate_adjust.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_manifest.F90 -o ../diag_manager/diag_manifest.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_axis.F90 -o ../diag_manager/diag_axis.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../horiz_interp/horiz_interp.F90 -o ../horiz_interp/horiz_interp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../field_manager/fm_util.F90 -o ../field_manager/fm_util.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../oda_tools/oda_core.F90 -o ../oda_tools/oda_core.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/fm_util.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_output.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../oda_tools/oda_core_ecda.F90 -o ../oda_tools/oda_core_ecda.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../tracer_manager/tracer_manager.F90 -o ../tracer_manager/tracer_manager.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_output.F90 -o ../diag_manager/diag_output.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_util.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_util.F90 -o ../diag_manager/diag_util.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_table.F90.o
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manager.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_table.F90 -o ../diag_manager/diag_table.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../amip_interp/amip_interp.F90 -o ../amip_interp/amip_interp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../time_interp/time_interp_external.F90 -o ../time_interp/time_interp_external.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../topography/topography.F90 -o ../topography/topography.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../diag_manager/diag_manager.F90 -o ../diag_manager/diag_manager.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/data_override/data_override.F90.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 37%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/stock_constants.F90.o
-[ 37%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/coupler_types.F90.o
-[ 38%] Building Fortran object CMakeFiles/fms.dir/FMS/amip_interp/amip_interp.F90.o
-[ 38%] Building Fortran object CMakeFiles/fms.dir/FMS/astronomy/astronomy.F90.o
-[ 38%] Building Fortran object CMakeFiles/fms.dir/FMS/block_control/block_control.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../data_override/data_override.F90 -o ../data_override/data_override.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 39%] Building Fortran object CMakeFiles/fms.dir/FMS/column_diagnostics/column_diagnostics.F90.o
-[ 39%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/atmos_ocean_fluxes.F90.o
-[ 39%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/ensemble_manager.F90.o
-[ 40%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters.F90.o
-[ 40%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/xgrid.F90.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft.F90.o
-Compiling in MPI mode (with or without MPP) 
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../coupler/coupler_types.F90 -o ../coupler/coupler_types.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../exchange/stock_constants.F90 -o ../exchange/stock_constants.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../interpolator/interpolator.F90 -o ../interpolator/interpolator.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../station_data/station_data.F90 -o ../station_data/station_data.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../exchange/xgrid.F90 -o ../exchange/xgrid.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft99.F90.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/interpolator/interpolator.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/grid.F90.o
-[ 41%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_driver.F90.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_utilities.F90.o
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core.F90.o
-[ 41%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_abstraction_layer.F90.o
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2oc.f.o
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_solar_heating.f.o
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_tracer.f.o
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ideaca.f.o
-[ 42%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core_ecda.F90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfcsub.F.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ugwp_driver_v0.f.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cnvc90.f.o
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/random_numbers.F90.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.f.o
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres.F90.o
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/station_data/station_data.F90.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.pre.rad.f.o
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/topography.F90.o
-[ 45%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs.f.o
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/tracer_manager/tracer_manager.F90.o
-[ 45%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gocart_tracer_config_stub.f.o
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/tridiagonal/tridiagonal.F90.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscond.f.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscondp.f.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdc.f.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdps.f.o
-[ 47%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/quicksort.F90.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_orowam2017.f.o
-[ 48%] Building C object CMakeFiles/fms.dir/FMS/memutils/memuse.c.o
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ohdc.f.o
-[ 48%] Building C object CMakeFiles/fms.dir/FMS/mosaic/create_xgrid.c.o
-[ 48%] Building C object CMakeFiles/fms.dir/FMS/mosaic/gradient_c2l.c.o
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ophys.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_co2.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_dissipation.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_h2o.f.o
-[ 51%] Building C object CMakeFiles/fms.dir/FMS/mosaic/interp.c.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_ion.f.o
-[ 51%] Building C object CMakeFiles/fms.dir/FMS/mosaic/mosaic_util.c.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_o2_o3.f.o
-[ 51%] Building C object CMakeFiles/fms.dir/FMS/mosaic/read_mosaic.c.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_phys.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/lrgsclr.f.o
-[ 53%] Building C object CMakeFiles/fms.dir/FMS/affinity/affinity.c.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbl.f.o
-[ 54%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpblt.f.o
-[ 54%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbltq.f.o
-[ 55%] Building C object CMakeFiles/fms.dir/FMS/mpp/nsclock.c.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscu.f.o
-[ 55%] Building C object CMakeFiles/fms.dir/FMS/mpp/threadloc.c.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscuq.f.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf.f.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf_hafs.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp1.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq1.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninshoc.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadb.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn2.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstcnv.f.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys.f.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys_2015.f.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd.f.o
-[ 60%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd_shoc.f.o
-[ 60%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpdp.f.o
-[ 60%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progt2.f.o
-[ 61%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rad_initialize.f.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp.f.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp_mesopause.f.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfaerosols.f.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfdeepcnv.f.o
-[ 63%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfshalcnv.f.o
-[ 63%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnv.f.o
-[ 63%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnvn.f.o
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdif.f.o
-[ 64%] Linking Fortran static library FMS/libfms.a
-[ 64%] Built target fms
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdifq.f.o
-[ 64%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/set_soilveg.f.o
-[ 65%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_noahmp_drv.f.o
-[ 65%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sflx.f.o
-[ 65%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcnv.f.o
-[ 65%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_1lyr.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_fixdp.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_opr.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tridi2t3.f.o
-[ 66%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/calpreciptype.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcm_shoc.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ointerp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozinterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccninterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerinterp.f90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/num_parthds.F.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcycle.F90.o
-[ 67%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_utils.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_triggers.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_solvers.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_lsatdis.F90.o
-[ 68%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_orodis.F90.o
-[ 69%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_wmsdis.F90.o
-[ 69%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/m_micro_driver.F90.o
-[ 69%] Linking Fortran static library libgfsphysics.a
-[ 69%] Built target gfsphysics
-Scanning dependencies of target ipd
-[ 69%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_typedefs.F90.o
-[ 69%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_driver.F90.o
-[ 69%] Linking Fortran static library libipd.a
-[ 69%] Built target ipd
-Scanning dependencies of target io
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_fv3_io_def.F90.o
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_internal_state.F90.o
-Scanning dependencies of target fv3core
-[ 69%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_sst.F90.o
-[ 69%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_arrays.F90.o
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_fill.F90.o
-[ 70%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_nemsio.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sim_nc_mod.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf_parallel.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/DYCORE_typedefs.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_gfs.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_mp_mod.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sorted_index.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_cmp.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_timing.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_eta.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_sg.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_grid_utils.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/boundary.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 74%] Building Fortran object FV3/io/CMakeFiles/io.dir/FV3GFS_io.F90.o
-[ 75%] Building Fortran object FV3/io/CMakeFiles/io.dir/ffsync.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_wrt_grid_comp.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_nems_routines.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_mapz.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/a2b_edge.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_surf_map.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/tp_core.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_grid_tools.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/init_hydro.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_treat_da_inc.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/sw_core.F90.o
-[ 78%] Linking Fortran static library libio.a
-[ 78%] Built target io
-[ 78%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_iau_mod.F90.o
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_io.F90.o
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_diagnostics.F90.o
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_utils.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_core.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/test_cases.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_nudge.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_regional_bc.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_tracer2d.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/dyn_core.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_update_phys.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_ic.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_restart.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_control.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_nesting.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_dynamics.F90.o
-[ 85%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90.o
-[ 85%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/multi_gases.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 85%] Linking Fortran static library libfv3core.a
-[ 85%] Built target fv3core
-Scanning dependencies of target stochastic_physics
-[ 85%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_resol_def.f.o
-[ 86%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/update_ca.f90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_gg_def.f.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/spectral_layout.F90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_layout_lag.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/glats_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_namelist_def.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/compns_stochy.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_lag_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/epslon_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_lats_node_a_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_ls_node_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/gozrineo_stochy.f.o
-[ 89%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/pln2eo_stochy.f.o
-[ 90%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_a_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_internal_state_mod.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dezouv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dozeuv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/four_to_grid_stochy.F.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_patterngenerator.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/sumfln_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_lag_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_spectral.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/initialize_spectral_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_data_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_stochy_pattern.F90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/cellular_automata.f90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochastic_physics.F90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/plumes.f90.o
-[ 94%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/num_parthds_stochy.f.o
-[ 95%] Linking Fortran static library libstochastic_physics.a
-[ 95%] Built target stochastic_physics
-Scanning dependencies of target fv3cap
-[ 95%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fv3_config.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/atmos_model.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fcst_grid_comp.F90.o
-[ 97%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/time_utils.F90.o
-[ 97%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/fv3_cap.F90.o
-[ 97%] Linking Fortran static library libfv3cap.a
-[ 97%] Built target fv3cap
-Scanning dependencies of target NEMS.exe
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_SpaceWeather.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_methods.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/ENS_Cpl/ENS_CplComp_ESMFMod_STUB.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_UTILS.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_Rusage.F90.o
-[ 98%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_GRID_COMP.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_GRID_COMP.F90.o
-[100%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/MAIN_NEMS.F90.o
-[100%] Building C object CMakeFiles/NEMS.exe.dir/NEMS/src/nems_c_rusage.c.o
-[100%] Linking Fortran executable NEMS.exe
-/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a(jas_stream.o): In function `jas_stream_tmpfile':
-/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29/src/libjasper/base/jas_stream.c:520: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
-[100%] Built target NEMS.exe
-+ mv NEMS.exe ../fv3_2.exe
-+ cp /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3 ../modules.fv3_2
-+ cd ..
-+ '[' YES = YES ']'
-+ rm -rf build_fv3_2
-+ elapsed=539
-+ echo 'Elapsed time 539 seconds. Compiling WW3=Y finished'
-Elapsed time 539 seconds. Compiling WW3=Y finished
-+ SECONDS=0
-+++ readlink -f /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-++ dirname /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/compile_cmake.sh
-+ readonly MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ MYDIR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ readonly ARGC=4
-+ ARGC=4
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ [[ 4 -eq 0 ]]
-+ [[ 4 -lt 2 ]]
-+ PATHTR=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model
-+ MACHINE_ID=wcoss_dell_p3
-+ MAKE_OPT=32BIT=Y
-+ BUILD_NAME=fv3_3
-+ clean_before=YES
-+ clean_after=YES
-+ BUILD_DIR=build_fv3_3
-+ [[ wcoss_dell_p3 == cheyenne.* ]]
-+ [[ wcoss_dell_p3 == wcoss_dell_p3 ]]
-+ MAKE_THREADS=4
-+ MAKE_THREADS=4
-+ hostname
-m72a2
-+ cd /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests
-+ echo 'Compiling 32BIT=Y into fv3_3.exe on wcoss_dell_p3'
-Compiling 32BIT=Y into fv3_3.exe on wcoss_dell_p3
-+ '[' YES = YES ']'
-+ rm -rf build_fv3_3
-+ mkdir -p build_fv3_3
-+ CCPP_CMAKE_FLAGS=
-+ [[ 32BIT=Y == *\D\E\B\U\G\=\Y* ]]
-+ [[ 32BIT=Y == *\R\E\P\R\O\=\Y* ]]
-+ [[ 32BIT=Y == *\3\2\B\I\T\=\Y* ]]
-+ CCPP_CMAKE_FLAGS=' -D32BIT=Y'
-+ [[ 32BIT=Y == *\O\P\E\N\M\P\=\N* ]]
-+ [[ 32BIT=Y == *\C\C\P\P\=\Y* ]]
-+ [[ 32BIT=Y == *\N\A\M\_\p\h\y\s\=\Y* ]]
-+ [[ 32BIT=Y == *\W\W\3\=\Y* ]]
-++ trim ' -D32BIT=Y'
-++ local 'var= -D32BIT=Y'
-++ var=-D32BIT=Y
-++ var=-D32BIT=Y
-++ echo -n -D32BIT=Y
-+ CCPP_CMAKE_FLAGS=-D32BIT=Y
-+ source /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/NEMS/src/conf/module-setup.sh.inc
-++ __ms_function_name=setup__test_function__20097
-++ eval 'setup__test_function__20097() { /bin/true ; }'
-+++ eval '__text="text" ; if [[ $__text =~ ^(t).* ]] ; then printf "%s" ${.sh.match[1]} ; fi'
-+++ cat
-++ __ms_ksh_test=
-+++ eval 'if ( set | grep setup__test_function__20097 | grep -v name > /dev/null 2>&1 ) ; then echo t ; fi '
-+++ cat
-++ __ms_bash_test=t
-++ [[ ! -z '' ]]
-++ [[ ! -z t ]]
-++ __ms_shell=bash
-++ [[ -d /lfs3 ]]
-++ [[ -d /scratch1 ]]
-++ [[ -d /gpfs/hps ]]
-++ [[ -e /etc/SuSE-release ]]
-++ [[ -d /dcom ]]
-++ [[ -L /usrx ]]
-+++ readlink /usrx
-++ [[ /gpfs/dell1/usrx =~ dell ]]
-++ eval module help
-++ module purge
-+++ /usrx/local/prod/lmod/lmod/libexec/lmod bash purge
-++ eval unset 'ADVISOR_2018_DIR;' unset 'BACIO_LIB4;' unset 'BACIO_LIB8;' unset 'BACIO_SRC;' unset 'BACIO_VER;' unset 'BINARY_TYPE_HPC;' unset '__LMOD_REF_COUNT_CLASSPATH;' unset 'CLASSPATH;' unset 'CLCK_ROOT;' unset 'CMAKE_CXX_COMPILER;' unset 'CMAKE_C_COMPILER;' unset 'CMAKE_Fortran_COMPILER;' unset 'CMAKE_Platform;' unset 'COMP;' unset '__LMOD_REF_COUNT_CPATH;' unset 'CPATH;' unset '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' unset 'CPLUS_INCLUDE_PATH;' unset 'CRTM_FIX;' unset 'CRTM_INC;' unset 'CRTM_LIB;' unset 'CRTM_SRC;' unset 'CRTM_VER;' unset 'DAALROOT;' unset 'ECF_HOSTFILE;' unset 'ECF_PORT;' unset 'ECF_ROOT;' unset 'ESMFMKFILE;' unset 'G2TMPL_INC;' unset 'G2TMPL_LIB;' unset 'G2TMPL_SRC;' unset 'G2TMPL_VER;' unset 'G2_INC4;' unset 'G2_INCd;' unset 'G2_LIB4;' unset 'G2_LIBd;' unset 'G2_SRC;' unset 'G2_VER;' unset 'GDBSERVER_MIC;' unset 'GDB_CROSS;' unset 'HDF5;' unset 'HDF5_CFLAGS;' unset 'HDF5_CXXFLAGS;' unset 'HDF5_FFLAGS;' unset 'HDF5_INCLUDE;' unset 'HDF5_LDFLAGS;' unset 'HDF5_LDFLAGS_C;' unset 'HDF5_LDFLAGS_CXX;' unset 'HDF5_LDFLAGS_F;' unset '__LMOD_REF_COUNT_INFOPATH;' unset 'INFOPATH;' unset 'INSPECTOR_2018_DIR;' unset 'INTEL_LICENSE_FILE;' unset 'INTEL_PYTHONHOME;' unset 'IPPROOT;' unset 'IP_INC4;' unset 'IP_INC8;' unset 'IP_INCd;' unset 'IP_LIB4;' unset 'IP_LIB8;' unset 'IP_LIBd;' unset 'IP_SRC;' unset 'IP_VER;' unset 'I_MPI_CC;' unset 'I_MPI_CXX;' unset 'I_MPI_EXTRA_FILESYSTEM;' unset 'I_MPI_EXTRA_FILESYSTEM_LIST;' unset 'I_MPI_F77;' unset 'I_MPI_F90;' unset 'I_MPI_FC;' unset 'I_MPI_HYDRA_BOOTSTRAP;' unset 'I_MPI_HYDRA_IFACE;' unset 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' unset 'I_MPI_ROOT;' unset 'JASPER_INC;' unset 'JASPER_LIB;' unset 'JASPER_LIBDIR;' unset 'JASPER_SRC;' unset 'JASPER_VER;' unset 'KMP_AFFINITY;' unset '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' unset 'LD_LIBRARY_PATH;' unset '__LMOD_REF_COUNT_LIBRARY_PATH;' unset 'LIBRARY_PATH;' unset 'LIB_NAME;' unset 'LMOD_FAMILY_COMPILER;' unset 'LMOD_FAMILY_COMPILER_VERSION;' unset 'LMOD_FAMILY_MPI;' unset 'LMOD_FAMILY_MPI_VERSION;' unset '__LMOD_REF_COUNT_LOADEDMODULES;' unset 'LOADEDMODULES;' unset 'LSF_BINDIR;' unset 'LSF_ENVDIR;' unset 'LSF_LIBDIR;' unset 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/prod/lmod/lmod/share/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/prod/lmod/lmod/share/man::";' export 'MANPATH;' unset 'MKLROOT;' 'MODULEPATH="/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' unset 'MPM_LAUNCHER;' unset 'NEMSIO_INC;' unset 'NEMSIO_LIB;' unset 'NEMSIO_SRC;' unset 'NEMSIO_VER;' unset 'NETCDF;' unset 'NETCDF_CFLAGS;' unset 'NETCDF_CXX4FLAGS;' unset 'NETCDF_CXXFLAGS;' unset 'NETCDF_FFLAGS;' unset 'NETCDF_INC;' unset 'NETCDF_INCLUDE;' unset 'NETCDF_LDFLAGS;' unset 'NETCDF_LDFLAGS_C;' unset 'NETCDF_LDFLAGS_CXX;' unset 'NETCDF_LDFLAGS_CXX4;' unset 'NETCDF_LDFLAGS_F;' unset 'NETCDF_LIB;' unset 'NETCDF_ROOT;' unset '__LMOD_REF_COUNT_NLSPATH;' unset 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin";' export 'PATH;' unset 'PKG_CONFIG_PATH;' unset 'PNG_INC;' unset 'PNG_LIB;' unset 'PNG_LIB12;' unset 'PNG_LIBDIR;' unset 'PNG_LIBso;' unset 'PNG_SRC;' unset 'PNG_VER;' unset 'POST_INC;' unset 'POST_LIB;' unset 'POST_SRC;' unset 'POST_VER;' unset 'PSTLROOT;' unset 'PYTHONPATH;' unset '__LMOD_REF_COUNT_QT_PLUGIN_PATH;' unset 'QT_PLUGIN_PATH;' unset 'SP_LIB4;' unset 'SP_LIB8;' unset 'SP_LIBd;' unset 'SP_SRC;' unset 'SP_VER;' unset 'TBBROOT;' unset 'VT_ADD_LIBS;' unset 'VT_ARCH;' unset 'VT_LIB_DIR;' unset 'VT_MPI;' unset 'VT_ROOT;' unset 'VT_SLIB_DIR;' unset 'W3EMC_INC4;' unset 'W3EMC_INC8;' unset 'W3EMC_INCd;' unset 'W3EMC_LIB4;' unset 'W3EMC_LIB8;' unset 'W3EMC_LIBd;' unset 'W3EMC_SRC;' unset 'W3EMC_VER;' unset 'W3NCO_INC4;' unset 'W3NCO_INC8;' unset 'W3NCO_INCd;' unset 'W3NCO_LIB4;' unset 'W3NCO_LIB8;' unset 'W3NCO_LIBd;' unset 'W3NCO_SRC;' unset 'W3NCO_VER;' unset 'XLSF_UIDDIR;' unset 'Z_INC;' unset 'Z_LIB;' unset 'Z_SRC;' unset 'Z_VER;' unset '__LMOD_REF_COUNT__LMFILES_;' unset '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;' unset '_ModuleTable004_;' unset '_ModuleTable005_;' unset '_ModuleTable006_;' unset '_ModuleTable007_;' unset '_ModuleTable008_;' unset '_ModuleTable009_;' unset '_ModuleTable010_;' unset '_ModuleTable011_;' unset '_ModuleTable012_;' unset '_ModuleTable013_;' unset '_ModuleTable014_;' unset '_ModuleTable015_;' unset '_ModuleTable016_;' unset '_ModuleTable017_;'
-+++ unset ADVISOR_2018_DIR
-+++ unset BACIO_LIB4
-+++ unset BACIO_LIB8
-+++ unset BACIO_SRC
-+++ unset BACIO_VER
-+++ unset BINARY_TYPE_HPC
-+++ unset __LMOD_REF_COUNT_CLASSPATH
-+++ unset CLASSPATH
-+++ unset CLCK_ROOT
-+++ unset CMAKE_CXX_COMPILER
-+++ unset CMAKE_C_COMPILER
-+++ unset CMAKE_Fortran_COMPILER
-+++ unset CMAKE_Platform
-+++ unset COMP
-+++ unset __LMOD_REF_COUNT_CPATH
-+++ unset CPATH
-+++ unset __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-+++ unset CPLUS_INCLUDE_PATH
-+++ unset CRTM_FIX
-+++ unset CRTM_INC
-+++ unset CRTM_LIB
-+++ unset CRTM_SRC
-+++ unset CRTM_VER
-+++ unset DAALROOT
-+++ unset ECF_HOSTFILE
-+++ unset ECF_PORT
-+++ unset ECF_ROOT
-+++ unset ESMFMKFILE
-+++ unset G2TMPL_INC
-+++ unset G2TMPL_LIB
-+++ unset G2TMPL_SRC
-+++ unset G2TMPL_VER
-+++ unset G2_INC4
-+++ unset G2_INCd
-+++ unset G2_LIB4
-+++ unset G2_LIBd
-+++ unset G2_SRC
-+++ unset G2_VER
-+++ unset GDBSERVER_MIC
-+++ unset GDB_CROSS
-+++ unset HDF5
-+++ unset HDF5_CFLAGS
-+++ unset HDF5_CXXFLAGS
-+++ unset HDF5_FFLAGS
-+++ unset HDF5_INCLUDE
-+++ unset HDF5_LDFLAGS
-+++ unset HDF5_LDFLAGS_C
-+++ unset HDF5_LDFLAGS_CXX
-+++ unset HDF5_LDFLAGS_F
-+++ unset __LMOD_REF_COUNT_INFOPATH
-+++ unset INFOPATH
-+++ unset INSPECTOR_2018_DIR
-+++ unset INTEL_LICENSE_FILE
-+++ unset INTEL_PYTHONHOME
-+++ unset IPPROOT
-+++ unset IP_INC4
-+++ unset IP_INC8
-+++ unset IP_INCd
-+++ unset IP_LIB4
-+++ unset IP_LIB8
-+++ unset IP_LIBd
-+++ unset IP_SRC
-+++ unset IP_VER
-+++ unset I_MPI_CC
-+++ unset I_MPI_CXX
-+++ unset I_MPI_EXTRA_FILESYSTEM
-+++ unset I_MPI_EXTRA_FILESYSTEM_LIST
-+++ unset I_MPI_F77
-+++ unset I_MPI_F90
-+++ unset I_MPI_FC
-+++ unset I_MPI_HYDRA_BOOTSTRAP
-+++ unset I_MPI_HYDRA_IFACE
-+++ unset I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-+++ unset I_MPI_ROOT
-+++ unset JASPER_INC
-+++ unset JASPER_LIB
-+++ unset JASPER_LIBDIR
-+++ unset JASPER_SRC
-+++ unset JASPER_VER
-+++ unset KMP_AFFINITY
-+++ unset __LMOD_REF_COUNT_LD_LIBRARY_PATH
-+++ unset LD_LIBRARY_PATH
-+++ unset __LMOD_REF_COUNT_LIBRARY_PATH
-+++ unset LIBRARY_PATH
-+++ unset LIB_NAME
-+++ unset LMOD_FAMILY_COMPILER
-+++ unset LMOD_FAMILY_COMPILER_VERSION
-+++ unset LMOD_FAMILY_MPI
-+++ unset LMOD_FAMILY_MPI_VERSION
-+++ unset __LMOD_REF_COUNT_LOADEDMODULES
-+++ unset LOADEDMODULES
-+++ unset LSF_BINDIR
-+++ unset LSF_ENVDIR
-+++ unset LSF_LIBDIR
-+++ unset LSF_SERVERDIR
-+++ __LMOD_REF_COUNT_MANPATH=/usrx/local/prod/lmod/lmod/share/man:1
-+++ export __LMOD_REF_COUNT_MANPATH
-+++ MANPATH=/usrx/local/prod/lmod/lmod/share/man::
-+++ export MANPATH
-+++ unset MKLROOT
-+++ MODULEPATH=/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-+++ export MODULEPATH
-+++ unset MPM_LAUNCHER
-+++ unset NEMSIO_INC
-+++ unset NEMSIO_LIB
-+++ unset NEMSIO_SRC
-+++ unset NEMSIO_VER
-+++ unset NETCDF
-+++ unset NETCDF_CFLAGS
-+++ unset NETCDF_CXX4FLAGS
-+++ unset NETCDF_CXXFLAGS
-+++ unset NETCDF_FFLAGS
-+++ unset NETCDF_INC
-+++ unset NETCDF_INCLUDE
-+++ unset NETCDF_LDFLAGS
-+++ unset NETCDF_LDFLAGS_C
-+++ unset NETCDF_LDFLAGS_CXX
-+++ unset NETCDF_LDFLAGS_CXX4
-+++ unset NETCDF_LDFLAGS_F
-+++ unset NETCDF_LIB
-+++ unset NETCDF_ROOT
-+++ unset __LMOD_REF_COUNT_NLSPATH
-+++ unset NLSPATH
-+++ __LMOD_REF_COUNT_PATH='/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1'
-+++ export __LMOD_REF_COUNT_PATH
-+++ PATH=/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin
-+++ export PATH
-+++ unset PKG_CONFIG_PATH
-+++ unset PNG_INC
-+++ unset PNG_LIB
-+++ unset PNG_LIB12
-+++ unset PNG_LIBDIR
-+++ unset PNG_LIBso
-+++ unset PNG_SRC
-+++ unset PNG_VER
-+++ unset POST_INC
-+++ unset POST_LIB
-+++ unset POST_SRC
-+++ unset POST_VER
-+++ unset PSTLROOT
-+++ unset PYTHONPATH
-+++ unset __LMOD_REF_COUNT_QT_PLUGIN_PATH
-+++ unset QT_PLUGIN_PATH
-+++ unset SP_LIB4
-+++ unset SP_LIB8
-+++ unset SP_LIBd
-+++ unset SP_SRC
-+++ unset SP_VER
-+++ unset TBBROOT
-+++ unset VT_ADD_LIBS
-+++ unset VT_ARCH
-+++ unset VT_LIB_DIR
-+++ unset VT_MPI
-+++ unset VT_ROOT
-+++ unset VT_SLIB_DIR
-+++ unset W3EMC_INC4
-+++ unset W3EMC_INC8
-+++ unset W3EMC_INCd
-+++ unset W3EMC_LIB4
-+++ unset W3EMC_LIB8
-+++ unset W3EMC_LIBd
-+++ unset W3EMC_SRC
-+++ unset W3EMC_VER
-+++ unset W3NCO_INC4
-+++ unset W3NCO_INC8
-+++ unset W3NCO_INCd
-+++ unset W3NCO_LIB4
-+++ unset W3NCO_LIB8
-+++ unset W3NCO_LIBd
-+++ unset W3NCO_SRC
-+++ unset W3NCO_VER
-+++ unset XLSF_UIDDIR
-+++ unset Z_INC
-+++ unset Z_LIB
-+++ unset Z_SRC
-+++ unset Z_VER
-+++ unset __LMOD_REF_COUNT__LMFILES_
-+++ unset _LMFILES_
-+++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-+++ export _ModuleTable001_
-+++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-+++ export _ModuleTable002_
-+++ _ModuleTable_Sz_=2
-+++ export _ModuleTable_Sz_
-+++ unset _ModuleTable004_
-+++ unset _ModuleTable005_
-+++ unset _ModuleTable006_
-+++ unset _ModuleTable007_
-+++ unset _ModuleTable008_
-+++ unset _ModuleTable009_
-+++ unset _ModuleTable010_
-+++ unset _ModuleTable011_
-+++ unset _ModuleTable012_
-+++ unset _ModuleTable013_
-+++ unset _ModuleTable014_
-+++ unset _ModuleTable015_
-+++ unset _ModuleTable016_
-+++ unset _ModuleTable017_
-+++ : -s sh
-++ eval
-++ unset __ms_shell
-++ unset __ms_ksh_test
-++ unset __ms_bash_test
-++ unset setup__test_function__20097
-++ unset __ms_function_name
-+ [[ wcoss_dell_p3 == macosx.* ]]
-+ [[ wcoss_dell_p3 == linux.* ]]
-+ module use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash use /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl";' export '_ModuleTable001_;' '_ModuleTable002_="cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=";' export '_ModuleTable002_;' '_ModuleTable_Sz_="2";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXt9LG1UPXt9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMiLCIvdXNyeC9sb2NhbC9kZXYvZW1jX3JvY290by9tb2R1bGVmaWxlcyIsIi9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3NvZnQvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9kZXYvbW9kdWxlZmlsZXMiLCIvdXNyeC9sb2NhbC9wcm9kL2xtb2QvbG1vZC9tb2R1bGVmaWxl
-++ export _ModuleTable001_
-++ _ModuleTable002_=cy9Db3JlIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzIiwiL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29yZV9wcm9kIix9LFsic3lzdGVtQmFzZU1QQVRIIl09Ii91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmU6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkOi91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvZGVmczovZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLH0=
-++ export _ModuleTable002_
-++ _ModuleTable_Sz_=2
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module load fv3
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash load fv3
-+ eval 'ADVISOR_2018_DIR="/usrx/local/prod/intel/2018UP01/advisor_2018";' export 'ADVISOR_2018_DIR;' 'BACIO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a";' export 'BACIO_LIB4;' 'BACIO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a";' export 'BACIO_LIB8;' 'BACIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3";' export 'BACIO_SRC;' 'BACIO_VER="v2.0.3";' export 'BACIO_VER;' 'BINARY_TYPE_HPC="";' export 'BINARY_TYPE_HPC;' '__LMOD_REF_COUNT_CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1";' export '__LMOD_REF_COUNT_CLASSPATH;' 'CLASSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar";' export 'CLASSPATH;' 'CLCK_ROOT="/usrx/local/prod/intel/2018UP01/clck_latest";' export 'CLCK_ROOT;' 'CMAKE_CXX_COMPILER="mpiicpc";' export 'CMAKE_CXX_COMPILER;' 'CMAKE_C_COMPILER="mpiicc";' export 'CMAKE_C_COMPILER;' 'CMAKE_Fortran_COMPILER="mpiifort";' export 'CMAKE_Fortran_COMPILER;' 'CMAKE_Platform="wcoss_dell_p3";' export 'CMAKE_Platform;' 'COMP="ips";' export 'COMP;' '__LMOD_REF_COUNT_CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1";' export '__LMOD_REF_COUNT_CPATH;' 'CPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include";' export 'CPATH;' '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include:1";' export '__LMOD_REF_COUNT_CPLUS_INCLUDE_PATH;' 'CPLUS_INCLUDE_PATH="/usrx/local/prod/intel/2018UP01/clck_latest/include";' export 'CPLUS_INCLUDE_PATH;' 'CRTM_FIX="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix";' export 'CRTM_FIX;' 'CRTM_INC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6";' export 'CRTM_INC;' 'CRTM_LIB="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a";' export 'CRTM_LIB;' 'CRTM_SRC="/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src";' export 'CRTM_SRC;' 'CRTM_VER="v2.2.6";' export 'CRTM_VER;' 'DAALROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal";' export 'DAALROOT;' 'ESMFMKFILE="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk";' export 'ESMFMKFILE;' 'G2TMPL_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0";' export 'G2TMPL_INC;' 'G2TMPL_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a";' export 'G2TMPL_LIB;' 'G2TMPL_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src";' export 'G2TMPL_SRC;' 'G2TMPL_VER="v1.6.0";' export 'G2TMPL_VER;' 'G2_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4";' export 'G2_INC4;' 'G2_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d";' export 'G2_INCd;' 'G2_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a";' export 'G2_LIB4;' 'G2_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a";' export 'G2_LIBd;' 'G2_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1";' export 'G2_SRC;' 'G2_VER="v3.1.1";' export 'G2_VER;' 'GDBSERVER_MIC="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver";' export 'GDBSERVER_MIC;' 'GDB_CROSS="/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia";' export 'GDB_CROSS;' 'HDF5="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'HDF5;' 'HDF5_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CFLAGS;' 'HDF5_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_CXXFLAGS;' 'HDF5_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_FFLAGS;' 'HDF5_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'HDF5_INCLUDE;' 'HDF5_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran -lhdf5 '-lhdf5_fortran";' export 'HDF5_LDFLAGS;' 'HDF5_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl '-lhdf5";' export 'HDF5_LDFLAGS_C;' 'HDF5_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -hdf5_hl_cpp -lhdf5 '-lhdf5_cpp";' export 'HDF5_LDFLAGS_CXX;' 'HDF5_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lhdf5_hl -lhdf5hl_fortran '-lhdf5";' export 'HDF5_LDFLAGS_F;' '__LMOD_REF_COUNT_INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1";' export '__LMOD_REF_COUNT_INFOPATH;' 'INFOPATH="/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx";' export 'INFOPATH;' 'INSPECTOR_2018_DIR="/usrx/local/prod/intel/2018UP01/inspector_2018";' export 'INSPECTOR_2018_DIR;' 'INTEL_LICENSE_FILE="/usrx/local/prod/intel/licenses";' export 'INTEL_LICENSE_FILE;' 'INTEL_PYTHONHOME="/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64";' export 'INTEL_PYTHONHOME;' 'IPPROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp";' export 'IPPROOT;' 'IP_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4";' export 'IP_INC4;' 'IP_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8";' export 'IP_INC8;' 'IP_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d";' export 'IP_INCd;' 'IP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a";' export 'IP_LIB4;' 'IP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a";' export 'IP_LIB8;' 'IP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a";' export 'IP_LIBd;' 'IP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2";' export 'IP_SRC;' 'IP_VER="v3.0.2";' export 'IP_VER;' 'I_MPI_CC="icc";' export 'I_MPI_CC;' 'I_MPI_CXX="icpc";' export 'I_MPI_CXX;' 'I_MPI_EXTRA_FILESYSTEM="yes";' export 'I_MPI_EXTRA_FILESYSTEM;' 'I_MPI_EXTRA_FILESYSTEM_LIST="gpfs";' export 'I_MPI_EXTRA_FILESYSTEM_LIST;' 'I_MPI_F77="ifort";' export 'I_MPI_F77;' 'I_MPI_F90="ifort";' export 'I_MPI_F90;' 'I_MPI_FC="ifort";' export 'I_MPI_FC;' 'I_MPI_HYDRA_BOOTSTRAP="lsf";' export 'I_MPI_HYDRA_BOOTSTRAP;' 'I_MPI_HYDRA_IFACE="ib0";' export 'I_MPI_HYDRA_IFACE;' 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH="1";' export 'I_MPI_LSF_USE_COLLECTIVE_LAUNCH;' 'I_MPI_ROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi";' export 'I_MPI_ROOT;' 'JASPER_INC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include";' export 'JASPER_INC;' 'JASPER_LIB="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a";' export 'JASPER_LIB;' 'JASPER_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib";' export 'JASPER_LIBDIR;' 'JASPER_SRC="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29";' export 'JASPER_SRC;' 'JASPER_VER="1.900.29";' export 'JASPER_VER;' 'KMP_AFFINITY="scatter";' export 'KMP_AFFINITY;' unset 'LAUNCH;' '__LMOD_REF_COUNT_LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LD_LIBRARY_PATH;' 'LD_LIBRARY_PATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LD_LIBRARY_PATH;' '__LMOD_REF_COUNT_LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1";' export '__LMOD_REF_COUNT_LIBRARY_PATH;' 'LIBRARY_PATH="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4";' export 'LIBRARY_PATH;' 'LIB_NAME="POST";' export 'LIB_NAME;' 'LMOD_FAMILY_COMPILER="ips";' export 'LMOD_FAMILY_COMPILER;' 'LMOD_FAMILY_COMPILER_VERSION="18.0.1.163";' export 'LMOD_FAMILY_COMPILER_VERSION;' 'LMOD_FAMILY_MPI="impi";' export 'LMOD_FAMILY_MPI;' 'LMOD_FAMILY_MPI_VERSION="18.0.1";' export 'LMOD_FAMILY_MPI_VERSION;' '__LMOD_REF_COUNT_LOADEDMODULES="ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1";' export '__LMOD_REF_COUNT_LOADEDMODULES;' 'LOADEDMODULES="ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3";' export 'LOADEDMODULES;' 'LSF_BINDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin";' export 'LSF_BINDIR;' 'LSF_ENVDIR="/gpfs/lsf/conf";' export 'LSF_ENVDIR;' 'LSF_LIBDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib";' export 'LSF_LIBDIR;' 'LSF_SERVERDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc";' export 'LSF_SERVERDIR;' '__LMOD_REF_COUNT_MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1";' export '__LMOD_REF_COUNT_MANPATH;' 'MANPATH="/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man";' export 'MANPATH;' 'MKLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl";' export 'MKLROOT;' 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' 'MPM_LAUNCHER="/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh";' export 'MPM_LAUNCHER;' 'NEMSIO_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4";' export 'NEMSIO_INC;' 'NEMSIO_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a";' export 'NEMSIO_LIB;' 'NEMSIO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4";' export 'NEMSIO_SRC;' 'NEMSIO_VER="v2.2.4";' export 'NEMSIO_VER;' 'NETCDF="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF;' 'NETCDF_CFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CFLAGS;' 'NETCDF_CXX4FLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXX4FLAGS;' 'NETCDF_CXXFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_CXXFLAGS;' 'NETCDF_FFLAGS="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_FFLAGS;' 'NETCDF_INC="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INC;' 'NETCDF_INCLUDE="-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include";' export 'NETCDF_INCLUDE;' 'NETCDF_LDFLAGS="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS;' 'NETCDF_LDFLAGS_C="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdf";' export 'NETCDF_LDFLAGS_C;' 'NETCDF_LDFLAGS_CXX="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++";' export 'NETCDF_LDFLAGS_CXX;' 'NETCDF_LDFLAGS_CXX4="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' -lnetcdf '-lnetcdf_c++4";' export 'NETCDF_LDFLAGS_CXX4;' 'NETCDF_LDFLAGS_F="-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib' '-lnetcdff";' export 'NETCDF_LDFLAGS_F;' 'NETCDF_LIB="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib";' export 'NETCDF_LIB;' 'NETCDF_ROOT="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel";' export 'NETCDF_ROOT;' '__LMOD_REF_COUNT_NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1";' export '__LMOD_REF_COUNT_NLSPATH;' 'NLSPATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N";' export 'NLSPATH;' '__LMOD_REF_COUNT_PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1";' export '__LMOD_REF_COUNT_PATH;' 'PATH="/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'PATH;' 'PKG_CONFIG_PATH="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig";' export 'PKG_CONFIG_PATH;' 'PNG_INC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include";' export 'PNG_INC;' 'PNG_LIB="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a";' export 'PNG_LIB;' 'PNG_LIB12="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a";' export 'PNG_LIB12;' 'PNG_LIBDIR="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib";' export 'PNG_LIBDIR;' 'PNG_LIBso="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so";' export 'PNG_LIBso;' 'PNG_SRC="/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59";' export 'PNG_SRC;' 'PNG_VER="1.2.59";' export 'PNG_VER;' 'POST_INC="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4";' export 'POST_INC;' 'POST_LIB="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a";' export 'POST_LIB;' 'POST_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5";' export 'POST_SRC;' 'POST_VER="v8.0.5";' export 'POST_VER;' 'PSTLROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl";' export 'PSTLROOT;' 'PYTHONPATH="/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi";' export 'PYTHONPATH;' 'SP_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a";' export 'SP_LIB4;' 'SP_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a";' export 'SP_LIB8;' 'SP_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a";' export 'SP_LIBd;' 'SP_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3";' export 'SP_SRC;' 'SP_VER="v2.0.3";' export 'SP_VER;' 'TBBROOT="/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb";' export 'TBBROOT;' 'VT_ADD_LIBS="-ldwarf' -lelf -lvtunwind -lm '-lpthread";' export 'VT_ADD_LIBS;' 'VT_ARCH="intel64";' export 'VT_ARCH;' 'VT_LIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/lib";' export 'VT_LIB_DIR;' 'VT_MPI="impi4";' export 'VT_MPI;' 'VT_ROOT="/usrx/local/prod/intel/2018UP01/itac_latest";' export 'VT_ROOT;' 'VT_SLIB_DIR="/usrx/local/prod/intel/2018UP01/itac_latest/slib";' export 'VT_SLIB_DIR;' 'W3EMC_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4";' export 'W3EMC_INC4;' 'W3EMC_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8";' export 'W3EMC_INC8;' 'W3EMC_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d";' export 'W3EMC_INCd;' 'W3EMC_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a";' export 'W3EMC_LIB4;' 'W3EMC_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a";' export 'W3EMC_LIB8;' 'W3EMC_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a";' export 'W3EMC_LIBd;' 'W3EMC_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1";' export 'W3EMC_SRC;' 'W3EMC_VER="v2.3.1";' export 'W3EMC_VER;' 'W3NCO_INC4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4";' export 'W3NCO_INC4;' 'W3NCO_INC8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8";' export 'W3NCO_INC8;' 'W3NCO_INCd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d";' export 'W3NCO_INCd;' 'W3NCO_LIB4="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a";' export 'W3NCO_LIB4;' 'W3NCO_LIB8="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a";' export 'W3NCO_LIB8;' 'W3NCO_LIBd="/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a";' export 'W3NCO_LIBd;' 'W3NCO_SRC="/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7";' export 'W3NCO_SRC;' 'W3NCO_VER="v2.0.7";' export 'W3NCO_VER;' 'XLSF_UIDDIR="/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid";' export 'XLSF_UIDDIR;' 'Z_INC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include";' export 'Z_INC;' 'Z_LIB="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a";' export 'Z_LIB;' 'Z_SRC="/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src";' export 'Z_SRC;' 'Z_VER="1.2.11";' export 'Z_VER;' '__LMOD_REF_COUNT__LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1";' export '__LMOD_REF_COUNT__LMFILES_;' '_LMFILES_="/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3";' export '_LMFILES_;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ ADVISOR_2018_DIR=/usrx/local/prod/intel/2018UP01/advisor_2018
-++ export ADVISOR_2018_DIR
-++ BACIO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a
-++ export BACIO_LIB4
-++ BACIO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_8.a
-++ export BACIO_LIB8
-++ BACIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/bacio_v2.0.3
-++ export BACIO_SRC
-++ BACIO_VER=v2.0.3
-++ export BACIO_VER
-++ BINARY_TYPE_HPC=
-++ export BINARY_TYPE_HPC
-++ __LMOD_REF_COUNT_CLASSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar:1'
-++ export __LMOD_REF_COUNT_CLASSPATH
-++ CLASSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64/mpi.jar:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/daal.jar
-++ export CLASSPATH
-++ CLCK_ROOT=/usrx/local/prod/intel/2018UP01/clck_latest
-++ export CLCK_ROOT
-++ CMAKE_CXX_COMPILER=mpiicpc
-++ export CMAKE_CXX_COMPILER
-++ CMAKE_C_COMPILER=mpiicc
-++ export CMAKE_C_COMPILER
-++ CMAKE_Fortran_COMPILER=mpiifort
-++ export CMAKE_Fortran_COMPILER
-++ CMAKE_Platform=wcoss_dell_p3
-++ export CMAKE_Platform
-++ COMP=ips
-++ export COMP
-++ __LMOD_REF_COUNT_CPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include:1'
-++ export __LMOD_REF_COUNT_CPATH
-++ CPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/include:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/include
-++ export CPATH
-++ __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include:1
-++ export __LMOD_REF_COUNT_CPLUS_INCLUDE_PATH
-++ CPLUS_INCLUDE_PATH=/usrx/local/prod/intel/2018UP01/clck_latest/include
-++ export CPLUS_INCLUDE_PATH
-++ CRTM_FIX=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/fix
-++ export CRTM_FIX
-++ CRTM_INC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/include/crtm_v2.2.6
-++ export CRTM_INC
-++ CRTM_LIB=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a
-++ export CRTM_LIB
-++ CRTM_SRC=/gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/src
-++ export CRTM_SRC
-++ CRTM_VER=v2.2.6
-++ export CRTM_VER
-++ DAALROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal
-++ export DAALROOT
-++ ESMFMKFILE=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
-++ export ESMFMKFILE
-++ G2TMPL_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2tmpl_v1.6.0
-++ export G2TMPL_INC
-++ G2TMPL_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2tmpl_v1.6.0.a
-++ export G2TMPL_LIB
-++ G2TMPL_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2tmpl_v1.6.0/src
-++ export G2TMPL_SRC
-++ G2TMPL_VER=v1.6.0
-++ export G2TMPL_VER
-++ G2_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_4
-++ export G2_INC4
-++ G2_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/g2_v3.1.1_d
-++ export G2_INCd
-++ G2_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a
-++ export G2_LIB4
-++ G2_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_d.a
-++ export G2_LIBd
-++ G2_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/g2_v3.1.1
-++ export G2_SRC
-++ G2_VER=v3.1.1
-++ export G2_VER
-++ GDBSERVER_MIC=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver
-++ export GDBSERVER_MIC
-++ GDB_CROSS=/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin/gdb-ia
-++ export GDB_CROSS
-++ HDF5=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export HDF5
-++ HDF5_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CFLAGS
-++ HDF5_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_CXXFLAGS
-++ HDF5_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_FFLAGS
-++ HDF5_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export HDF5_INCLUDE
-++ HDF5_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5 -lhdf5_fortran'
-++ export HDF5_LDFLAGS
-++ HDF5_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5'
-++ export HDF5_LDFLAGS_C
-++ HDF5_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -hdf5_hl_cpp -lhdf5 -lhdf5_cpp'
-++ export HDF5_LDFLAGS_CXX
-++ HDF5_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lhdf5_hl -lhdf5hl_fortran -lhdf5'
-++ export HDF5_LDFLAGS_F
-++ __LMOD_REF_COUNT_INFOPATH='/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:1;info_gdb_igfx:1'
-++ export __LMOD_REF_COUNT_INFOPATH
-++ INFOPATH=/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/info:info_gdb_igfx
-++ export INFOPATH
-++ INSPECTOR_2018_DIR=/usrx/local/prod/intel/2018UP01/inspector_2018
-++ export INSPECTOR_2018_DIR
-++ INTEL_LICENSE_FILE=/usrx/local/prod/intel/licenses
-++ export INTEL_LICENSE_FILE
-++ INTEL_PYTHONHOME=/usrx/local/prod/intel/2018UP01/debugger_2018/python/intel64
-++ export INTEL_PYTHONHOME
-++ IPPROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp
-++ export IPPROOT
-++ IP_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_4
-++ export IP_INC4
-++ IP_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_8
-++ export IP_INC8
-++ IP_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ip_v3.0.2_d
-++ export IP_INCd
-++ IP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_4.a
-++ export IP_LIB4
-++ IP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_8.a
-++ export IP_LIB8
-++ IP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libip_v3.0.2_d.a
-++ export IP_LIBd
-++ IP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/ip_v3.0.2
-++ export IP_SRC
-++ IP_VER=v3.0.2
-++ export IP_VER
-++ I_MPI_CC=icc
-++ export I_MPI_CC
-++ I_MPI_CXX=icpc
-++ export I_MPI_CXX
-++ I_MPI_EXTRA_FILESYSTEM=yes
-++ export I_MPI_EXTRA_FILESYSTEM
-++ I_MPI_EXTRA_FILESYSTEM_LIST=gpfs
-++ export I_MPI_EXTRA_FILESYSTEM_LIST
-++ I_MPI_F77=ifort
-++ export I_MPI_F77
-++ I_MPI_F90=ifort
-++ export I_MPI_F90
-++ I_MPI_FC=ifort
-++ export I_MPI_FC
-++ I_MPI_HYDRA_BOOTSTRAP=lsf
-++ export I_MPI_HYDRA_BOOTSTRAP
-++ I_MPI_HYDRA_IFACE=ib0
-++ export I_MPI_HYDRA_IFACE
-++ I_MPI_LSF_USE_COLLECTIVE_LAUNCH=1
-++ export I_MPI_LSF_USE_COLLECTIVE_LAUNCH
-++ I_MPI_ROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi
-++ export I_MPI_ROOT
-++ JASPER_INC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/include
-++ export JASPER_INC
-++ JASPER_LIB=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a
-++ export JASPER_LIB
-++ JASPER_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib
-++ export JASPER_LIBDIR
-++ JASPER_SRC=/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29
-++ export JASPER_SRC
-++ JASPER_VER=1.900.29
-++ export JASPER_VER
-++ KMP_AFFINITY=scatter
-++ export KMP_AFFINITY
-++ unset LAUNCH
-++ __LMOD_REF_COUNT_LD_LIBRARY_PATH='/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/itac_latest/slib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:1;/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LD_LIBRARY_PATH
-++ LD_LIBRARY_PATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/itac_latest/slib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/lib64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/debugger_2018/iga/lib:/usrx/local/prod/intel/2018UP01/debugger_2018/libipt/intel64/lib:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LD_LIBRARY_PATH
-++ __LMOD_REF_COUNT_LIBRARY_PATH='/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:1;/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4:1'
-++ export __LMOD_REF_COUNT_LIBRARY_PATH
-++ LIBRARY_PATH=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib:/usrx/local/prod/intel/2018UP01/clck_latest/lib/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/ipp/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.7:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/daal/lib/intel64_lin:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb/lib/intel64_lin/gcc4.4
-++ export LIBRARY_PATH
-++ LIB_NAME=POST
-++ export LIB_NAME
-++ LMOD_FAMILY_COMPILER=ips
-++ export LMOD_FAMILY_COMPILER
-++ LMOD_FAMILY_COMPILER_VERSION=18.0.1.163
-++ export LMOD_FAMILY_COMPILER_VERSION
-++ LMOD_FAMILY_MPI=impi
-++ export LMOD_FAMILY_MPI
-++ LMOD_FAMILY_MPI_VERSION=18.0.1
-++ export LMOD_FAMILY_MPI_VERSION
-++ __LMOD_REF_COUNT_LOADEDMODULES='ips/18.0.1.163:1;impi/18.0.1:1;lsf/10.1:1;bacio/2.0.3:1;ip/3.0.2:1;sp/2.0.3:1;w3nco/2.0.7:1;w3emc/2.3.1:1;nemsio/2.2.4:1;g2/3.1.1:1;g2tmpl/1.6.0:1;crtm/2.2.6:1;jasper/1.900.29:1;libpng/1.2.59:1;zlib/1.2.11:1;post/8.0.5:1;hdf5_parallel/1.10.6:1;netcdf_parallel/4.7.4:1;esmf/8.0.0_ParallelNetCDF:1;cmake/3.10.0:1;fv3:1'
-++ export __LMOD_REF_COUNT_LOADEDMODULES
-++ LOADEDMODULES=ips/18.0.1.163:impi/18.0.1:lsf/10.1:bacio/2.0.3:ip/3.0.2:sp/2.0.3:w3nco/2.0.7:w3emc/2.3.1:nemsio/2.2.4:g2/3.1.1:g2tmpl/1.6.0:crtm/2.2.6:jasper/1.900.29:libpng/1.2.59:zlib/1.2.11:post/8.0.5:hdf5_parallel/1.10.6:netcdf_parallel/4.7.4:esmf/8.0.0_ParallelNetCDF:cmake/3.10.0:fv3
-++ export LOADEDMODULES
-++ LSF_BINDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin
-++ export LSF_BINDIR
-++ LSF_ENVDIR=/gpfs/lsf/conf
-++ export LSF_ENVDIR
-++ LSF_LIBDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib
-++ export LSF_LIBDIR
-++ LSF_SERVERDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc
-++ export LSF_SERVERDIR
-++ __LMOD_REF_COUNT_MANPATH='/usrx/local/dev/packages/cmake/3.10.0/share/man:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:2;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:1;/gpfs/lsf/10.1/man:1;/usrx/local/prod/intel/2018UP01/itac_latest/man:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:1;/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:1;/usrx/local/prod/lmod/lmod/share/man:1;/usrx/local/prod/intel/2018UP01/inspector_2018/man:1;/usrx/local/prod/intel/2018UP01/advisor_2018/man:1'
-++ export __LMOD_REF_COUNT_MANPATH
-++ MANPATH=/usrx/local/dev/packages/cmake/3.10.0/share/man:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/share/man:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/share/man:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/share/man:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/man:/gpfs/lsf/10.1/man:/usrx/local/prod/intel/2018UP01/itac_latest/man:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/man/common:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-ia/man:/usrx/local/prod/intel/2018UP01/documentation_2018/en/debugger/gdb-igfx/man:/usrx/local/prod/lmod/lmod/share/man::/usrx/local/prod/intel/2018UP01/inspector_2018/man:/usrx/local/prod/intel/2018UP01/advisor_2018/man
-++ export MANPATH
-++ MKLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl
-++ export MKLROOT
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ MPM_LAUNCHER=/usrx/local/prod/intel/2018UP01/debugger_2018/mpm/mic/bin/start_mpm.sh
-++ export MPM_LAUNCHER
-++ NEMSIO_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4
-++ export NEMSIO_INC
-++ NEMSIO_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a
-++ export NEMSIO_LIB
-++ NEMSIO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/nemsio_v2.2.4
-++ export NEMSIO_SRC
-++ NEMSIO_VER=v2.2.4
-++ export NEMSIO_VER
-++ NETCDF=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF
-++ NETCDF_CFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CFLAGS
-++ NETCDF_CXX4FLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXX4FLAGS
-++ NETCDF_CXXFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_CXXFLAGS
-++ NETCDF_FFLAGS=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_FFLAGS
-++ NETCDF_INC=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INC
-++ NETCDF_INCLUDE=-I/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-++ export NETCDF_INCLUDE
-++ NETCDF_LDFLAGS='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS
-++ NETCDF_LDFLAGS_C='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf'
-++ export NETCDF_LDFLAGS_C
-++ NETCDF_LDFLAGS_CXX='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++'
-++ export NETCDF_LDFLAGS_CXX
-++ NETCDF_LDFLAGS_CXX4='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdf -lnetcdf_c++4'
-++ export NETCDF_LDFLAGS_CXX4
-++ NETCDF_LDFLAGS_F='-L/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib -lnetcdff'
-++ export NETCDF_LDFLAGS_F
-++ NETCDF_LIB=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/lib
-++ export NETCDF_LIB
-++ NETCDF_ROOT=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel
-++ export NETCDF_ROOT
-++ __LMOD_REF_COUNT_NLSPATH='/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N:1'
-++ export __LMOD_REF_COUNT_NLSPATH
-++ NLSPATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/lib/intel64_lin/locale/%l_%t/%N:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/lib/intel64_lin/locale/%l_%t/%N::/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/share/locale/%l_%t/%N
-++ export NLSPATH
-++ __LMOD_REF_COUNT_PATH='/usrx/local/dev/packages/cmake/3.10.0/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:2;/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:1;/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:1;/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:1;/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:1;/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:1;/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:1;/usrx/local/prod/intel/2018UP01/itac_latest/bin:1;/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:1;/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:1;/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:1;/usr/lib64/qt-3.3/bin:1;/usr/local/bin:1;/usr/bin:1;/usr/local/sbin:1;/usr/sbin:1;/usr/lpp/mmfs/bin:1;/opt/ibutils/bin:1;/opt/dell/srvadmin/bin:1;/u/Dusan.Jovic/bin:2;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:1;/u/Dusan.Jovic/.local/bin:1;/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include:1'
-++ export __LMOD_REF_COUNT_PATH
-++ PATH=/usrx/local/dev/packages/cmake/3.10.0/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/bin:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/bin:/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/bin:/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/bin:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/etc:/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/bin:/usrx/local/prod/intel/2018UP01/advisor_2018/bin64:/usrx/local/prod/intel/2018UP01/vtune_amplifier_2018/bin64:/usrx/local/prod/intel/2018UP01/inspector_2018/bin64:/usrx/local/prod/intel/2018UP01/itac_latest/bin:/usrx/local/prod/intel/2018UP01/clck_latest/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/bin/intel64:/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/targets/intel64/x200/bin:/usrx/local/prod/intel/2018UP01/debugger_2018/gdb/intel64/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/lpp/mmfs/bin:/opt/ibutils/bin:/opt/dell/srvadmin/bin:/u/Dusan.Jovic/bin:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/dbrowse:/u/Dusan.Jovic/.local/bin:/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export PATH
-++ PKG_CONFIG_PATH=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mkl/bin/pkgconfig
-++ export PKG_CONFIG_PATH
-++ PNG_INC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/include
-++ export PNG_INC
-++ PNG_LIB=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a
-++ export PNG_LIB
-++ PNG_LIB12=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng12.a
-++ export PNG_LIB12
-++ PNG_LIBDIR=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib
-++ export PNG_LIBDIR
-++ PNG_LIBso=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.so
-++ export PNG_LIBso
-++ PNG_SRC=/usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/src/libpng-1.2.59
-++ export PNG_SRC
-++ PNG_VER=1.2.59
-++ export PNG_VER
-++ POST_INC=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.5_4
-++ export POST_INC
-++ POST_LIB=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.5_4.a
-++ export POST_LIB
-++ POST_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/post_v8.0.5
-++ export POST_SRC
-++ POST_VER=v8.0.5
-++ export POST_VER
-++ PSTLROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/pstl
-++ export PSTLROOT
-++ PYTHONPATH=/usrx/local/prod/intel/2018UP01/advisor_2018/pythonapi
-++ export PYTHONPATH
-++ SP_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_4.a
-++ export SP_LIB4
-++ SP_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_8.a
-++ export SP_LIB8
-++ SP_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a
-++ export SP_LIBd
-++ SP_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/sp_v2.0.3
-++ export SP_SRC
-++ SP_VER=v2.0.3
-++ export SP_VER
-++ TBBROOT=/usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/tbb
-++ export TBBROOT
-++ VT_ADD_LIBS='-ldwarf -lelf -lvtunwind -lm -lpthread'
-++ export VT_ADD_LIBS
-++ VT_ARCH=intel64
-++ export VT_ARCH
-++ VT_LIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/lib
-++ export VT_LIB_DIR
-++ VT_MPI=impi4
-++ export VT_MPI
-++ VT_ROOT=/usrx/local/prod/intel/2018UP01/itac_latest
-++ export VT_ROOT
-++ VT_SLIB_DIR=/usrx/local/prod/intel/2018UP01/itac_latest/slib
-++ export VT_SLIB_DIR
-++ W3EMC_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_4
-++ export W3EMC_INC4
-++ W3EMC_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_8
-++ export W3EMC_INC8
-++ W3EMC_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3emc_v2.3.1_d
-++ export W3EMC_INCd
-++ W3EMC_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_4.a
-++ export W3EMC_LIB4
-++ W3EMC_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_8.a
-++ export W3EMC_LIB8
-++ W3EMC_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a
-++ export W3EMC_LIBd
-++ W3EMC_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3emc_v2.3.1
-++ export W3EMC_SRC
-++ W3EMC_VER=v2.3.1
-++ export W3EMC_VER
-++ W3NCO_INC4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_4
-++ export W3NCO_INC4
-++ W3NCO_INC8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_8
-++ export W3NCO_INC8
-++ W3NCO_INCd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/w3nco_v2.0.7_d
-++ export W3NCO_INCd
-++ W3NCO_LIB4=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_4.a
-++ export W3NCO_LIB4
-++ W3NCO_LIB8=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_8.a
-++ export W3NCO_LIB8
-++ W3NCO_LIBd=/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a
-++ export W3NCO_LIBd
-++ W3NCO_SRC=/usrx/local/nceplibs/dev/NCEPLIBS/src/w3nco_v2.0.7
-++ export W3NCO_SRC
-++ W3NCO_VER=v2.0.7
-++ export W3NCO_VER
-++ XLSF_UIDDIR=/gpfs/lsf/10.1/linux3.10-glibc2.17-x86_64/lib/uid
-++ export XLSF_UIDDIR
-++ Z_INC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/include
-++ export Z_INC
-++ Z_LIB=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a
-++ export Z_LIB
-++ Z_SRC=/usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/src
-++ export Z_SRC
-++ Z_VER=1.2.11
-++ export Z_VER
-++ __LMOD_REF_COUNT__LMFILES_='/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:1;/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:1;/usrx/local/prod/modulefiles/core_third/lsf/10.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:1;/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:1;/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:1;/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:1;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:1;/usrx/local/dev/modulefiles/cmake/3.10.0:1;/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3:1'
-++ export __LMOD_REF_COUNT__LMFILES_
-++ _LMFILES_=/usrx/local/prod/modulefiles/core_third/ips/18.0.1.163:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1/impi/18.0.1.lua:/usrx/local/prod/modulefiles/core_third/lsf/10.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/bacio/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/ip/3.0.2:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/sp/2.0.3:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3nco/2.0.7:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/w3emc/2.3.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/nemsio/2.2.4:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2/3.1.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/g2tmpl/1.6.0:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1/crtm/2.2.6:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/jasper/1.900.29:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/libpng/1.2.59:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1/zlib/1.2.11:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles/post/8.0.5:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/hdf5_parallel/1.10.6:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/netcdf_parallel/4.7.4:/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles/esmf/8.0.0_ParallelNetCDF:/usrx/local/dev/modulefiles/cmake/3.10.0:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3
-++ export _LMFILES_
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ module list
-++ /usrx/local/prod/lmod/lmod/libexec/lmod bash list
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../include -I../mpp/include -I../fms  -c ../coupler/atmos_ocean_fluxes.F90 -o ../coupler/atmos_ocean_fluxes.o
+ar rv libfms.a ../oda_tools/xbt_drop_rate_adjust.o ../affinity/fms_affinity.o ../amip_interp/amip_interp.o ../astronomy/astronomy.o ../axis_utils/axis_utils.o ../block_control/block_control.o ../column_diagnostics/column_diagnostics.o ../constants/constants.o ../coupler/atmos_ocean_fluxes.o ../coupler/coupler_types.o ../coupler/ensemble_manager.o ../data_override/data_override.o ../diag_integral/diag_integral.o ../diag_manager/diag_axis.o ../diag_manager/diag_data.o ../diag_manager/diag_grid.o ../diag_manager/diag_manifest.o ../diag_manager/diag_manager.o ../diag_manager/diag_output.o ../diag_manager/diag_table.o ../diag_manager/diag_util.o ../drifters/cloud_interpolator.o ../drifters/drifters.o ../drifters/drifters_comm.o ../drifters/drifters_core.o ../drifters/drifters_input.o ../drifters/drifters_io.o ../drifters/quicksort.o ../exchange/stock_constants.o ../exchange/xgrid.o ../fft/fft.o ../fft/fft99.o ../field_manager/field_manager.o ../field_manager/fm_util.o ../fms/fms.o ../fms/fms_io.o ../horiz_interp/horiz_interp.o ../horiz_interp/horiz_interp_bicubic.o ../horiz_interp/horiz_interp_bilinear.o ../horiz_interp/horiz_interp_conserve.o ../horiz_interp/horiz_interp_spherical.o ../horiz_interp/horiz_interp_type.o ../interpolator/interpolator.o ../memutils/memutils.o ../monin_obukhov/monin_obukhov.o ../monin_obukhov/monin_obukhov_kernel.o ../mosaic/gradient.o ../mosaic/grid.o ../mosaic/mosaic.o ../mpp/mpp.o ../mpp/mpp_data.o ../mpp/mpp_domains.o ../mpp/mpp_efp.o ../mpp/mpp_io.o ../mpp/mpp_memutils.o ../mpp/mpp_parameter.o ../mpp/mpp_pset.o ../mpp/mpp_utilities.o ../oda_tools/oda_core.o ../oda_tools/oda_core_ecda.o ../oda_tools/oda_types.o ../oda_tools/write_ocean_data.o ../platform/platform.o ../random_numbers/MersenneTwister.o ../random_numbers/random_numbers.o ../sat_vapor_pres/sat_vapor_pres.o ../sat_vapor_pres/sat_vapor_pres_k.o ../station_data/station_data.o ../time_interp/time_interp.o ../time_interp/time_interp_external.o ../time_manager/get_cal_time.o ../time_manager/time_manager.o ../topography/gaussian_topog.o ../topography/topography.o ../tracer_manager/tracer_manager.o ../tridiagonal/tridiagonal.o ../affinity/affinity.o ../memutils/memuse.o ../mosaic/create_xgrid.o ../mosaic/gradient_c2l.o ../mosaic/interp.o ../mosaic/mosaic_util.o ../mosaic/read_mosaic.o ../mpp/nsclock.o ../mpp/threadloc.o
+ar: creating libfms.a
+a - ../oda_tools/xbt_drop_rate_adjust.o
+a - ../affinity/fms_affinity.o
+a - ../amip_interp/amip_interp.o
+a - ../astronomy/astronomy.o
+a - ../axis_utils/axis_utils.o
+a - ../block_control/block_control.o
+a - ../column_diagnostics/column_diagnostics.o
+a - ../constants/constants.o
+a - ../coupler/atmos_ocean_fluxes.o
+a - ../coupler/coupler_types.o
+a - ../coupler/ensemble_manager.o
+a - ../data_override/data_override.o
+a - ../diag_integral/diag_integral.o
+a - ../diag_manager/diag_axis.o
+a - ../diag_manager/diag_data.o
+a - ../diag_manager/diag_grid.o
+a - ../diag_manager/diag_manifest.o
+a - ../diag_manager/diag_manager.o
+a - ../diag_manager/diag_output.o
+a - ../diag_manager/diag_table.o
+a - ../diag_manager/diag_util.o
+a - ../drifters/cloud_interpolator.o
+a - ../drifters/drifters.o
+a - ../drifters/drifters_comm.o
+a - ../drifters/drifters_core.o
+a - ../drifters/drifters_input.o
+a - ../drifters/drifters_io.o
+a - ../drifters/quicksort.o
+a - ../exchange/stock_constants.o
+a - ../exchange/xgrid.o
+a - ../fft/fft.o
+a - ../fft/fft99.o
+a - ../field_manager/field_manager.o
+a - ../field_manager/fm_util.o
+a - ../fms/fms.o
+a - ../fms/fms_io.o
+a - ../horiz_interp/horiz_interp.o
+a - ../horiz_interp/horiz_interp_bicubic.o
+a - ../horiz_interp/horiz_interp_bilinear.o
+a - ../horiz_interp/horiz_interp_conserve.o
+a - ../horiz_interp/horiz_interp_spherical.o
+a - ../horiz_interp/horiz_interp_type.o
+a - ../interpolator/interpolator.o
+a - ../memutils/memutils.o
+a - ../monin_obukhov/monin_obukhov.o
+a - ../monin_obukhov/monin_obukhov_kernel.o
+a - ../mosaic/gradient.o
+a - ../mosaic/grid.o
+a - ../mosaic/mosaic.o
+a - ../mpp/mpp.o
+a - ../mpp/mpp_data.o
+a - ../mpp/mpp_domains.o
+a - ../mpp/mpp_efp.o
+a - ../mpp/mpp_io.o
+a - ../mpp/mpp_memutils.o
+a - ../mpp/mpp_parameter.o
+a - ../mpp/mpp_pset.o
+a - ../mpp/mpp_utilities.o
+a - ../oda_tools/oda_core.o
+a - ../oda_tools/oda_core_ecda.o
+a - ../oda_tools/oda_types.o
+a - ../oda_tools/write_ocean_data.o
+a - ../platform/platform.o
+a - ../random_numbers/MersenneTwister.o
+a - ../random_numbers/random_numbers.o
+a - ../sat_vapor_pres/sat_vapor_pres.o
+a - ../sat_vapor_pres/sat_vapor_pres_k.o
+a - ../station_data/station_data.o
+a - ../time_interp/time_interp.o
+a - ../time_interp/time_interp_external.o
+a - ../time_manager/get_cal_time.o
+a - ../time_manager/time_manager.o
+a - ../topography/gaussian_topog.o
+a - ../topography/topography.o
+a - ../tracer_manager/tracer_manager.o
+a - ../tridiagonal/tridiagonal.o
+a - ../affinity/affinity.o
+a - ../memutils/memuse.o
+a - ../mosaic/create_xgrid.o
+a - ../mosaic/gradient_c2l.o
+a - ../mosaic/interp.o
+a - ../mosaic/mosaic_util.o
+a - ../mosaic/read_mosaic.o
+a - ../mpp/nsclock.o
+a - ../mpp/threadloc.o
+mkdir -p "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL"
+mv fms.mk "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/."
+cp -fp *.a *.mod ../include/*.h "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL"/.
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+test -d /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; set -x ; cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf       ; \
+export COMP_SRCDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model" COMP_BINDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL" WW3_COMP="wcoss_dell_p3"                                  ; \
+exec gmake -j 1 WW3_COMP="wcoss_dell_p3" ww3_nems
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
+
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
 
 Currently Loaded Modules:
   1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
-  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.5
-  3) lsf/10.1        10) g2/3.1.1         17) hdf5_parallel/1.10.6
-  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) netcdf_parallel/4.7.4
-  5) ip/3.0.2        12) crtm/2.2.6       19) esmf/8.0.0_ParallelNetCDF
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
   6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
-  7) w3nco/2.0.7     14) libpng/1.2.59    21) fv3
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
 
  
 
-+ eval 'MODULEPATH="/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles";' export 'MODULEPATH;' '_ModuleTable001_="X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs";' export '_ModuleTable001_;' '_ModuleTable002_="WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw";' export '_ModuleTable002_;' '_ModuleTable003_="YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09";' export '_ModuleTable003_;' '_ModuleTable004_="ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy";' export '_ModuleTable004_;' '_ModuleTable005_="TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv";' export '_ModuleTable005_;' '_ModuleTable006_="YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy";' export '_ModuleTable006_;' '_ModuleTable007_="b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO";' export '_ModuleTable007_;' '_ModuleTable008_="YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt";' export '_ModuleTable008_;' '_ModuleTable009_="c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs";' export '_ModuleTable009_;' '_ModuleTable010_="aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ";' export '_ModuleTable010_;' '_ModuleTable011_="QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t";' export '_ModuleTable011_;' '_ModuleTable012_="cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv";' export '_ModuleTable012_;' '_ModuleTable013_="ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy";' export '_ModuleTable013_;' '_ModuleTable014_="eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl";' export '_ModuleTable014_;' '_ModuleTable015_="bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==";' export '_ModuleTable015_;' '_ModuleTable_Sz_="15";' export '_ModuleTable_Sz_;'
-++ MODULEPATH=/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3:/usrx/local/dev/emc_rocoto/modulefiles:/gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/soft/modulefiles:/usrx/local/dev/modulefiles:/usrx/local/prod/lmod/lmod/modulefiles/Core:/usrx/local/prod/modulefiles/core_third:/usrx/local/prod/modulefiles/defs:/gpfs/dell1/nco/ops/nwprod/modulefiles/core_prod:/usrx/local/prod/modulefiles/compiler_third/ips/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/compiler_prod/ips/18.0.1:/usrx/local/prod/modulefiles/compiler_mpi/ips/18.0.1:/usrx/local/prod/modulefiles/mpi_third/ips/18.0.1/impi/18.0.1:/gpfs/dell1/nco/ops/nwprod/modulefiles/mpi_prod/ips/18.0.1/impi/18.0.1:/usrx/local/nceplibs/dev/NCEPLIBS/modulefiles
-++ export MODULEPATH
-++ _ModuleTable001_=X01vZHVsZVRhYmxlXz17WyJNVHZlcnNpb24iXT0zLFsiY19yZWJ1aWxkVGltZSJdPWZhbHNlLFsiY19zaG9ydFRpbWUiXT1mYWxzZSxkZXB0aFQ9e30sZmFtaWx5PXtbImNvbXBpbGVyIl09ImlwcyIsWyJtcGkiXT0iaW1waSIsfSxtVD17YmFjaW89e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2JhY2lvLzIuMC4zIixbImZ1bGxOYW1lIl09ImJhY2lvLzIuMC4zIixbImxvYWRPcmRlciJdPTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iYmFjaW8vMi4wLjMiLH0sY21ha2U9e1siZm4iXT0iL3VzcngvbG9jYWwvZGV2L21vZHVsZWZpbGVzL2NtYWtlLzMuMTAuMCIs
-++ export _ModuleTable001_
-++ _ModuleTable002_=WyJmdWxsTmFtZSJdPSJjbWFrZS8zLjEwLjAiLFsibG9hZE9yZGVyIl09MjAscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iY21ha2UvMy4xMC4wIix9LGNydG09e1siZm4iXT0iL2dwZnMvZGVsbDEvbmNvL29wcy9ud3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfcHJvZC9pcHMvMTguMC4xL2NydG0vMi4yLjYiLFsiZnVsbE5hbWUiXT0iY3J0bS8yLjIuNiIsWyJsb2FkT3JkZXIiXT0xMixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJjcnRtLzIuMi42Iix9LGVzbWY9e1siZm4iXT0iL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvZW1jLm5lbXNw
-++ export _ModuleTable002_
-++ _ModuleTable003_=YXJhL3NvZnQvbW9kdWxlZmlsZXMvZXNtZi84LjAuMF9QYXJhbGxlbE5ldENERiIsWyJmdWxsTmFtZSJdPSJlc21mLzguMC4wX1BhcmFsbGVsTmV0Q0RGIixbImxvYWRPcmRlciJdPTE5LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImVzbWYvOC4wLjBfUGFyYWxsZWxOZXRDREYiLH0sZnYzPXtbImZuIl09Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL0R1c2FuLkpvdmljL3Vmcy9wcjU2L3Vmcy13ZWF0aGVyLW1vZGVsL21vZHVsZWZpbGVzL3djb3NzX2RlbGxfcDMvZnYzIixbImZ1bGxOYW1lIl09ImZ2MyIsWyJsb2FkT3JkZXIiXT0yMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0wLFsic3RhdHVzIl09
-++ export _ModuleTable003_
-++ _ModuleTable004_=ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJmdjMiLH0sZzI9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2cyLzMuMS4xIixbImZ1bGxOYW1lIl09ImcyLzMuMS4xIixbImxvYWRPcmRlciJdPTEwLHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09ImcyLzMuMS4xIix9LGcydG1wbD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvZzJ0bXBsLzEuNi4wIixbImZ1bGxOYW1lIl09ImcydG1wbC8xLjYuMCIsWyJsb2FkT3JkZXIiXT0xMSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2Vy
-++ export _ModuleTable004_
-++ _ModuleTable005_=TmFtZSJdPSJnMnRtcGwvMS42LjAiLH0saGRmNV9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9oZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJmdWxsTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsWyJsb2FkT3JkZXIiXT0xNyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJoZGY1X3BhcmFsbGVsLzEuMTAuNiIsfSxpbXBpPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfbXBpL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEubHVhIixbImZ1bGxOYW1lIl09ImltcGkvMTguMC4xIixbImxv
-++ export _ModuleTable005_
-++ _ModuleTable006_=YWRPcmRlciJdPTIscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaW1waS8xOC4wLjEiLH0saXA9e1siZm4iXT0iL3VzcngvbG9jYWwvbmNlcGxpYnMvZGV2L05DRVBMSUJTL21vZHVsZWZpbGVzL2lwLzMuMC4yIixbImZ1bGxOYW1lIl09ImlwLzMuMC4yIixbImxvYWRPcmRlciJdPTUscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0iaXAvMy4wLjIiLH0saXBzPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29yZV90aGlyZC9pcHMvMTguMC4xLjE2MyIsWyJmdWxsTmFtZSJdPSJpcHMvMTguMC4xLjE2MyIsWyJsb2FkT3JkZXIiXT0xLHBy
-++ export _ModuleTable006_
-++ _ModuleTable007_=b3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Imlwcy8xOC4wLjEuMTYzIix9LGphc3Blcj17WyJmbiJdPSIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEvamFzcGVyLzEuOTAwLjI5IixbImZ1bGxOYW1lIl09Imphc3Blci8xLjkwMC4yOSIsWyJsb2FkT3JkZXIiXT0xMyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJqYXNwZXIvMS45MDAuMjkiLH0sbGlicG5nPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29tcGlsZXJfdGhpcmQvaXBzLzE4LjAuMS9saWJwbmcvMS4yLjU5IixbImZ1bGxO
-++ export _ModuleTable007_
-++ _ModuleTable008_=YW1lIl09ImxpYnBuZy8xLjIuNTkiLFsibG9hZE9yZGVyIl09MTQscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibGlicG5nLzEuMi41OSIsfSxsc2Y9e1siZm4iXT0iL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9jb3JlX3RoaXJkL2xzZi8xMC4xIixbImZ1bGxOYW1lIl09ImxzZi8xMC4xIixbImxvYWRPcmRlciJdPTMscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibHNmLzEwLjEiLH0sbmVtc2lvPXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBsaWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9uZW1zaW8vMi4yLjQiLFsiZnVsbE5hbWUiXT0ibmVt
-++ export _ModuleTable008_
-++ _ModuleTable009_=c2lvLzIuMi40IixbImxvYWRPcmRlciJdPTkscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0ibmVtc2lvLzIuMi40Iix9LG5ldGNkZl9wYXJhbGxlbD17WyJmbiJdPSIvZ3Bmcy9kZWxsMi9lbWMvbW9kZWxpbmcvbm9zY3J1Yi9lbWMubmVtc3BhcmEvc29mdC9tb2R1bGVmaWxlcy9uZXRjZGZfcGFyYWxsZWwvNC43LjQiLFsiZnVsbE5hbWUiXT0ibmV0Y2RmX3BhcmFsbGVsLzQuNy40IixbImxvYWRPcmRlciJdPTE4LHByb3BUPXt9LFsic3RhY2tEZXB0aCJdPTEsWyJzdGF0dXMiXT0iYWN0aXZlIixbInVzZXJOYW1lIl09Im5ldGNkZl9wYXJhbGxlbC80LjcuNCIsfSxwb3N0PXtbImZuIl09Ii91c3J4L2xvY2FsL25jZXBs
-++ export _ModuleTable009_
-++ _ModuleTable010_=aWJzL2Rldi9OQ0VQTElCUy9tb2R1bGVmaWxlcy9wb3N0LzguMC41IixbImZ1bGxOYW1lIl09InBvc3QvOC4wLjUiLFsibG9hZE9yZGVyIl09MTYscHJvcFQ9e30sWyJzdGFja0RlcHRoIl09MSxbInN0YXR1cyJdPSJhY3RpdmUiLFsidXNlck5hbWUiXT0icG9zdC84LjAuNSIsfSxzcD17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvc3AvMi4wLjMiLFsiZnVsbE5hbWUiXT0ic3AvMi4wLjMiLFsibG9hZE9yZGVyIl09Nixwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJzcC8yLjAuMyIsfSx3M2VtYz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJ
-++ export _ModuleTable010_
-++ _ModuleTable011_=QlMvbW9kdWxlZmlsZXMvdzNlbWMvMi4zLjEiLFsiZnVsbE5hbWUiXT0idzNlbWMvMi4zLjEiLFsibG9hZE9yZGVyIl09OCxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M2VtYy8yLjMuMSIsfSx3M25jbz17WyJmbiJdPSIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMvdzNuY28vMi4wLjciLFsiZnVsbE5hbWUiXT0idzNuY28vMi4wLjciLFsibG9hZE9yZGVyIl09Nyxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ3M25jby8yLjAuNyIsfSx6bGliPXtbImZuIl09Ii91c3J4L2xvY2FsL3Byb2QvbW9kdWxlZmlsZXMvY29t
-++ export _ModuleTable011_
-++ _ModuleTable012_=cGlsZXJfdGhpcmQvaXBzLzE4LjAuMS96bGliLzEuMi4xMSIsWyJmdWxsTmFtZSJdPSJ6bGliLzEuMi4xMSIsWyJsb2FkT3JkZXIiXT0xNSxwcm9wVD17fSxbInN0YWNrRGVwdGgiXT0xLFsic3RhdHVzIl09ImFjdGl2ZSIsWyJ1c2VyTmFtZSJdPSJ6bGliLzEuMi4xMSIsfSx9LG1wYXRoQT17Ii9ncGZzL2RlbGwyL2VtYy9tb2RlbGluZy9ub3NjcnViL2VtYy5uZW1zcGFyYS9zb2Z0L21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIvZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvdWZzL3ByNTYvdWZzLXdlYXRoZXItbW9kZWwvbW9kdWxlZmlsZXMvd2Nvc3NfZGVsbF9wMyIsIi91c3J4L2xvY2FsL2Rldi9lbWNfcm9jb3RvL21vZHVsZWZpbGVzIiwiL2dwZnMvZGVsbDIv
-++ export _ModuleTable012_
-++ _ModuleTable013_=ZW1jL21vZGVsaW5nL25vc2NydWIvRHVzYW4uSm92aWMvc29mdC9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL2Rldi9tb2R1bGVmaWxlcyIsIi91c3J4L2xvY2FsL3Byb2QvbG1vZC9sbW9kL21vZHVsZWZpbGVzL0NvcmUiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2RlZnMiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb3JlX3Byb2QiLCIvdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX3RoaXJkL2lwcy8xOC4wLjEiLCIvZ3Bmcy9kZWxsMS9uY28vb3BzL253cHJvZC9tb2R1bGVmaWxlcy9jb21waWxlcl9wcm9kL2lwcy8xOC4wLjEiLCIvdXNy
-++ export _ModuleTable013_
-++ _ModuleTable014_=eC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvbXBpbGVyX21waS9pcHMvMTguMC4xIiwiL3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9tcGlfdGhpcmQvaXBzLzE4LjAuMS9pbXBpLzE4LjAuMSIsIi9ncGZzL2RlbGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL21waV9wcm9kL2lwcy8xOC4wLjEvaW1waS8xOC4wLjEiLCIvdXNyeC9sb2NhbC9uY2VwbGlicy9kZXYvTkNFUExJQlMvbW9kdWxlZmlsZXMiLH0sWyJzeXN0ZW1CYXNlTVBBVEgiXT0iL3VzcngvbG9jYWwvcHJvZC9sbW9kL2xtb2QvbW9kdWxlZmlsZXMvQ29yZTovdXNyeC9sb2NhbC9wcm9kL21vZHVsZWZpbGVzL2NvcmVfdGhpcmQ6L3VzcngvbG9jYWwvcHJvZC9tb2R1bGVmaWxlcy9kZWZzOi9ncGZzL2Rl
-++ export _ModuleTable014_
-++ _ModuleTable015_=bGwxL25jby9vcHMvbndwcm9kL21vZHVsZWZpbGVzL2NvcmVfcHJvZCIsfQ==
-++ export _ModuleTable015_
-++ _ModuleTable_Sz_=15
-++ export _ModuleTable_Sz_
-++ : -s sh
-+ eval
-+ cd build_fv3_3
-+ cmake /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model -D32BIT=Y
--- The C compiler identification is Intel 18.0.1.20171018
--- The CXX compiler identification is Intel 18.0.1.20171018
--- The Fortran compiler identification is Intel 18.0.1.20171018
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc
--- Check for working C compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc -- works
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Detecting C compile features
--- Detecting C compile features - done
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc
--- Check for working CXX compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc -- works
--- Detecting CXX compiler ABI info
--- Detecting CXX compiler ABI info - done
--- Detecting CXX compile features
--- Detecting CXX compile features - done
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort
--- Check for working Fortran compiler: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort  -- works
--- Detecting Fortran compiler ABI info
--- Detecting Fortran compiler ABI info - done
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90
--- Checking whether /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort supports Fortran 90 -- yes
--- Found MPI_C: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicc (found version "3.1") 
--- Found MPI_CXX: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiicpc (found version "3.1") 
--- Found MPI_Fortran: /usrx/local/prod/intel/2018UP01/compilers_and_libraries/linux/mpi/bin64/mpiifort (found version "3.1") 
--- Found MPI: TRUE (found version "3.1")  
-ESMFMKFILE:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib/esmf.mk
- Found ESMF:
-ESMF_VERSION_MAJOR:     8
-ESMF_F90COMPILEPATHS:   /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include
-ESMF_F90ESMFLINKRPATHS: -Wl,-rpath,/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/lib
-ESMF_F90ESMFLINKLIBS:   -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf
--- Found ESMF: /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/mod;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/esmf/8.0.0_ParallelNetCDF/include;/gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/netcdf_parallel/include (found version "8.0.0") 
++ cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf
++ export COMP_SRCDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model COMP_BINDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL WW3_COMP=wcoss_dell_p3
++ COMP_SRCDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
++ COMP_BINDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL
++ WW3_COMP=wcoss_dell_p3
++ exec gmake -j 1 WW3_COMP=wcoss_dell_p3 ww3_nems
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+gmake[1]: warning: -jN forced in submake: disabling jobserver mode.
+ 
+                *****************************
+              ***   WAVEWATCH III setup     ***
+                *****************************
+ 
+ 
+[INFO] local env file wwatch3.env found in /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/wwatch3.env
+   Setup file /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/wwatch3.env found
+      Printer (listings)          : 
+      auxiliary FORTRAN compiler  : gfortran
+      auxiliary C compiler        : gcc
+      Source directory            : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+      Scratch directory           : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+      Save source code            : yes
+      Save listings               : yes
+ 
+   Setup makefile for auxiliary programs
+ 
+ 
+   Compile auxiliary programs
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/aux'
+gfortran -o /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3adc w3adc.f
+gfortran -o /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3list w3list.f
+gfortran -o /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3prnt w3prnt.f
+gfortran -o /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3split w3split.f
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/aux'
+ 
+ 
+   Setup comp & link files
+      sed /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/comp.tmpl => /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/comp
+      sed /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/link.tmpl => /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/link
+ 
+   Create required model subdirectories
+ 
+Finished setting up WAVEWATCH III
+ 
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/tempswitch
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_grid
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_grid
+Making makefile ...
+ 
+                *****************************
+              ***   WAVEWATCH III makefile  ***
+                *****************************
+ 
+switch = /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/switch
+   Checking all subroutines for modules (this may take a while) ...
+ 
+Processing ww3_grid
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing constants 
+ad3 : processing w3servmd 
+ad3 : processing w3arrymd 
+ad3 : processing w3gsrumd 
+ad3 : processing w3gdatmd 
+ad3 : processing w3odatmd 
+ad3 : processing w3idatmd 
+ad3 : processing w3timemd 
+ad3 : processing w3nmlgridmd 
+ad3 : processing w3adatmd 
+ad3 : processing w3dispmd 
+ad3 : processing wmmdatmd 
+ad3 : processing w3src4md 
+ad3 : processing w3triamd 
+ad3 : processing w3parall 
+ad3 : processing w3snl1md 
+ad3 : processing w3wdatmd 
+ad3 : processing w3iogrmd 
+ad3 : processing ww3_grid 
+      Linking ww3_grid
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_outf
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_outf
+ 
+Processing ww3_outf
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3sbt1md 
+ad3 : processing w3iogomd 
+ad3 : processing w3sdb1md 
+ad3 : processing ww3_outf 
+      Linking ww3_outf
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_outp
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_outp
+ 
+Processing ww3_outp
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3bullmd 
+ad3 : processing w3iopomd 
+ad3 : processing w3partmd 
+ad3 : processing w3flx1md 
+ad3 : processing ww3_outp 
+      Linking ww3_outp
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_prep
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_prep
+ 
+Processing ww3_prep
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3fldsmd 
+ad3 : processing ww3_prep 
+      Linking ww3_prep
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_gint
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_gint
+ 
+Processing ww3_gint
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing ww3_gint 
+      Linking ww3_gint
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_prnc
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_prnc
+ 
+Processing ww3_prnc
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3nmlprncmd 
+ad3 : processing ww3_prnc 
+      Linking ww3_prnc
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_ounf
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_ounf
+ 
+Processing ww3_ounf
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3iorsmd 
+ad3 : processing w3nmlounfmd 
+ad3 : processing w3initmd 
+ad3 : processing ww3_ounf 
+      Linking ww3_ounf
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_ounp
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_ounp
+ 
+Processing ww3_ounp
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing w3nmlounpmd 
+ad3 : processing ww3_ounp 
+      Linking ww3_ounp
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/tempswitch
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_grib
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_grib
+Making makefile ...
+ 
+                *****************************
+              ***   WAVEWATCH III makefile  ***
+                *****************************
+ 
+switch = /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/switch
+   new GRIB package
+   Checking all subroutines for modules (this may take a while) ...
+ 
+Processing ww3_grib
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing ww3_grib 
+      Linking ww3_grib
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+\rm -rf /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/exec
+\mkdir -p /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/exec
+\cp -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/exe/ww3_* /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/exec
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_multi_esmf
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_multi_esmf
+Making makefile ...
+ 
+                *****************************
+              ***   WAVEWATCH III makefile  ***
+                *****************************
+ 
+switch = /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/switch
+   new shared / distributed memory
+   new message passing protocol
+   Checking all subroutines for modules (this may take a while) ...
+ 
+Processing ww3_multi_esmf
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing constants 
+ad3 : processing scrip_kindsmod [no w3adc]
+ad3 : processing w3uqckmd 
+ad3 : processing scrip_constants [no w3adc]
+ad3 : processing scrip_iounitsmod [no w3adc]
+ad3 : processing scrip_timers [no w3adc]
+ad3 : processing w3servmd 
+ad3 : processing scrip_errormod [no w3adc]
+ad3 : processing scrip_netcdfmod [no w3adc]
+ad3 : processing scrip_grids [no w3adc]
+ad3 : processing w3gsrumd 
+ad3 : processing w3arrymd 
+ad3 : processing w3cspcmd 
+ad3 : processing wmunitmd 
+ad3 : processing scrip_remap_vars [no w3adc]
+ad3 : processing scrip_remap_conservative [no w3adc]
+ad3 : processing scrip_remap_read [no w3adc]
+ad3 : processing scrip_remap_write [no w3adc]
+ad3 : processing scrip_interface 
+ad3 : processing w3gdatmd 
+ad3 : processing w3sbt1md 
+ad3 : processing w3idatmd 
+ad3 : processing w3odatmd 
+ad3 : processing wmscrpmd 
+ad3 : processing w3dispmd 
+ad3 : processing w3timemd 
+ad3 : processing wmmdatmd 
+ad3 : processing w3adatmd 
+ad3 : processing w3src4md 
+ad3 : processing w3fldsmd 
+ad3 : processing w3sdb1md 
+ad3 : processing w3flx1md 
+ad3 : processing w3partmd 
+ad3 : processing w3nmlmultimd 
+ad3 : processing wmfinlmd 
+ad3 : processing w3snl1md 
+ad3 : processing w3parall 
+ad3 : processing w3triamd 
+ad3 : processing w3wdatmd 
+ad3 : processing w3iogrmd 
+ad3 : processing wmupdtmd 
+ad3 : processing w3iogomd 
+ad3 : processing w3iosfmd 
+ad3 : processing w3iotrmd 
+ad3 : processing w3pro3md 
+ad3 : processing w3profsmd 
+ad3 : processing w3srcemd 
+ad3 : processing w3wdasmd 
+ad3 : processing w3updtmd 
+ad3 : processing w3iopomd 
+ad3 : processing w3iorsmd 
+ad3 : processing wmgridmd 
+ad3 : processing w3iobcmd 
+ad3 : processing wminiomd 
+ad3 : processing w3initmd 
+ad3 : processing w3wavemd 
+ad3 : processing wmiopomd 
+ad3 : processing wmwavemd 
+ad3 : processing wminitmd 
+ad3 : processing wmesmfmd 
+ar: creating libww3_multi_esmf.a
+a - wmmdatmd.o
+a - w3gdatmd.o
+a - w3wdatmd.o
+a - w3adatmd.o
+a - w3idatmd.o
+a - w3odatmd.o
+a - wmesmfmd.o
+a - wminitmd.o
+a - wmwavemd.o
+a - wmfinlmd.o
+a - wmgridmd.o
+a - wmupdtmd.o
+a - wminiomd.o
+a - w3fldsmd.o
+a - w3initmd.o
+a - w3wavemd.o
+a - w3wdasmd.o
+a - w3updtmd.o
+a - w3profsmd.o
+a - w3pro3md.o
+a - w3uqckmd.o
+a - w3parall.o
+a - w3triamd.o
+a - w3srcemd.o
+a - w3flx1md.o
+a - w3src4md.o
+a - w3snl1md.o
+a - w3sbt1md.o
+a - w3sdb1md.o
+a - w3iogrmd.o
+a - w3iogomd.o
+a - w3iopomd.o
+a - wmiopomd.o
+a - w3iotrmd.o
+a - w3iorsmd.o
+a - w3iobcmd.o
+a - w3iosfmd.o
+a - w3partmd.o
+a - constants.o
+a - w3servmd.o
+a - w3timemd.o
+a - w3arrymd.o
+a - w3dispmd.o
+a - w3cspcmd.o
+a - w3gsrumd.o
+a - wmunitmd.o
+a - w3nmlmultimd.o
+a - scrip_constants.o
+a - scrip_grids.o
+a - scrip_iounitsmod.o
+a - scrip_remap_vars.o
+a - scrip_timers.o
+a - scrip_errormod.o
+a - scrip_interface.o
+a - scrip_kindsmod.o
+a - scrip_remap_conservative.o
+a - wmscrpmd.o
+a - scrip_netcdfmod.o
+a - scrip_remap_write.o
+a - scrip_remap_read.o
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_make ww3_multi
+ 
+                *****************************
+              ***   WAVEWATCH III make      ***
+                *****************************
+ 
+Main directory    : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model
+Scratch directory : /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+Save source codes : yes
+Save listings     : yes
+Shared Object     : No
+ 
+[INFO] list of the programs selected : ww3_multi
+ 
+Processing ww3_multi
+---------------------
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ad3 : processing ww3_multi 
+      Linking ww3_multi
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn'
+ 
+ 
+                       **********************
+                     *** end of compilation ***
+                       **********************
+ 
+\cp -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/exe/ww3_multi /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/exec
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+mkdir -p /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL
+cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/nuopc.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/.
+test -d "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL"
+Compiling 32BIT=Y WW3=Y into /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL on wcoss
+cp -fp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems \
+       "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3"/conf/configure.fv3
+cp -fp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/modules.nems   \
+       "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3"/conf/modules.fv3
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 ; \
+  exec gmake COMP=FV3 COMP_SRCDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 COMP_BINDIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL MACHINE_ID=wcoss FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL 32BIT=Y WW3=Y nemsinstall
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
 
-Setting configuration for wcoss_dell_p3
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
 
-C       compiler: Intel 18.0.1.20171018 (mpiicc)
-CXX     compiler: Intel 18.0.1.20171018 (mpiicpc)
-Fortran compiler: Intel 18.0.1.20171018 (mpiifort)
+Currently Loaded Modules:
+  1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
+  6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
 
-DEBUG  is      disabled
-REPRO  is      disabled
-32BIT  is      ENABLED
-OPENMP is      ENABLED
-AVX2 is        disabled
-INLINE_POST is ENABLED
+ 
 
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+Building dependencies ...
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+gmake -C cpl                  FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
 
-Selected physics package: gfs
+Build standalone FV3 io ...
 
-Force 64 bits in gfsphysics
-Force 64 bits in ipd
-Force 64 bits in stochastic_physics
--- Configuring done
--- Generating done
--- Build files have been written to: /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/tests/build_fv3_3
-+ make -j 4
-Scanning dependencies of target fv3cpl
-[  1%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cap_cpl.F90.o
-[  1%] Building Fortran object FV3/cpl/CMakeFiles/fv3cpl.dir/module_cplfields.F90.o
-Scanning dependencies of target gfsphysics
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/machine.F.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/co2hc.f.o
-[  1%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_composition.f.o
-[  1%] Linking Fortran static library libfv3cpl.a
-[  2%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/efield.f.o
-[  2%] Built target fv3cpl
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wam_f107_kp_mod.f90.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mersenne_twister.f.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/GFDL_parse_tracers.F90.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iounitdef.f.o
-[  3%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/namelist_soilveg.f.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_wrf_utl.f90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/noahmp_tables.f90.o
-[  4%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_radar.F90.o
-Scanning dependencies of target fms
-[  5%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physcons.F90.o
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/platform/platform.F90.o
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+
+Build standalone FV3 io ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_cplfields.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_cap_cpl.F90
+ar rv libfv3cpl.a module_cplfields.o module_cap_cpl.o
+ar: creating libfv3cpl.a
+a - module_cplfields.o
+a - module_cap_cpl.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+gmake -C gfsphysics      FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+
+Build standalone FV3 gfsphysics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+makefile:278: depend: No such file or directory
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+
+Build standalone FV3 gfsphysics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/machine.F -o physics/machine.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/co2hc.f -o physics/co2hc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/efield.f -o physics/efield.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gocart_tracer_config_stub.f -o physics/gocart_tracer_config_stub.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/h2oc.f -o physics/h2oc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/h2ohdc.f -o physics/h2ohdc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ideaca.f -o physics/ideaca.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_composition.f -o physics/idea_composition.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/wam_f107_kp_mod.f90 -o physics/wam_f107_kp_mod.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/iounitdef.f -o physics/iounitdef.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mersenne_twister.f -o physics/mersenne_twister.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/namelist_soilveg.f -o physics/namelist_soilveg.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ozne_def.f -o physics/ozne_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/iccn_def.f -o physics/iccn_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/aerclm_def.f -o physics/aerclm_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/physparam.f -o physics/physparam.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/progtm_module.f -o physics/progtm_module.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/surface_perturbation.F90 -o physics/surface_perturbation.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/GFDL_parse_tracers.F90 -o physics/GFDL_parse_tracers.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gfs_phy_tracer_config.F -o physics/gfs_phy_tracer_config.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/rayleigh_damp.f -o physics/rayleigh_damp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/rayleigh_damp_mesopause.f -o physics/rayleigh_damp_mesopause.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/set_soilveg.f -o physics/set_soilveg.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_wrf_utl.f90 -o physics/module_wrf_utl.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/noahmp_tables.f90 -o physics/noahmp_tables.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/tridi2t3.f -o physics/tridi2t3.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ozinterp.f90 -o physics/ozinterp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/iccninterp.f90 -o physics/iccninterp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/aerinterp.f90 -o physics/aerinterp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/num_parthds.F -o physics/num_parthds.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfcsub.F -o physics/sfcsub.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_mp_radar.F90 -o physics/module_mp_radar.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/micro_mg_utils.F90 -o physics/micro_mg_utils.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cnvc90.f -o physics/cnvc90.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/date_def.f -o physics/date_def.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/physcons.F90 -o physics/physcons.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gwdc.f -o physics/gwdc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gwdps.f -o physics/gwdps.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/h2o_def.f -o physics/h2o_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/h2ophys.f -o physics/h2ophys.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_co2.f -o physics/idea_co2.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_dissipation.f -o physics/idea_dissipation.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_h2o.f -o physics/idea_h2o.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_o2_o3.f -o physics/idea_o2_o3.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_solar_heating.f -o physics/idea_solar_heating.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_tracer.f -o physics/idea_tracer.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mfpbl.f -o physics/mfpbl.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninp.f -o physics/moninp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninp1.f -o physics/moninp1.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ozphys.f -o physics/ozphys.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ozphys_2015.f -o physics/ozphys_2015.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/progt2.f -o physics/progt2.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radlw_param.f -o physics/radlw_param.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radsw_param.f -o physics/radsw_param.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radiation_astronomy.f -o physics/radiation_astronomy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radiation_surface.f -o physics/radiation_surface.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radsw_datatb.f -o physics/radsw_datatb.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/samfaerosols.f -o physics/samfaerosols.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_cice.f -o physics/sfc_cice.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_diff.f -o physics/sfc_diff.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_sf_noahmp_glacier.f90 -o physics/module_sf_noahmp_glacier.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_sf_noahmplsm.f90 -o physics/module_sf_noahmplsm.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_nst_parameters.f90 -o physics/module_nst_parameters.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sflx.f -o physics/sflx.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/shalcv.f -o physics/shalcv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/shalcv_1lyr.f -o physics/shalcv_1lyr.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/shalcv_fixdp.f -o physics/shalcv_fixdp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/shalcv_opr.f -o physics/shalcv_opr.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/get_prs_fv3.f90 -o physics/get_prs_fv3.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/h2ointerp.f90 -o physics/h2ointerp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/aer_cloud.F -o physics/aer_cloud.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gfdl_cloud_microphys.F90 -o physics/gfdl_cloud_microphys.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_mp_thompson_gfs.F90 -o physics/module_mp_thompson_gfs.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_mp_wsm6_fv3.F90 -o physics/module_mp_wsm6_fv3.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/dcyc2.f -o physics/dcyc2.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/dcyc2.pre.rad.f -o physics/dcyc2.pre.rad.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/tracer_const_h.f -o physics/tracer_const_h.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/funcphys.f90 -o physics/funcphys.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_ugwp_initialize.F90 -o physics/cires_ugwp_initialize.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_ion.f -o physics/idea_ion.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/idea_phys.f -o physics/idea_phys.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/lrgsclr.f -o physics/lrgsclr.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mfpblt.f -o physics/mfpblt.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mfpbltq.f -o physics/mfpbltq.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mfscu.f -o physics/mfscu.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mfscuq.f -o physics/mfscuq.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_bfmicrophysics.f -o physics/module_bfmicrophysics.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninedmf.f -o physics/moninedmf.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninedmf_hafs.f -o physics/moninedmf_hafs.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninq.f -o physics/moninq.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninq1.f -o physics/moninq1.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/moninshoc.f -o physics/moninshoc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mstadb.f -o physics/mstadb.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mstadbtn.f -o physics/mstadbtn.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mstadbtn2.f -o physics/mstadbtn2.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/mstcnv.f -o physics/mstcnv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/precpd.f -o physics/precpd.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/precpd_shoc.f -o physics/precpd_shoc.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/precpdp.f -o physics/precpdp.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radlw_datatb.f -o physics/radlw_datatb.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/rascnvv2.f -o physics/rascnvv2.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xCORE-AVX-I -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radiation_aerosols.f -o physics/radiation_aerosols.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radsw_main.f -o physics/radsw_main.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radiation_gases.f -o physics/radiation_gases.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radiation_clouds.f -o physics/radiation_clouds.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/samfdeepcnv.f -o physics/samfdeepcnv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/samfshalcnv.f -o physics/samfshalcnv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sascnv.f -o physics/sascnv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sascnvn.f -o physics/sascnvn.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/satmedmfvdif.f -o physics/satmedmfvdif.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/satmedmfvdifq.f -o physics/satmedmfvdifq.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_diag.f -o physics/sfc_diag.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_drv.f -o physics/sfc_drv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_noahmp_drv.f -o physics/sfc_noahmp_drv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_nst_water_prop.f90 -o physics/module_nst_water_prop.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_ocean.f -o physics/sfc_ocean.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_sice.f -o physics/sfc_sice.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/shalcnv.f -o physics/shalcnv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/calpreciptype.f90 -o physics/calpreciptype.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gcm_shoc.f90 -o physics/gcm_shoc.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/wv_saturation.F -o physics/wv_saturation.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_ugwp_utils.F90 -o physics/cires_ugwp_utils.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_ugwp_triggers.F90 -o physics/cires_ugwp_triggers.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cs_conv.F90 -o physics/cs_conv.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/get_prs.f -o physics/get_prs.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gscond.f -o physics/gscond.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gscondp.f -o physics/gscondp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_ugwp_module.F90 -o physics/cires_ugwp_module.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_orowam2017.f -o physics/cires_orowam2017.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/radlw_main.f -o physics/radlw_main.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_typedefs.F90 -o GFS_layer/GFS_typedefs.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/module_nst_model.f90 -o physics/module_nst_model.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cldmacro.F -o physics/cldmacro.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cldwat2m_micro.F -o physics/cldwat2m_micro.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_ugwp_solvers.F90 -o physics/cires_ugwp_solvers.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_vert_lsatdis.F90 -o physics/cires_vert_lsatdis.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_vert_orodis.F90 -o physics/cires_vert_orodis.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/cires_vert_wmsdis.F90 -o physics/cires_vert_wmsdis.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/micro_mg2_0.F90 -o physics/micro_mg2_0.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/micro_mg3_0.F90 -o physics/micro_mg3_0.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/ugwp_driver_v0.f -o physics/ugwp_driver_v0.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/sfc_nst.f -o physics/sfc_nst.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/m_micro_driver.F90 -o physics/m_micro_driver.o
+mpiicc -E -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML  GFS_layer/GFS_radiation_driver.F90 > GFS_layer/GFS_radiation_driver.tmp.f90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/gcycle.F90 -o physics/gcycle.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/GFS_debug.F90 -o physics/GFS_debug.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -O0 -c GFS_layer/GFS_diagnostics.F90 -o GFS_layer/GFS_diagnostics.o
+mpiicc -E -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML  GFS_layer/GFS_physics_driver.F90 > GFS_layer/GFS_physics_driver.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_physics_driver.tmp.f90 -o GFS_layer/GFS_physics_driver.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_radiation_driver.tmp.f90 -o GFS_layer/GFS_radiation_driver.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_restart.F90 -o GFS_layer/GFS_restart.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c physics/rad_initialize.f -o physics/rad_initialize.o
+mpiicc -E -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML  GFS_layer/GFS_driver.F90 > GFS_layer/GFS_driver.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_driver.tmp.f90 -o GFS_layer/GFS_driver.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../cpl  -c GFS_layer/GFS_abstraction_layer.F90 -o GFS_layer/GFS_abstraction_layer.o
+ar rv libgfsphys.a physics/cnvc90.o physics/co2hc.o physics/date_def.o physics/dcyc2.o physics/dcyc2.pre.rad.o physics/efield.o physics/get_prs.o physics/gocart_tracer_config_stub.o physics/gscond.o physics/gscondp.o physics/gwdc.o physics/gwdps.o physics/ugwp_driver_v0.o physics/cires_orowam2017.o physics/h2o_def.o physics/h2oc.o physics/h2ohdc.o physics/h2ophys.o physics/ideaca.o physics/idea_co2.o physics/idea_composition.o physics/idea_dissipation.o physics/idea_h2o.o physics/idea_ion.o physics/idea_o2_o3.o physics/idea_phys.o physics/idea_solar_heating.o physics/idea_tracer.o physics/iounitdef.o physics/lrgsclr.o physics/mersenne_twister.o physics/mfpbl.o physics/mfpblt.o physics/mfpbltq.o physics/mfscu.o physics/mfscuq.o physics/module_bfmicrophysics.o physics/moninedmf.o physics/moninedmf_hafs.o physics/moninp.o physics/moninp1.o physics/moninq.o physics/moninq1.o physics/moninshoc.o physics/mstadb.o physics/mstadbtn.o physics/mstadbtn2.o physics/mstcnv.o physics/namelist_soilveg.o physics/ozne_def.o physics/iccn_def.o physics/aerclm_def.o physics/ozphys.o physics/ozphys_2015.o physics/physparam.o physics/precpd.o physics/precpd_shoc.o physics/precpdp.o physics/progt2.o physics/progtm_module.o physics/rad_initialize.o physics/radiation_aerosols.o physics/radiation_astronomy.o physics/radiation_clouds.o physics/radiation_gases.o physics/radiation_surface.o physics/radlw_datatb.o physics/radlw_main.o physics/radlw_param.o physics/radsw_datatb.o physics/radsw_main.o physics/radsw_param.o physics/rascnvv2.o physics/rayleigh_damp.o physics/rayleigh_damp_mesopause.o physics/samfaerosols.o physics/samfdeepcnv.o physics/samfshalcnv.o physics/sascnv.o physics/sascnvn.o physics/satmedmfvdif.o physics/satmedmfvdifq.o physics/set_soilveg.o physics/sfc_cice.o physics/sfc_diag.o physics/sfc_diff.o physics/sfc_drv.o physics/sfc_noahmp_drv.o physics/sfc_nst.o physics/sfc_ocean.o physics/sfc_sice.o physics/sflx.o physics/shalcnv.o physics/shalcv.o physics/shalcv_1lyr.o physics/shalcv_fixdp.o physics/shalcv_opr.o physics/tracer_const_h.o physics/tridi2t3.o physics/calpreciptype.o physics/funcphys.o physics/gcm_shoc.o physics/get_prs_fv3.o physics/h2ointerp.o physics/module_nst_model.o physics/module_nst_parameters.o physics/module_nst_water_prop.o physics/ozinterp.o physics/module_wrf_utl.o physics/noahmp_tables.o physics/module_sf_noahmplsm.o physics/module_sf_noahmp_glacier.o physics/iccninterp.o physics/aerinterp.o physics/wam_f107_kp_mod.o physics/aer_cloud.o physics/cldmacro.o physics/cldwat2m_micro.o physics/gfs_phy_tracer_config.o physics/machine.o physics/num_parthds.o physics/sfcsub.o physics/wv_saturation.o physics/GFDL_parse_tracers.o physics/gcycle.o physics/cires_ugwp_initialize.o physics/cires_ugwp_module.o physics/cires_ugwp_utils.o physics/cires_ugwp_triggers.o physics/cires_ugwp_solvers.o physics/cires_vert_lsatdis.o physics/cires_vert_orodis.o physics/cires_vert_wmsdis.o physics/gfdl_cloud_microphys.o physics/micro_mg_utils.o physics/micro_mg2_0.o physics/micro_mg3_0.o physics/m_micro_driver.o physics/cs_conv.o physics/GFS_debug.o physics/module_mp_radar.o physics/module_mp_thompson_gfs.o physics/module_mp_wsm6_fv3.o physics/physcons.o physics/surface_perturbation.o GFS_layer/GFS_abstraction_layer.o GFS_layer/GFS_diagnostics.o GFS_layer/GFS_driver.o GFS_layer/GFS_physics_driver.o GFS_layer/GFS_radiation_driver.o GFS_layer/GFS_restart.o GFS_layer/GFS_typedefs.o
+ar: creating libgfsphys.a
+a - physics/cnvc90.o
+a - physics/co2hc.o
+a - physics/date_def.o
+a - physics/dcyc2.o
+a - physics/dcyc2.pre.rad.o
+a - physics/efield.o
+a - physics/get_prs.o
+a - physics/gocart_tracer_config_stub.o
+a - physics/gscond.o
+a - physics/gscondp.o
+a - physics/gwdc.o
+a - physics/gwdps.o
+a - physics/ugwp_driver_v0.o
+a - physics/cires_orowam2017.o
+a - physics/h2o_def.o
+a - physics/h2oc.o
+a - physics/h2ohdc.o
+a - physics/h2ophys.o
+a - physics/ideaca.o
+a - physics/idea_co2.o
+a - physics/idea_composition.o
+a - physics/idea_dissipation.o
+a - physics/idea_h2o.o
+a - physics/idea_ion.o
+a - physics/idea_o2_o3.o
+a - physics/idea_phys.o
+a - physics/idea_solar_heating.o
+a - physics/idea_tracer.o
+a - physics/iounitdef.o
+a - physics/lrgsclr.o
+a - physics/mersenne_twister.o
+a - physics/mfpbl.o
+a - physics/mfpblt.o
+a - physics/mfpbltq.o
+a - physics/mfscu.o
+a - physics/mfscuq.o
+a - physics/module_bfmicrophysics.o
+a - physics/moninedmf.o
+a - physics/moninedmf_hafs.o
+a - physics/moninp.o
+a - physics/moninp1.o
+a - physics/moninq.o
+a - physics/moninq1.o
+a - physics/moninshoc.o
+a - physics/mstadb.o
+a - physics/mstadbtn.o
+a - physics/mstadbtn2.o
+a - physics/mstcnv.o
+a - physics/namelist_soilveg.o
+a - physics/ozne_def.o
+a - physics/iccn_def.o
+a - physics/aerclm_def.o
+a - physics/ozphys.o
+a - physics/ozphys_2015.o
+a - physics/physparam.o
+a - physics/precpd.o
+a - physics/precpd_shoc.o
+a - physics/precpdp.o
+a - physics/progt2.o
+a - physics/progtm_module.o
+a - physics/rad_initialize.o
+a - physics/radiation_aerosols.o
+a - physics/radiation_astronomy.o
+a - physics/radiation_clouds.o
+a - physics/radiation_gases.o
+a - physics/radiation_surface.o
+a - physics/radlw_datatb.o
+a - physics/radlw_main.o
+a - physics/radlw_param.o
+a - physics/radsw_datatb.o
+a - physics/radsw_main.o
+a - physics/radsw_param.o
+a - physics/rascnvv2.o
+a - physics/rayleigh_damp.o
+a - physics/rayleigh_damp_mesopause.o
+a - physics/samfaerosols.o
+a - physics/samfdeepcnv.o
+a - physics/samfshalcnv.o
+a - physics/sascnv.o
+a - physics/sascnvn.o
+a - physics/satmedmfvdif.o
+a - physics/satmedmfvdifq.o
+a - physics/set_soilveg.o
+a - physics/sfc_cice.o
+a - physics/sfc_diag.o
+a - physics/sfc_diff.o
+a - physics/sfc_drv.o
+a - physics/sfc_noahmp_drv.o
+a - physics/sfc_nst.o
+a - physics/sfc_ocean.o
+a - physics/sfc_sice.o
+a - physics/sflx.o
+a - physics/shalcnv.o
+a - physics/shalcv.o
+a - physics/shalcv_1lyr.o
+a - physics/shalcv_fixdp.o
+a - physics/shalcv_opr.o
+a - physics/tracer_const_h.o
+a - physics/tridi2t3.o
+a - physics/calpreciptype.o
+a - physics/funcphys.o
+a - physics/gcm_shoc.o
+a - physics/get_prs_fv3.o
+a - physics/h2ointerp.o
+a - physics/module_nst_model.o
+a - physics/module_nst_parameters.o
+a - physics/module_nst_water_prop.o
+a - physics/ozinterp.o
+a - physics/module_wrf_utl.o
+a - physics/noahmp_tables.o
+a - physics/module_sf_noahmplsm.o
+a - physics/module_sf_noahmp_glacier.o
+a - physics/iccninterp.o
+a - physics/aerinterp.o
+a - physics/wam_f107_kp_mod.o
+a - physics/aer_cloud.o
+a - physics/cldmacro.o
+a - physics/cldwat2m_micro.o
+a - physics/gfs_phy_tracer_config.o
+a - physics/machine.o
+a - physics/num_parthds.o
+a - physics/sfcsub.o
+a - physics/wv_saturation.o
+a - physics/GFDL_parse_tracers.o
+a - physics/gcycle.o
+a - physics/cires_ugwp_initialize.o
+a - physics/cires_ugwp_module.o
+a - physics/cires_ugwp_utils.o
+a - physics/cires_ugwp_triggers.o
+a - physics/cires_ugwp_solvers.o
+a - physics/cires_vert_lsatdis.o
+a - physics/cires_vert_orodis.o
+a - physics/cires_vert_wmsdis.o
+a - physics/gfdl_cloud_microphys.o
+a - physics/micro_mg_utils.o
+a - physics/micro_mg2_0.o
+a - physics/micro_mg3_0.o
+a - physics/m_micro_driver.o
+a - physics/cs_conv.o
+a - physics/GFS_debug.o
+a - physics/module_mp_radar.o
+a - physics/module_mp_thompson_gfs.o
+a - physics/module_mp_wsm6_fv3.o
+a - physics/physcons.o
+a - physics/surface_perturbation.o
+a - GFS_layer/GFS_abstraction_layer.o
+a - GFS_layer/GFS_diagnostics.o
+a - GFS_layer/GFS_driver.o
+a - GFS_layer/GFS_physics_driver.o
+a - GFS_layer/GFS_radiation_driver.o
+a - GFS_layer/GFS_restart.o
+a - GFS_layer/GFS_typedefs.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+gmake -C ipd                  FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+
+Build standalone FV3 gfsphysics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+makefile:54: depend: No such file or directory
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+
+Build standalone FV3 gfsphysics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../namphysics  -c IPD_typedefs.F90 -o IPD_typedefs.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -DNEW_TAUCTMAX -DSMALL_PE -DNEMS_GSM -DINTERNAL_FILE_NML -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../namphysics  -c IPD_driver.F90 -o IPD_driver.o
+ar rv libipd.a IPD_driver.o IPD_typedefs.o
+ar: creating libipd.a
+a - IPD_driver.o
+a - IPD_typedefs.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+gmake -C io                   FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
+
+Build standalone FV3 io ...
+
+$ESMF_INC is [-I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include]
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+
+Build standalone FV3 io ...
+
+$ESMF_INC is [-I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include]
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics  -c ffsync.F90 -o ffsync.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c FV3GFS_io.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics  -c module_fv3_io_def.F90 -o module_fv3_io_def.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_write_internal_state.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.10_4 -c post_nems_routines.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -I/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/nemsio_v2.2.4 -c module_write_nemsio.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_write_netcdf.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_write_netcdf_parallel.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -I/usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/include/ncep_post_v8.0.10_4 -c post_gfs.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../namphysics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_wrt_grid_comp.F90
+ar rv libfv3io.a ffsync.o FV3GFS_io.o post_gfs.o post_nems_routines.o module_write_nemsio.o module_write_netcdf.o module_write_netcdf_parallel.o module_fv3_io_def.o module_write_internal_state.o module_wrt_grid_comp.o
+ar: creating libfv3io.a
+a - ffsync.o
+a - FV3GFS_io.o
+a - post_gfs.o
+a - post_nems_routines.o
+a - module_write_nemsio.o
+a - module_write_netcdf.o
+a - module_write_netcdf_parallel.o
+a - module_fv3_io_def.o
+a - module_write_internal_state.o
+a - module_wrt_grid_comp.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+gmake -C atmos_cubed_sphere   FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
+
+Build standalone FV3 fv3core ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+
+Build standalone FV3 fv3core ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_arrays.F90 -o model/fv_arrays.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/external_sst.F90 -o tools/external_sst.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_fill.F90 -o model/fv_fill.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/sim_nc_mod.F90 -o tools/sim_nc_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c driver/fvGFS/DYCORE_typedefs.F90 -o driver/fvGFS/DYCORE_typedefs.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_parameter.F90.o
-[  6%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_core.F90.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_mp_mod.F90 -o tools/fv_mp_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/sorted_index.F90 -o tools/sorted_index.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_timing.F90 -o tools/fv_timing.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_eta.F90 -o tools/fv_eta.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/multi_gases.F90 -o model/multi_gases.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/boundary.F90 -o model/boundary.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_sg.F90 -o model/fv_sg.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_cmp.F90 -o model/fv_cmp.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_grid_utils.F90 -o model/fv_grid_utils.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/a2b_edge.F90 -o model/a2b_edge.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -fast-transcendentals -c model/fv_mapz.F90 -o model/fv_mapz.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_surf_map.F90 -o tools/fv_surf_map.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/init_hydro.F90 -o tools/init_hydro.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_grid_tools.F90 -o tools/fv_grid_tools.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/tp_core.F90 -o model/tp_core.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_treat_da_inc.F90 -o tools/fv_treat_da_inc.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_iau_mod.F90 -o tools/fv_iau_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_diagnostics.F90 -o tools/fv_diagnostics.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_io.F90 -o tools/fv_io.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/test_cases.F90 -o tools/test_cases.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_nudge.F90 -o tools/fv_nudge.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_regional_bc.F90 -o model/fv_regional_bc.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c driver/fvGFS/fv_nggps_diag.F90 -o driver/fvGFS/fv_nggps_diag.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_tracer2d.F90 -o model/fv_tracer2d.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_update_phys.F90 -o model/fv_update_phys.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/sw_core.F90 -o model/sw_core.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/external_ic.F90 -o tools/external_ic.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c tools/fv_restart.F90 -o tools/fv_restart.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -fast-transcendentals -c model/nh_utils.F90 -o model/nh_utils.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_control.F90 -o model/fv_control.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_nesting.F90 -o model/fv_nesting.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/nh_core.F90 -o model/nh_core.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/dyn_core.F90 -o model/dyn_core.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -c model/fv_dynamics.F90 -o model/fv_dynamics.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../gfsphysics -I../ipd -I../io -I../namphysics  -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c driver/fvGFS/atmosphere.F90 -o driver/fvGFS/atmosphere.o
 Using 8-byte addressing
 Using pure routines.
 Using allocatable derived type array members.
 Using cray pointers.
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/date_def.f.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_input.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/cloud_interpolator.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progtm_module.f.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_io.F90.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerclm_def.f.o
-[  7%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/MersenneTwister.F90.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2o_def.f.o
-[  7%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/physparam.f.o
-[  8%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozne_def.f.o
-[  9%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfs_phy_tracer_config.F.o
-[  9%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/surface_perturbation.F90.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres_k.F90.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_data.F90.o
-[ 10%] Building Fortran object CMakeFiles/fms.dir/FMS/constants/constants.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmp_glacier.f90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_sf_noahmplsm.f90.o
-[ 11%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccn_def.f.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg_utils.F90.o
-[ 11%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gfdl_cloud_microphys.F90.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tracer_const_h.f.o
-[ 12%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/funcphys.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_initialize.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_param.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_astronomy.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_surface.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_parameters.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aer_cloud.F.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_thompson_gfs.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_mp_wsm6_fv3.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs_fv3.f90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_cice.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diff.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_module.F90.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rascnvv2.f.o
-[ 13%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_aerosols.f.o
-ifort: command line warning #10121: overriding '-xHOST' with '-xCORE-AVX-I'
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_bfmicrophysics.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_gases.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_datatb.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_datatb.f.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_water_prop.f90.o
-[ 14%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/wv_saturation.F.o
-[ 14%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_efp.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 14%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_memutils.F90.o
-[ 15%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cs_conv.F90.o
-[ 16%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_pset.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 17%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_type.F90.o
-[ 18%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_diag.f.o
-[ 19%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/gradient.F90.o
-[ 19%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_drv.f.o
-[ 20%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_domains.F90.o
-[ 20%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_ocean.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_sice.f.o
-[ 21%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_typedefs.F90.o
-[ 22%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radiation_clouds.f.o
-[ 23%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radlw_main.f.o
-[ 24%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/radsw_main.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/module_nst_model.f90.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldmacro.F.o
-[ 25%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cldwat2m_micro.F.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg2_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/micro_mg3_0.F90.o
-[ 26%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_radiation_driver.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_diagnostics.F90.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_nst.f.o
-[ 27%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_physics_driver.F90.o
-[ 28%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_restart.F90.o
-[ 28%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters_comm.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_io.F90.o
-Compiling in MPI mode (with or without MPP) 
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/memutils/memutils.F90.o
-[ 29%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms_io.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 29%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_driver.F90.o
-[ 29%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/GFS_layer/GFS_abstraction_layer.F90.o
-[ 29%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_solar_heating.f.o
-[ 30%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2oc.f.o
-[ 30%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_tracer.f.o
-[ 30%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ideaca.f.o
-[ 31%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfcsub.F.o
-[ 32%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ugwp_driver_v0.f.o
-[ 32%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cnvc90.f.o
-[ 32%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.f.o
-[ 32%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/dcyc2.pre.rad.f.o
-[ 32%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/get_prs.f.o
-[ 33%] Building Fortran object CMakeFiles/fms.dir/FMS/fms/fms.F90.o
-[ 33%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gocart_tracer_config_stub.f.o
-[ 33%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/time_manager.F90.o
-[ 33%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bicubic.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 34%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscond.f.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_bilinear.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_conserve.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp_spherical.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gscondp.f.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/axis_utils/axis_utils.F90.o
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdc.f.o
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gwdps.f.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_grid.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/field_manager.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/mosaic.F90.o
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_orowam2017.f.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/gaussian_topog.F90.o
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ohdc.f.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/time_manager/get_cal_time.F90.o
-[ 35%] Building Fortran object CMakeFiles/fms.dir/FMS/horiz_interp/horiz_interp.F90.o
-[ 35%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ophys.f.o
-[ 36%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp.F90.o
-[ 37%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_co2.f.o
-[ 37%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_data.F90.o
-[ 37%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_dissipation.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 38%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_h2o.f.o
-[ 39%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_types.F90.o
-[ 39%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_ion.f.o
-[ 39%] Building Fortran object CMakeFiles/fms.dir/FMS/time_interp/time_interp_external.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 40%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_axis.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 41%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manifest.F90.o
-[ 41%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_o2_o3.f.o
-[ 42%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/idea_phys.f.o
-[ 42%] Building Fortran object CMakeFiles/fms.dir/FMS/field_manager/fm_util.F90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/lrgsclr.f.o
-[ 43%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/xbt_drop_rate_adjust.f90.o
-[ 43%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbl.f.o
-[ 43%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/write_ocean_data.F90.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpblt.f.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfpbltq.f.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscu.f.o
-[ 44%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_output.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mfscuq.f.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf.f.o
-[ 44%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninedmf_hafs.f.o
-[ 45%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_util.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp.f.o
-[ 46%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_table.F90.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninp1.f.o
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq.f.o
-[ 46%] Building Fortran object CMakeFiles/fms.dir/FMS/diag_manager/diag_manager.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 46%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninq1.f.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/moninshoc.f.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadb.f.o
-[ 47%] Building Fortran object CMakeFiles/fms.dir/FMS/data_override/data_override.F90.o
-[ 47%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn.f.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstadbtn2.f.o
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/mstcnv.f.o
-[ 48%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozphys_2015.f.o
-[ 49%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpd_shoc.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/precpdp.f.o
-[ 50%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/progt2.f.o
-[ 51%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rad_initialize.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/rayleigh_damp_mesopause.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfaerosols.f.o
-[ 52%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfdeepcnv.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/samfshalcnv.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnv.f.o
-[ 53%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sascnvn.f.o
-[ 54%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdif.f.o
-[ 55%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/coupler_types.F90.o
-[ 55%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/stock_constants.F90.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/satmedmfvdifq.f.o
-[ 55%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/set_soilveg.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sfc_noahmp_drv.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/sflx.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcnv.f.o
-[ 56%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_1lyr.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_fixdp.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/shalcv_opr.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/tridi2t3.f.o
-[ 57%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/calpreciptype.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcm_shoc.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/h2ointerp.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/ozinterp.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/iccninterp.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/aerinterp.f90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/num_parthds.F.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/gcycle.F90.o
-[ 58%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_utils.F90.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_triggers.F90.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_ugwp_solvers.F90.o
-[ 59%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_lsatdis.F90.o
-[ 60%] Building Fortran object CMakeFiles/fms.dir/FMS/amip_interp/amip_interp.F90.o
-[ 60%] Building Fortran object CMakeFiles/fms.dir/FMS/astronomy/astronomy.F90.o
-[ 60%] Building Fortran object CMakeFiles/fms.dir/FMS/block_control/block_control.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 60%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_orodis.F90.o
-[ 61%] Building Fortran object CMakeFiles/fms.dir/FMS/column_diagnostics/column_diagnostics.F90.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/cires_vert_wmsdis.F90.o
-[ 62%] Building Fortran object FV3/gfsphysics/CMakeFiles/gfsphysics.dir/physics/m_micro_driver.F90.o
-[ 62%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/atmos_ocean_fluxes.F90.o
-[ 62%] Building Fortran object CMakeFiles/fms.dir/FMS/coupler/ensemble_manager.F90.o
-[ 63%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/drifters.F90.o
-[ 63%] Building Fortran object CMakeFiles/fms.dir/FMS/exchange/xgrid.F90.o
-Compiling in MPI mode (with or without MPP) 
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/fft/fft99.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/interpolator/interpolator.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/mosaic/grid.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 64%] Linking Fortran static library libgfsphysics.a
-[ 64%] Built target gfsphysics
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/mpp/mpp_utilities.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core.F90.o
-Scanning dependencies of target ipd
-[ 64%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_typedefs.F90.o
-[ 64%] Building Fortran object FV3/ipd/CMakeFiles/ipd.dir/IPD_driver.F90.o
-[ 64%] Linking Fortran static library libipd.a
-[ 64%] Built target ipd
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/oda_tools/oda_core_ecda.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/random_numbers/random_numbers.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/sat_vapor_pres/sat_vapor_pres.F90.o
-[ 64%] Building Fortran object CMakeFiles/fms.dir/FMS/station_data/station_data.F90.o
-[ 65%] Building Fortran object CMakeFiles/fms.dir/FMS/topography/topography.F90.o
-[ 65%] Building Fortran object CMakeFiles/fms.dir/FMS/tracer_manager/tracer_manager.F90.o
-[ 65%] Building Fortran object CMakeFiles/fms.dir/FMS/tridiagonal/tridiagonal.F90.o
-[ 66%] Building Fortran object CMakeFiles/fms.dir/FMS/drifters/quicksort.F90.o
-[ 67%] Building C object CMakeFiles/fms.dir/FMS/memutils/memuse.c.o
-[ 67%] Building C object CMakeFiles/fms.dir/FMS/mosaic/create_xgrid.c.o
-[ 67%] Building C object CMakeFiles/fms.dir/FMS/mosaic/gradient_c2l.c.o
-[ 68%] Building C object CMakeFiles/fms.dir/FMS/mosaic/interp.c.o
-[ 68%] Building C object CMakeFiles/fms.dir/FMS/mosaic/mosaic_util.c.o
-[ 68%] Building C object CMakeFiles/fms.dir/FMS/mosaic/read_mosaic.c.o
-[ 68%] Building C object CMakeFiles/fms.dir/FMS/affinity/affinity.c.o
-[ 69%] Building C object CMakeFiles/fms.dir/FMS/mpp/nsclock.c.o
-[ 69%] Building C object CMakeFiles/fms.dir/FMS/mpp/threadloc.c.o
-[ 69%] Linking Fortran static library FMS/libfms.a
-[ 69%] Built target fms
-Scanning dependencies of target io
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_internal_state.F90.o
-[ 69%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_fv3_io_def.F90.o
-Scanning dependencies of target fv3core
-[ 69%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_arrays.F90.o
-[ 69%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_sst.F90.o
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_fill.F90.o
-[ 70%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_nemsio.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 70%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sim_nc_mod.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_write_netcdf_parallel.F90.o
-[ 71%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/DYCORE_typedefs.F90.o
-[ 71%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_gfs.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/sorted_index.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_mp_mod.F90.o
-[ 72%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_eta.F90.o
-[ 73%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_cmp.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_timing.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_sg.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_grid_utils.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/boundary.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/a2b_edge.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_surf_map.F90.o
-[ 74%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_mapz.F90.o
-[ 74%] Building Fortran object FV3/io/CMakeFiles/io.dir/FV3GFS_io.F90.o
-[ 75%] Building Fortran object FV3/io/CMakeFiles/io.dir/module_wrt_grid_comp.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/ffsync.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/tp_core.F90.o
-[ 76%] Building Fortran object FV3/io/CMakeFiles/io.dir/post_nems_routines.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_grid_tools.F90.o
-[ 76%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/init_hydro.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_treat_da_inc.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/sw_core.F90.o
-[ 77%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_iau_mod.F90.o
-[ 78%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_diagnostics.F90.o
-[ 79%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_io.F90.o
-[ 80%] Linking Fortran static library libio.a
-[ 80%] Built target io
-[ 80%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_utils.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/nh_core.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_nudge.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/fv_nggps_diag.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_regional_bc.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/test_cases.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_tracer2d.F90.o
-[ 81%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/dyn_core.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_update_phys.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/external_ic.F90.o
-[ 82%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/tools/fv_restart.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_control.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_nesting.F90.o
-[ 83%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/fv_dynamics.F90.o
-[ 85%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90.o
-[ 85%] Building Fortran object FV3/CMakeFiles/fv3core.dir/atmos_cubed_sphere/model/multi_gases.F90.o
-Using 8-byte addressing
-Using pure routines.
-Using allocatable derived type array members.
-Using cray pointers.
-[ 85%] Linking Fortran static library libfv3core.a
-[ 85%] Built target fv3core
-Scanning dependencies of target stochastic_physics
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/spectral_layout.F90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/update_ca.f90.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_gg_def.f.o
-[ 87%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_resol_def.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/glats_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_layout_lag.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_namelist_def.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/compns_stochy.F90.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/epslon_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_lag_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_lats_node_a_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_ls_node_stochy.f.o
-[ 88%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/gozrineo_stochy.f.o
-[ 89%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/pln2eo_stochy.f.o
-[ 90%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/setlats_a_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_internal_state_mod.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dezouv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/dozeuv_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/four_to_grid_stochy.F.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_patterngenerator.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/sumfln_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_lag_stochy.f.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/getcon_spectral.F90.o
-[ 91%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/initialize_spectral_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochy_data_mod.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/get_stochy_pattern.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/stochastic_physics.F90.o
-[ 92%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/plumes.f90.o
-[ 93%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/num_parthds_stochy.f.o
-[ 94%] Building Fortran object FV3/stochastic_physics/CMakeFiles/stochastic_physics.dir/__/__/stochastic_physics/cellular_automata.f90.o
-[ 95%] Linking Fortran static library libstochastic_physics.a
-[ 95%] Built target stochastic_physics
-Scanning dependencies of target fv3cap
-[ 95%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fv3_config.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/atmos_model.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/module_fcst_grid_comp.F90.o
-[ 96%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/fv3_cap.F90.o
-[ 97%] Building Fortran object FV3/CMakeFiles/fv3cap.dir/time_utils.F90.o
-[ 97%] Linking Fortran static library libfv3cap.a
-[ 97%] Built target fv3cap
-Scanning dependencies of target NEMS.exe
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/ENS_Cpl/ENS_CplComp_ESMFMod_STUB.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_methods.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR_SpaceWeather.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_UTILS.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_INTERNAL_STATE.F90.o
-[ 97%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_Rusage.F90.o
-[ 98%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_MEDIATOR.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_EARTH_GRID_COMP.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/module_NEMS_GRID_COMP.F90.o
-[ 99%] Building Fortran object CMakeFiles/NEMS.exe.dir/NEMS/src/MAIN_NEMS.F90.o
-[100%] Building C object CMakeFiles/NEMS.exe.dir/NEMS/src/nems_c_rusage.c.o
-[100%] Linking Fortran executable NEMS.exe
+ar rv libfv3core.a model/a2b_edge.o model/multi_gases.o model/boundary.o model/dyn_core.o model/fv_arrays.o model/fv_cmp.o model/fv_control.o model/fv_dynamics.o model/fv_fill.o model/fv_grid_utils.o model/fv_mapz.o model/fv_nesting.o model/fv_regional_bc.o model/fv_sg.o model/fv_tracer2d.o model/fv_update_phys.o model/sw_core.o model/tp_core.o model/nh_core.o model/nh_utils.o tools/external_ic.o tools/external_sst.o tools/fv_diagnostics.o tools/fv_eta.o tools/fv_grid_tools.o tools/fv_io.o tools/fv_mp_mod.o tools/fv_nudge.o tools/fv_treat_da_inc.o tools/fv_iau_mod.o tools/fv_restart.o tools/fv_surf_map.o tools/fv_timing.o tools/init_hydro.o tools/sim_nc_mod.o tools/sorted_index.o tools/test_cases.o driver/fvGFS/DYCORE_typedefs.o driver/fvGFS/fv_nggps_diag.o driver/fvGFS/atmosphere.o
+ar: creating libfv3core.a
+a - model/a2b_edge.o
+a - model/multi_gases.o
+a - model/boundary.o
+a - model/dyn_core.o
+a - model/fv_arrays.o
+a - model/fv_cmp.o
+a - model/fv_control.o
+a - model/fv_dynamics.o
+a - model/fv_fill.o
+a - model/fv_grid_utils.o
+a - model/fv_mapz.o
+a - model/fv_nesting.o
+a - model/fv_regional_bc.o
+a - model/fv_sg.o
+a - model/fv_tracer2d.o
+a - model/fv_update_phys.o
+a - model/sw_core.o
+a - model/tp_core.o
+a - model/nh_core.o
+a - model/nh_utils.o
+a - tools/external_ic.o
+a - tools/external_sst.o
+a - tools/fv_diagnostics.o
+a - tools/fv_eta.o
+a - tools/fv_grid_tools.o
+a - tools/fv_io.o
+a - tools/fv_mp_mod.o
+a - tools/fv_nudge.o
+a - tools/fv_treat_da_inc.o
+a - tools/fv_iau_mod.o
+a - tools/fv_restart.o
+a - tools/fv_surf_map.o
+a - tools/fv_timing.o
+a - tools/init_hydro.o
+a - tools/sim_nc_mod.o
+a - tools/sorted_index.o
+a - tools/test_cases.o
+a - driver/fvGFS/DYCORE_typedefs.o
+a - driver/fvGFS/fv_nggps_diag.o
+a - driver/fvGFS/atmosphere.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+gmake -C ../stochastic_physics   FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+
+Build standalone FV3 stochastic_physics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+makefile:86: depend: No such file or directory
+Building dependencies ...
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+
+Build standalone FV3 stochastic_physics ...
+
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_gg_def.f -o stochy_gg_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_resol_def.f -o stochy_resol_def.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_layout_lag.f -o stochy_layout_lag.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c spectral_layout.F90 -o spectral_layout.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c glats_stochy.f -o glats_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c num_parthds_stochy.f -o num_parthds_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c update_ca.f90 -o update_ca.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c plumes.f90 -o plumes.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_namelist_def.F90 -o stochy_namelist_def.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c compns_stochy.F90 -o compns_stochy.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c four_to_grid_stochy.F -o four_to_grid_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c sumfln_stochy.f -o sumfln_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c gozrineo_stochy.f -o gozrineo_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c get_ls_node_stochy.f -o get_ls_node_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c get_lats_node_a_stochy.f -o get_lats_node_a_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c setlats_a_stochy.f -o setlats_a_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c setlats_lag_stochy.f -o setlats_lag_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c epslon_stochy.f -o epslon_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c pln2eo_stochy.f -o pln2eo_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c dozeuv_stochy.f -o dozeuv_stochy.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c dezouv_stochy.f -o dezouv_stochy.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_internal_state_mod.F90 -o stochy_internal_state_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_patterngenerator.F90 -o stochy_patterngenerator.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c getcon_lag_stochy.f -o getcon_lag_stochy.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c getcon_spectral.F90 -o getcon_spectral.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c initialize_spectral_mod.F90 -o initialize_spectral_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochy_data_mod.F90 -o stochy_data_mod.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c get_stochy_pattern.F90 -o get_stochy_pattern.o
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOPENMP -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c stochastic_physics.F90 -o stochastic_physics.o
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I../FV3/gfsphysics/ -I../FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -I../FV3/namphysics  -c cellular_automata.f90 -o cellular_automata.o
+ar rv libstochastic_physics.a stochy_gg_def.o stochy_resol_def.o stochy_layout_lag.o four_to_grid_stochy.o glats_stochy.o sumfln_stochy.o gozrineo_stochy.o num_parthds_stochy.o get_ls_node_stochy.o get_lats_node_a_stochy.o setlats_a_stochy.o setlats_lag_stochy.o epslon_stochy.o getcon_lag_stochy.o pln2eo_stochy.o dozeuv_stochy.o dezouv_stochy.o cellular_automata.o update_ca.o plumes.o spectral_layout.o getcon_spectral.o stochy_namelist_def.o compns_stochy.o stochy_internal_state_mod.o stochastic_physics.o stochy_patterngenerator.o stochy_data_mod.o get_stochy_pattern.o initialize_spectral_mod.o
+ar: creating libstochastic_physics.a
+a - stochy_gg_def.o
+a - stochy_resol_def.o
+a - stochy_layout_lag.o
+a - four_to_grid_stochy.o
+a - glats_stochy.o
+a - sumfln_stochy.o
+a - gozrineo_stochy.o
+a - num_parthds_stochy.o
+a - get_ls_node_stochy.o
+a - get_lats_node_a_stochy.o
+a - setlats_a_stochy.o
+a - setlats_lag_stochy.o
+a - epslon_stochy.o
+a - getcon_lag_stochy.o
+a - pln2eo_stochy.o
+a - dozeuv_stochy.o
+a - dezouv_stochy.o
+a - cellular_automata.o
+a - update_ca.o
+a - plumes.o
+a - spectral_layout.o
+a - getcon_spectral.o
+a - stochy_namelist_def.o
+a - compns_stochy.o
+a - stochy_internal_state_mod.o
+a - stochastic_physics.o
+a - stochy_patterngenerator.o
+a - stochy_data_mod.o
+a - get_stochy_pattern.o
+a - initialize_spectral_mod.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+gmake libfv3cap.a  FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -DESMF_VERSION_MAJOR=8  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -Igfsphysics -Iipd -Icpl -Iio -Iatmos_cubed_sphere -Iccpp/driver -I../stochastic_physics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_fv3_config.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -DESMF_VERSION_MAJOR=8  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -Igfsphysics -Iipd -Icpl -Iio -Iatmos_cubed_sphere -Iccpp/driver -I../stochastic_physics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c time_utils.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -DESMF_VERSION_MAJOR=8  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -Igfsphysics -Iipd -Icpl -Iio -Iatmos_cubed_sphere -Iccpp/driver -I../stochastic_physics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c atmos_model.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -DESMF_VERSION_MAJOR=8  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -Igfsphysics -Iipd -Icpl -Iio -Iatmos_cubed_sphere -Iccpp/driver -I../stochastic_physics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c module_fcst_grid_comp.F90
+mpiifort -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO  -DUSE_GFSL63 -DGFS_PHYS -Duse_WRTCOMP -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DMOIST_CAPPA -DUSE_COND -DOVERLOAD_R4 -DOVERLOAD_R8 -DOPENMP -DESMF_VERSION_MAJOR=8  -fpp -Wp,-w -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 32 -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -Igfsphysics -Iipd -Icpl -Iio -Iatmos_cubed_sphere -Iccpp/driver -I../stochastic_physics   -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c fv3_cap.F90
+ar rv libfv3cap.a atmos_model.o module_fv3_config.o module_fcst_grid_comp.o time_utils.o fv3_cap.o
+ar: creating libfv3cap.a
+a - atmos_model.o
+a - module_fv3_config.o
+a - module_fcst_grid_comp.o
+a - time_utils.o
+a - fv3_cap.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+gmake esmf_make_fragment FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+# additional include files needed for PGI
+#@echo "ESMF_DEP_INCPATH   = /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/nems_dir" >> fv3.mk
+
+Finished generating ESMF self-describing build dependency makefile fragment: fv3.mk
+
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+Installation into "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL" complete!
+
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+test -d /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL
+( \
+echo "# Do not edit this file.  It is automatically generated." ; \
+echo "# Edit the component list or /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC.in"                          ; \
+echo ; cat "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC.in"                                                 ; \
+echo fms_mk="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk" ; echo ww3_mk="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk" ; echo fv3_mk="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk" ; ) > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC"
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack                                         ; \
+set -e                                                  ; \
+for m in /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk ; do                   \
+  test -s $m                                           ; \
+done                                                    ; \
+echo build NEMS after /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk         ; \
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src                                       ; \
+gmake nems                              \
+          COMPONENTS="FMS WW3 FV3"                      \
+          FMS_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL WW3_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL FV3_DIR=/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL TARGET="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x"    ; \
+test -x /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
+
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
+
+Currently Loaded Modules:
+  1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
+  6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
+
+ 
+
+build NEMS after /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk
+Components in linker order: FV3 WW3 FMS
+FV3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk
+WW3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk
+FMS: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk
+CPPFLAGS += ESMF_VERSION_STRING_GIT="ESMF_8_0_1"
+CPPFLAGS += ESMF_VERSION_MAJOR="8"
+CPPFLAGS += ESMF_VERSION_BETASNAPSHOT="'F'"
+CPPFLAGS += ESMF_VERSION_MINOR="0"
+CPPFLAGS += ESMF_VERSION_PATCHLEVEL="1"
+CPPFLAGS += ESMF_VERSION_STRING="8.0.1"
+CPPFLAGS += ESMF_VERSION_REVISION="1"
+CPPFLAGS += ESMF_VERSION_PUBLIC="'T'"
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
+cd ENS_Cpl             && gmake stub
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+mpiicc -E -traditional ENS_CplComp_ESMFMod_STUB.F90 > ENS_CplComp_ESMFMod_STUB.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -c ENS_CplComp_ESMFMod_STUB.f90
+ar rv ENS_Cpl.a ENS_CplComp_ESMFMod_STUB.o
+ar: creating ENS_Cpl.a
+a - ENS_CplComp_ESMFMod_STUB.o
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_NEMS_UTILS.F90 > module_NEMS_UTILS.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_NEMS_UTILS.tmp.f90
+mv -v module_NEMS_UTILS.tmp.o module_NEMS_UTILS.o
+‘module_NEMS_UTILS.tmp.o’ -> ‘module_NEMS_UTILS.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_MEDIATOR_methods.F90 > module_MEDIATOR_methods.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_MEDIATOR_methods.tmp.f90
+mv -v module_MEDIATOR_methods.tmp.o module_MEDIATOR_methods.o
+‘module_MEDIATOR_methods.tmp.o’ -> ‘module_MEDIATOR_methods.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_MEDIATOR.F90 > module_MEDIATOR.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_MEDIATOR.tmp.f90
+mv -v module_MEDIATOR.tmp.o module_MEDIATOR.o
+‘module_MEDIATOR.tmp.o’ -> ‘module_MEDIATOR.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_MEDIATOR_SpaceWeather.F90 > module_MEDIATOR_SpaceWeather.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_MEDIATOR_SpaceWeather.tmp.f90
+mv -v module_MEDIATOR_SpaceWeather.tmp.o module_MEDIATOR_SpaceWeather.o
+‘module_MEDIATOR_SpaceWeather.tmp.o’ -> ‘module_MEDIATOR_SpaceWeather.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_EARTH_INTERNAL_STATE.F90 > module_EARTH_INTERNAL_STATE.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_EARTH_INTERNAL_STATE.tmp.f90
+mv -v module_EARTH_INTERNAL_STATE.tmp.o module_EARTH_INTERNAL_STATE.o
+‘module_EARTH_INTERNAL_STATE.tmp.o’ -> ‘module_EARTH_INTERNAL_STATE.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_EARTH_GRID_COMP.F90 > module_EARTH_GRID_COMP.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_EARTH_GRID_COMP.tmp.f90
+mv -v module_EARTH_GRID_COMP.tmp.o module_EARTH_GRID_COMP.o
+‘module_EARTH_GRID_COMP.tmp.o’ -> ‘module_EARTH_GRID_COMP.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_NEMS_INTERNAL_STATE.F90 > module_NEMS_INTERNAL_STATE.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_NEMS_INTERNAL_STATE.tmp.f90
+mv -v module_NEMS_INTERNAL_STATE.tmp.o module_NEMS_INTERNAL_STATE.o
+‘module_NEMS_INTERNAL_STATE.tmp.o’ -> ‘module_NEMS_INTERNAL_STATE.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_NEMS_GRID_COMP.F90 > module_NEMS_GRID_COMP.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_NEMS_GRID_COMP.tmp.f90
+mv -v module_NEMS_GRID_COMP.tmp.o module_NEMS_GRID_COMP.o
+‘module_NEMS_GRID_COMP.tmp.o’ -> ‘module_NEMS_GRID_COMP.o’
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" module_NEMS_Rusage.F90 > module_NEMS_Rusage.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c module_NEMS_Rusage.tmp.f90
+mv -v module_NEMS_Rusage.tmp.o module_NEMS_Rusage.o
+‘module_NEMS_Rusage.tmp.o’ -> ‘module_NEMS_Rusage.o’
+mpiicc -c nems_c_rusage.c
+mpiicc -E -traditional  -DFRONT_FV3=fv3gfs_cap_mod -DFRONT_WW3=WMESMFMD -DFRONT_FMS= -D'SVN_INFO="(Jun.Wang) Tue Sep 29 01:55:33 UTC 2020 r845c887776c6 https://github.com/NOAA-EMC/NEMS"' -D'CMP_YEAR=2020' -D'CMP_JD=273' -DESMF_VERSION_STRING_GIT="ESMF_8_0_1" -DESMF_VERSION_MAJOR="8" -DESMF_VERSION_BETASNAPSHOT="'F'" -DESMF_VERSION_MINOR="0" -DESMF_VERSION_PATCHLEVEL="1" -DESMF_VERSION_STRING="8.0.1" -DESMF_VERSION_REVISION="1" -DESMF_VERSION_PUBLIC="'T'" MAIN_NEMS.F90 > MAIN_NEMS.tmp.f90
+mpiifort -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -fno-alias -auto -safe-cray-ptr -save-temps -ftz -assume byterecl -nowarn -sox -align array64byte -i4 -real-size 64 -no-prec-div -no-prec-sqrt -xHOST -qno-opt-dynamic-align -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3 -qopenmp -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/mod -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/include -I/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/include -IENS_Cpl -I.  -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/../stochastic_physics -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB -I/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL -c MAIN_NEMS.tmp.f90
+mv -v MAIN_NEMS.tmp.o MAIN_NEMS.o
+‘MAIN_NEMS.tmp.o’ -> ‘MAIN_NEMS.o’
+echo libgocart is 
+libgocart is
+echo extlibs is /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.10_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a /gpfs/dell1/nco/ops/nwprod/lib/g2tmpl/v1.6.0/ips/18.0.1/libg2tmpl_v1.6.0.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a /gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a /usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a /usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a /usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -Wl,-rpath,/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf -lhdf5_hl -lhdf5   -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/lib -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/lib -qopenmp  -lnetcdf
+extlibs is /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.10_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a /gpfs/dell1/nco/ops/nwprod/lib/g2tmpl/v1.6.0/ips/18.0.1/libg2tmpl_v1.6.0.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a /gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a /usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a /usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a /usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -Wl,-rpath,/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -lesmf -cxxlib -lrt -ldl -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/lib -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/lib -qopenmp -lnetcdf
+mpiifort  -o /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x MAIN_NEMS.o module_NEMS_UTILS.o module_MEDIATOR_methods.o module_MEDIATOR.o module_MEDIATOR_SpaceWeather.o module_EARTH_INTERNAL_STATE.o module_EARTH_GRID_COMP.o module_NEMS_INTERNAL_STATE.o module_NEMS_GRID_COMP.o module_NEMS_Rusage.o nems_c_rusage.o  /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libfv3cap.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libfv3core.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libfv3io.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libipd.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libgfsphys.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libfv3cpl.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/libstochastic_physics.a /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/obj_HYB/libww3_multi_esmf.a  /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/libfms.a ENS_Cpl/ENS_Cpl.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libncep_post_v8.0.10_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libnemsio_v2.2.4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libg2_v3.1.1_4.a /gpfs/dell1/nco/ops/nwprod/lib/g2tmpl/v1.6.0/ips/18.0.1/libg2tmpl_v1.6.0.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libbacio_v2.0.3_4.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libsp_v2.0.3_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3emc_v2.3.1_d.a /usrx/local/nceplibs/dev/NCEPLIBS/compilers/ips/18.0.1.163/lib/libw3nco_v2.0.7_d.a /gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.2.6/ips/18.0.1/libcrtm_v2.2.6.a /usrx/local/prod/packages/gnu/4.8.5/libpng/1.2.59/lib/libpng.a /usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a /usrx/local/prod/packages/ips/18.0.1/zlib/1.2.11/lib/libz.a -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -Wl,-rpath,/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/esmf/8.0.1/lib -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf -lhdf5_hl -lhdf5   -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/netcdf/4.7.4/lib -L/usrx/local/prod/packages/ips/18.0.1/impi/18.0.1/hdf5/1.10.6/lib -qopenmp  -lnetcdf  
 /usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/lib/libjasper.a(jas_stream.o): In function `jas_stream_tmpfile':
 /usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.29/src/jasper-1.900.29/src/libjasper/base/jas_stream.c:520: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
-[100%] Built target NEMS.exe
-+ mv NEMS.exe ../fv3_3.exe
-+ cp /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr56/ufs-weather-model/modulefiles/wcoss_dell_p3/fv3 ../modules.fv3_3
-+ cd ..
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x is created.
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
+set -xe ; cp "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x" "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/tests/fv3_1.exe"
++ cp /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/exe/NEMS.x /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/tests/fv3_1.exe
 + '[' YES = YES ']'
-+ rm -rf build_fv3_3
-+ elapsed=539
-+ echo 'Elapsed time 539 seconds. Compiling 32BIT=Y finished'
-Elapsed time 539 seconds. Compiling 32BIT=Y finished
++ gmake -j 8 -k COMPONENTS=WW3,FMS,FV3 TEST_BUILD_NAME=fv3_1 BUILD_ENV=wcoss_dell_p3 'FV3_MAKEOPT=32BIT=Y WW3=Y' NEMS_BUILDOPT= clean
+Will copy modules.nems and NEMS.x as fv3_1 under tests/
+NOTE: Skipping appbuilder.mk creation; no appbuilder file in use.
+echo 'FMS WW3 FV3' > "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/components.mk"
+Adding FV3 makeopts to FMS makeopts
+cat /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs/makefile | sed 's,^include,#include,g'   \
+  > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs/makefile.temp.clean
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs                                       ; \
+    exec gmake 32BIT=Y WW3=Y -f makefile.temp.clean clean
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+Cleaning fms ... 
+
+cd .. ; \
+ls -1 */*.a */*.o */*.mod */depend \
+  | grep -vE 'INSTALL|\.git' | xargs rm -f || true ; \
+rm -rf FMS_INSTALL || true
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/fv3gfs'
+. /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf                ; \
+export COMP_SRCDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model" COMP_BINDIR="/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL" WW3_COMP="wcoss_dell_p3"                                  ; \
+export ESMFMKFILE=/dev/null                             ; \
+exec gmake distclean
+IMPORTANT: You are in more than one group account. You must manually set 
+the ECF_PORT environment variable to the appropriate port number:
+
+		Group Account ECF_PORT 
+		============= ======== 
+		emc.glopara 31487 
+		emc.climpara 31463 
+		emc.nomad 31523 
+Additional ports are listed in /usrx/local/sys/ecflow/assigned_ports.txt 
+
+Currently Loaded Modules:
+  1) ips/18.0.1.163   8) w3emc/2.3.1      15) zlib/1.2.11
+  2) impi/18.0.1      9) nemsio/2.2.4     16) post/8.0.10
+  3) lsf/10.1        10) g2/3.1.1         17) NetCDF-parallel/4.7.4
+  4) bacio/2.0.3     11) g2tmpl/1.6.0     18) ESMF/8.0.1
+  5) ip/3.0.2        12) crtm/2.2.6       19) HDF5-parallel/1.10.6
+  6) sp/2.0.3        13) jasper/1.900.29  20) cmake/3.10.0
+  7) w3nco/2.0.7     14) libpng/1.2.59    21) modules.nems
+
+ 
+
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/exe/ww3_multi_esmf *.o *.mod
+/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/w3_clean -c
+ 
+                *****************************
+              ***   WAVEWATCH III clean     ***
+                *****************************
+ 
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/ftn
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/aux
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_HYB
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/mod_SEQ
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/obj
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/obj_HYB
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/obj_SEQ
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin
+   Remove /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/exe
+   Clean up /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/../regtests
+\rm -fr /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/tmp
+\rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/bin/wwatch3.env
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model/esmf'
+cd "/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/model"                                      ; \
+rm -rf exe mod* obj* tmp ftn/makefile ftn/makefile_DIST   \
+   ftn/makefile_SHRD esmf/wwatch3.env aux/makefile        \
+   bin/link bin/comp                                    ; \
+find . -name '*.o' -o -name '*.mod' -o -name '*.a'        \
+  | xargs rm -f
+cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/configure.fv3
+cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/modules.fv3
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3 ; exec gmake          \
+  -k cleanall FMS_DIR=/dev/null
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+Cleaning ... 
+
+(cd gfsphysics     && make clean)
+
+Build standalone FV3 gfsphysics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning gfsphysics  ... 
+
+rm -f -f libgfsphys.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend */*.tmp.f90
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/gfsphysics'
+(cd ccpp/driver         && make clean)
+
+Build CCPP layer ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+makefile:67: depend: No such file or directory
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Building dependencies ...
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+
+Build CCPP layer ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+Cleaning CCPP_layer  ... 
+
+rm -f -f libccppdriver.a *__genmod.f90 *.tmp.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ccpp/driver'
+(cd ipd                 && make clean)
+
+Build standalone FV3 gfsphysics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning ipd  ... 
+
+rm -f -f libipd.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/ipd'
+(cd ../stochastic_physics  && make clean)
+
+Build standalone FV3 stochastic_physics ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning stochastic_physics ... 
+
+rm -f -f libstochastic_physics.a *__genmod.f90 *.o */*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/stochastic_physics'
+(cd io                  && make clean)
+
+Build standalone FV3 io ...
+
+$ESMF_INC is []
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning io ... 
+
+rm -f -f libfv3io.a *__genmod.f90 *.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/io'
+(cd atmos_cubed_sphere  && make clean)
+
+Build standalone FV3 fv3core ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning fv3core ... 
+
+rm -f -f libfv3core.a *__genmod.f90 */*.o */*/*.o *.mod *.i90 *.lst *.i depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/atmos_cubed_sphere'
+(cd cpl                 && make clean)
+
+Build standalone FV3 io ...
+
+make[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent make rule.
+Cleaning io ... 
+
+rm -f -f libfv3cpl.a *.o *.mod *.lst *.i90 depend
+make[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/cpl'
+rm -f -f fv3.exe libfv3cap.a *.o *.mod *.i90 *.lst depend
+rm -f -rf nems_dir fv3.mk FV3_INSTALL
+rm -f -f conf/modules.fv3
+rm -f -f conf/configure.fv3
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3'
+rm -rf nems_dir FV3_INSTALL /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/configure.fv3 \
+    /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/conf/modules.fv3
+if ! test -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC ; then       \
+  cat /dev/null > /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC       ; \
+  delete_nuopc=yes                                      ; \
+fi                                                      ; \
+cd /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src ; gmake "COMPONENTS=FMS WW3 FV3"    \
+  INCLUDES_ARE_OPTIONAL=YES clean                       ; \
+if [ "$delete_nuopc" = yes ] ; then                      \
+  rm -f /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/conf/configure.nems.NUOPC                 ; \
+fi
+Components in linker order: FV3 WW3 FMS
+FV3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk
+gmake[1]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
+GNUmakefile:70: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FV3/FV3_INSTALL/fv3.mk: component FV3 makefile fragment is missing
+WW3: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/WW3/WW3_INSTALL/nuopc.mk
+FMS: include /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk
+GNUmakefile:70: /gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/FMS/FMS_INSTALL/fms.mk: component FMS makefile fragment is missing
+CPPFLAGS += ESMF_VERSION_STRING_GIT="ESMF_8_0_1"
+CPPFLAGS += ESMF_VERSION_MAJOR="8"
+CPPFLAGS += ESMF_VERSION_BETASNAPSHOT="'F'"
+CPPFLAGS += ESMF_VERSION_MINOR="0"
+CPPFLAGS += ESMF_VERSION_PATCHLEVEL="1"
+CPPFLAGS += ESMF_VERSION_STRING="8.0.1"
+CPPFLAGS += ESMF_VERSION_REVISION="1"
+CPPFLAGS += ESMF_VERSION_PUBLIC="'T'"
+rm -f -f *.tmp.f90 *.lst *.o *.mod lm map
+cd ENS_Cpl ; gmake clean
+gmake[2]: Entering directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+rm -f -f ENS_Cpl.a *.f90 *.o *.mod *.lst lm map depend
+gmake[2]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src/ENS_Cpl'
+gmake[1]: Leaving directory `/gpfs/dell2/emc/modeling/noscrub/Jun.Wang/nems/vlab/gfs_v16/20200831/newlib/esmf801/NEMS/src'
++ elapsed=1193
++ echo 'Elapsed time 1193 seconds. Compiling 32BIT=Y WW3=Y finished'
+Elapsed time 1193 seconds. Compiling 32BIT=Y WW3=Y finished

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -381,7 +381,7 @@ done
 if [[ $MACHINE_ID = cheyenne.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/develop-20200210/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20200624}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20200626}
 fi
 
 shift $((OPTIND-1))


### PR DESCRIPTION
## Description

Provide a detailed description of what this PR does.
- Update netcdf/hdf5/esmf to user the release versions
- update NCEPLIBS to use the nwprod/nwtest version

Is a change of answers expected from this PR?
No
Are any library updates included in this PR (modulefiles etc.)?
Yes

## Testing

Tests have been done on hera/orion and wcoss dell and cray. 

There are no results changes compared to current GFS.v16.0.10 tag.  On cray ww3 does not work with the latest netcdf lib. ww3 developers are working on it.

