### PR TITLE
Fix running both Intel and GNU regression tests using ecflow on the same machine (node)

### DIFF
--- a/tests/fv3_conf/compile_bsub.IN_wcoss_cray
+++ b/tests/fv3_conf/compile_bsub.IN_wcoss_cray
@@ -11,6 +11,11 @@
 
 set -eux
 
+set +x
+module load alps
+module list
+set -x
+
 echo "Compile started:  " `date`
 
 aprun -n 1 -j 1 -N 1 -d 24 @[PATHRT]/compile.sh @[MACHINE_ID] "@[MAKE_OPT]" @[COMPILE_NR]

--- a/tests/fv3_conf/fv3_bsub.IN_wcoss_cray
+++ b/tests/fv3_conf/fv3_bsub.IN_wcoss_cray
@@ -15,7 +15,6 @@ set +x
 source ./module-setup.sh
 module use $( pwd -P )
 module load modules.fv3
-module load alps/5.2.3-2.0502.9295.14.14.ari
 module list
 set -x
 

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -99,12 +99,7 @@ source rt_utils.sh
 
 if [[ $MACHINE_ID = wcoss_cray ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
   module load xt-lsfhpc
-
-  module use $PATHTR/modulefiles/${MACHINE_ID}
-  module load fv3
-
   module load python/2.7.14
 
   module use /usrx/local/emc_rocoto/modulefiles
@@ -136,12 +131,7 @@ if [[ $MACHINE_ID = wcoss_cray ]]; then
 
 elif [[ $MACHINE_ID = wcoss_dell_p3 ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
   module load lsf/10.1
-
-  module use $PATHTR/modulefiles/${MACHINE_ID}
-  module load fv3
-
   module load python/2.7.14
 
   module use /usrx/local/dev/emc_rocoto/modulefiles

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -192,11 +192,6 @@ elif [[ $MACHINE_ID = gaea.* ]]; then
 
 elif [[ $MACHINE_ID = hera.* ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
-
-  module use $PATHTR/modulefiles/${MACHINE_ID}
-  module load fv3
-
   module load rocoto
   ROCOTORUN=$(which rocotorun)
   ROCOTOSTAT=$(which rocotostat)
@@ -224,10 +219,6 @@ elif [[ $MACHINE_ID = hera.* ]]; then
 
 elif [[ $MACHINE_ID = orion.* ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
-
-  module use $PATHTR/modulefiles/${MACHINE_ID}
-  module load fv3
   module load gcc/8.3.0
 
   module load contrib rocoto/1.3.1

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -97,6 +97,8 @@ export RT_COMPILER=${RT_COMPILER:-intel}
 source detect_machine.sh
 source rt_utils.sh
 
+source $PATHTR/NEMS/src/conf/module-setup.sh.inc
+
 if [[ $MACHINE_ID = wcoss_cray ]]; then
 
   module load xt-lsfhpc
@@ -158,8 +160,6 @@ elif [[ $MACHINE_ID = wcoss_dell_p3 ]]; then
   cp fv3_conf/compile_bsub.IN_wcoss_dell_p3 fv3_conf/compile_bsub.IN
 
 elif [[ $MACHINE_ID = gaea.* ]]; then
-
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
 
 #  export PATH=/gpfs/hps/nco/ops/ecf/ecfdir/ecflow.v4.1.0.intel/bin:$PATH
   export PYTHONPATH=
@@ -234,11 +234,6 @@ elif [[ $MACHINE_ID = orion.* ]]; then
 
 elif [[ $MACHINE_ID = jet.* ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
-
-  module use $PATHTR/modulefiles/${MACHINE_ID}
-  module load fv3
-
   module load rocoto/1.3.2
   ROCOTORUN=$(which rocotorun)
   ROCOTOSTAT=$(which rocotostat)
@@ -264,8 +259,6 @@ elif [[ $MACHINE_ID = jet.* ]]; then
 
 elif [[ $MACHINE_ID = cheyenne.* ]]; then
 
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
-
   module load python/2.7.16
   export PATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/bin:$PATH
   export PYTHONPATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/lib/python2.7/site-packages
@@ -283,8 +276,6 @@ elif [[ $MACHINE_ID = cheyenne.* ]]; then
   cp fv3_conf/compile_qsub.IN_cheyenne fv3_conf/compile_qsub.IN
 
 elif [[ $MACHINE_ID = stampede.* ]]; then
-
-  source $PATHTR/NEMS/src/conf/module-setup.sh.inc
 
   export PYTHONPATH=
   ECFLOW_START=

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -360,16 +360,17 @@ rocoto_create_compile_task() {
 
   NATIVE=""
   BUILD_CORES=8
+  BUILD_WALLTIME="00:30:00"
   if [[ ${MACHINE_ID} == wcoss_dell_p3 ]]; then
     BUILD_CORES=1
     NATIVE="<memory>8G</memory> <native>-R 'affinity[core(1)]'</native>"
+    BUILD_WALLTIME="01:00:00"
   fi
   if [[ ${MACHINE_ID} == wcoss_cray ]]; then
     BUILD_CORES=24
     rocoto_cmd="aprun -n 1 -j 1 -N 1 -d $BUILD_CORES $rocoto_cmd"
     NATIVE="<exclusive></exclusive> <envar><name>PATHTR</name><value>&PATHTR;</value></envar>"
   fi
-  BUILD_WALLTIME="00:30:00"
   if [[ ${MACHINE_ID} == jet ]]; then
     BUILD_WALLTIME="01:00:00"
   fi

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -367,7 +367,7 @@ rocoto_create_compile_task() {
   if [[ ${MACHINE_ID} == wcoss_cray ]]; then
     BUILD_CORES=24
     rocoto_cmd="aprun -n 1 -j 1 -N 1 -d $BUILD_CORES $rocoto_cmd"
-    NATIVE="<exclusive></exclusive>"
+    NATIVE="<exclusive></exclusive> <envar><name>PATHTR</name><value>&PATHTR;</value></envar>"
   fi
   BUILD_WALLTIME="00:30:00"
   if [[ ${MACHINE_ID} == jet ]]; then

--- a/tests/tests/fv3_ccpp_control_debug
+++ b/tests/tests/fv3_ccpp_control_debug
@@ -6,9 +6,32 @@
 
 export TEST_DESCR="Compare FV3 CCPP control results with previous trunk version"
 
-export CNTL_DIR=fv3_control
+export CNTL_DIR=fv3_control_debug
 
-export LIST_FILES=""
+export LIST_FILES="phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   phyf006.tile1.nc \
+                   phyf006.tile2.nc \
+                   phyf006.tile3.nc \
+                   phyf006.tile4.nc \
+                   phyf006.tile5.nc \
+                   phyf006.tile6.nc \
+                   dynf006.tile1.nc \
+                   dynf006.tile2.nc \
+                   dynf006.tile3.nc \
+                   dynf006.tile4.nc \
+                   dynf006.tile5.nc \
+                   dynf006.tile6.nc"
 
 export_fv3
 

--- a/tests/tests/fv3_ccpp_stretched_nest_debug
+++ b/tests/tests/fv3_ccpp_stretched_nest_debug
@@ -6,8 +6,22 @@
 
 export TEST_DESCR="Compare FV3 CCPP control results with previous trunk version"
 
-export CNTL_DIR=fv3_stretched_nest
-export LIST_FILES=
+export CNTL_DIR=fv3_stretched_nest_debug
+
+export LIST_FILES="fv3_history2d.nest02.tile7.nc \
+                   fv3_history2d.tile1.nc \
+                   fv3_history2d.tile2.nc \
+                   fv3_history2d.tile3.nc \
+                   fv3_history2d.tile4.nc \
+                   fv3_history2d.tile5.nc \
+                   fv3_history2d.tile6.nc \
+                   fv3_history.nest02.tile7.nc \
+                   fv3_history.tile1.nc \
+                   fv3_history.tile2.nc \
+                   fv3_history.tile3.nc \
+                   fv3_history.tile4.nc \
+                   fv3_history.tile5.nc \
+                   fv3_history.tile6.nc"
 
 export_fv3
 


### PR DESCRIPTION
## Description

Provide list of files to be compared in two debug regression test (#23).
Do not load fv3 modules in the rt.sh. The fv3 module will be loaded in the compile and run scripts (#235).
Rocoto must pass PATHTR environment variable via workflow xml file.
When rocoto is used increase build time on wcoss_dell to 60min (one of the coupled compilation times out)

### Issue(s) addressed

Issue #23 
Issue #235 

## Testing

New baselines required for fv3_ccpp_control_debug and fv3_ccpp_stretched_nest_debug.