### PR TITLE
release/public-v2: update CCPP's GFS_debug.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v2
+	url = https://github.com/climbfuji/fv3atm
+	branch = release_public_v2_update_gfs_debug
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v2
-	url = https://github.com/climbfuji/fv3atm
-	branch = release_public_v2_update_gfs_debug
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Fri Oct  2 10:11:44 MDT 2020
+Wed Oct  7 09:16:13 MDT 2020
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4205/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -14,7 +14,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4205/fv3_ccpp_regional_restart_prod
 Checking test 002 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -22,20 +22,9 @@ Checking test 002 fv3_ccpp_regional_restart results ....
 Test 002 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_regional_c768_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_regional_c768_prod
-Checking test 003 fv3_ccpp_regional_c768 results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf003.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf003.nc .........OK
-Test 003 fv3_ccpp_regional_c768 PASS
-
-
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_rrfs_v1beta_prod
-Checking test 004 fv3_ccpp_rrfs_v1beta results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4205/fv3_ccpp_rrfs_v1beta_prod
+Checking test 003 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -122,12 +111,12 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 004 fv3_ccpp_rrfs_v1beta PASS
+Test 003 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_gfs_v15p2_prod
-Checking test 005 fv3_ccpp_gfs_v15p2 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4205/fv3_ccpp_gfs_v15p2_prod
+Checking test 004 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -190,80 +179,12 @@ Checking test 005 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 005 fv3_ccpp_gfs_v15p2 PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 004 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_57505/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4205/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 005 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -326,9 +247,9 @@ Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_gfs_v15p2_debug PASS
+Test 005 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Oct  2 11:02:55 MDT 2020
-Elapsed time: 00h:51m:12s. Have a nice day!
+Wed Oct  7 09:52:38 MDT 2020
+Elapsed time: 00h:36m:25s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Fri Oct  2 10:11:52 MDT 2020
+Wed Oct  7 09:16:18 MDT 2020
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -14,7 +14,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_regional_restart_prod
 Checking test 002 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -23,7 +23,7 @@ Test 002 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_c768_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_regional_c768_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_regional_c768_prod
 Checking test 003 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -34,7 +34,7 @@ Test 003 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -91,7 +91,7 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing dynf048.tile5.nc .........OK
  Comparing dynf048.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -126,7 +126,7 @@ Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_gfs_v15p2_prod
 Checking test 005 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -159,7 +159,7 @@ Checking test 005 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -194,7 +194,7 @@ Test 005 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -227,7 +227,7 @@ Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -262,7 +262,7 @@ Test 006 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_36170/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_5299/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -295,7 +295,7 @@ Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -330,5 +330,5 @@ Test 007 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Oct  2 10:52:41 MDT 2020
-Elapsed time: 00h:40m:50s. Have a nice day!
+Wed Oct  7 10:25:26 MDT 2020
+Elapsed time: 01h:09m:09s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Fri Oct  2 22:35:25 UTC 2020
+Wed Oct  7 15:16:00 UTC 2020
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_154993/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_74059/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -14,7 +14,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_154993/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_74059/fv3_ccpp_regional_restart_prod
 Checking test 002 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -23,7 +23,7 @@ Test 002 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_154993/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_74059/fv3_ccpp_rrfs_v1beta_prod
 Checking test 003 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -115,7 +115,7 @@ Test 003 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_154993/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_74059/fv3_ccpp_gfs_v15p2_prod
 Checking test 004 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -183,7 +183,7 @@ Test 004 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_154993/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_74059/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 005 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -251,5 +251,5 @@ Test 005 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Oct  2 23:04:24 UTC 2020
-Elapsed time: 00h:29m:00s. Have a nice day!
+Wed Oct  7 15:46:53 UTC 2020
+Elapsed time: 00h:30m:54s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Fri Oct  2 21:09:38 UTC 2020
+Wed Oct  7 15:17:02 UTC 2020
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -14,7 +14,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_regional_restart_prod
 Checking test 002 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -23,7 +23,7 @@ Test 002 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_regional_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_regional_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_regional_c768_prod
 Checking test 003 fv3_ccpp_regional_c768 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -34,7 +34,7 @@ Test 003 fv3_ccpp_regional_c768 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -126,7 +126,7 @@ Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_gfs_v15p2_prod
 Checking test 005 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Test 005 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -262,7 +262,7 @@ Test 006 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_250671/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_248518/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -330,5 +330,5 @@ Test 007 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Oct  2 21:32:55 UTC 2020
-Elapsed time: 00h:23m:18s. Have a nice day!
+Wed Oct  7 15:41:03 UTC 2020
+Elapsed time: 00h:24m:02s. Have a nice day!


### PR DESCRIPTION
## Description

This PR updates CCPP's `GFS_debug.F90` to the version in ccpp-physics master. This allows us to use the same documentation on debugging with CCPP for the SRW App and the authoritative repositories.

## Testing

No regression testing required. The updated `GFS_debug.F90` is not used by any suite, and the change in `GFS_typedefs.F90` is a comment only. In order to make sure that the code changes are correct, I manually changed one suite and added calls to all debugging schemes in CCPP's `GFS_debug.F90`. I then compiled the code on macOS using clang+gfortran and gcc+gfortran, ran one short forecast and inspected the debugging output.

Update: regression tests were run on cheyenne.intel, cheyenne.gnu, hera.intel, hera.gnu - logs updated in the PR.

## Dependencies

https://github.com/NCAR/ccpp-doc/pull/25 (this can be merged before or after)
https://github.com/NCAR/ccpp-physics/pull/505
https://github.com/NOAA-EMC/fv3atm/pull/184
https://github.com/ufs-community/ufs-weather-model/pull/214