### PR TITLE
GFSv16: update GFS.v16 library version on orion and hera 

### DIFF
--- a/conf/configure.fv3.hera.intel
+++ b/conf/configure.fv3.hera.intel
@@ -37,7 +37,7 @@ include       $(ESMFMKFILE)
 ESMF_INC    = $(ESMF_F90COMPILEPATHS)
 
 NEMSIOINC = -I$(NEMSIO_INC)
-NCEPLIBS = $(POST_LIB) $(NEMSIO_LIB) $(G2_LIB4) $(G2TMPL_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd) $(CRTM_LIB) $(PNG_LIB) $(JASPER_LIB) $(Z_LIB)
+NCEPLIBS = $(UPP_LIB) $(NEMSIO_LIB) $(G2_LIB4) $(G2TMPL_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd) $(CRTM_LIB) $(PNG_LIB) $(JASPER_LIB) $(Z_LIB)
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #

--- a/conf/configure.fv3.orion.intel
+++ b/conf/configure.fv3.orion.intel
@@ -37,7 +37,7 @@ include       $(ESMFMKFILE)
 ESMF_INC    = $(ESMF_F90COMPILEPATHS)
 
 NEMSIOINC = -I$(NEMSIO_INC)
-NCEPLIBS = $(POST_LIB) $(NEMSIO_LIB) $(G2_LIB4) $(G2TMPL_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd) $(CRTM_LIB) $(PNG_LIB) $(JASPER_LIB) $(Z_LIB)
+NCEPLIBS = $(UPP_LIB) $(NEMSIO_LIB) $(G2_LIB4) $(G2TMPL_LIB) $(BACIO_LIB4) $(SP_LIBd) $(W3EMC_LIBd) $(W3NCO_LIBd) $(CRTM_LIB) $(PNG_LIB) $(JASPER_LIB) $(Z_LIB)
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #

--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -33,16 +33,16 @@ module load bacio/2.0.3
 module load ip/3.0.2
 module load nemsio/2.2.4
 module load sp/2.0.3
-module load w3emc/2.3.1
-module load w3nco/2.0.7
-module load g2/3.1.1
+module load w3emc/2.4.0
+module load w3nco/2.2.0
+module load g2/3.2.0
 module load g2tmpl/1.6.0
-module load crtm/2.2.6
+module load crtm/2.3.0
 module load jasper/1.900.1
 module load png/1.2.44
 module load z/1.2.11
 ## load modules for nceppost grib
-module load post/8.0.10
+module load upp/8.0.11
 
 ##
 ## load ESMF library for above compiler / MPI combination

--- a/modulefiles/orion.intel/fv3
+++ b/modulefiles/orion.intel/fv3
@@ -30,14 +30,14 @@ module load ip/3.0.2
 module load nemsio/2.2.4
 module load sp/2.0.3
 module load w3emc/2.4.0
-module load w3nco/2.0.7
-module load g2/3.1.1
+module load w3nco/2.2.0
+module load g2/3.2.0
 module load g2tmpl/1.6.0
 module load crtm/2.3.0
 module load jasper/1.900.2
 module load png/1.2.44
 module load z/1.2.6
-module load post/8.0.10
+module load upp/8.0.11
 
 ##
 ## load ESMF library for above compiler / MPI combination

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -378,8 +378,8 @@ while getopts ":cfsl:mkreh" opt; do
   esac
 done
 
-if [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/develop-20200210/${COMPILER^^}}
+if [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = hera.* ]]; then
+  RTPWD=${RTPWD:-$DISKNM/develop-20200626/${COMPILER^^}}
 else
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20200626}
 fi


### PR DESCRIPTION
## Description

This PR will update the hera/orion module files to use the GFS.v16 prod libraries:
g2/3.2.0
crtm/2.3.0
w3emc/2.4.0
w3nco/2.2.0
upp/8.0.11

No results will change from this PR. GFS.v16.0.13 only has prod lib change on wcoss( these prod lib were not available on hera/orion at that time). After this PR, we will be able to run the final gfs.v16 implementation package on wcoss, hera and orion.

## Testing

The code was tested with a RT test case and a fv3 parallel test case on hera/orion/wcoss.

## Dependencies

No.
