### PR TITLE
release/public-v2: addd RRFs v1alpha regression tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v2
-	url = https://github.com/climbfuji/fv3atm
-	branch = add_suite_FV3_RRFS_v1alpha
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v2
+	url = https://github.com/climbfuji/fv3atm
+	branch = add_suite_FV3_RRFS_v1alpha
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/parm/ccpp_global.nml.IN
+++ b/parm/ccpp_global.nml.IN
@@ -152,7 +152,6 @@
   lheatstrg = @[LHEATSTRG]
   do_mynnedmf   = @[DO_MYNNEDMF]
   do_mynnsfclay = @[DO_MYNNSFCLAY]
-  effr_in   = .true.
   random_clds = .false.
   trans_trac = .true.
   cnvcld    = .true.

--- a/parm/ccpp_regional.nml.IN
+++ b/parm/ccpp_regional.nml.IN
@@ -164,7 +164,6 @@
   lheatstrg = @[LHEATSTRG]
   do_mynnedmf   = @[DO_MYNNEDMF]
   do_mynnsfclay = @[DO_MYNNSFCLAY]
-  effr_in   = .true.
   random_clds = .false.
   trans_trac = .true.
   cnvcld    = .true.

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Thu Oct 29 11:15:36 MDT 2020
+Thu Nov 12 15:37:03 MST 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,8 +42,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf003.nc .........OK
@@ -52,8 +52,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -132,8 +132,8 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
 Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_rrfs_v1beta_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_rrfs_v1beta_coldstart_prod
 Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -161,9 +161,118 @@ Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
 Test 005 fv3_ccpp_rrfs_v1beta_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_gfs_v15p2_prod
-Checking test 006 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_gfs_v15p2_prod
+Checking test 008 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -226,12 +335,80 @@ Checking test 006 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 006 fv3_ccpp_gfs_v15p2 PASS
+Test 008 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_26513/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 009 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 009 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_1140/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 010 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -294,9 +471,9 @@ Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_gfs_v15p2_debug PASS
+Test 010 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 29 11:32:03 MDT 2020
-Elapsed time: 00h:16m:28s. Have a nice day!
+Thu Nov 12 15:50:20 MST 2020
+Elapsed time: 00h:13m:18s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Thu Oct 29 12:05:58 MDT 2020
+Thu Nov 12 16:30:51 MST 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,8 +42,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf003.nc .........OK
@@ -52,8 +52,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -132,8 +132,8 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
 Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_rrfs_v1beta_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1beta_coldstart_prod
 Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -161,9 +161,118 @@ Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
 Test 005 fv3_ccpp_rrfs_v1beta_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_gfs_v15p2_prod
-Checking test 006 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_gfs_v15p2_prod
+Checking test 008 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -226,12 +335,12 @@ Checking test 006 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 006 fv3_ccpp_gfs_v15p2 PASS
+Test 008 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_regional_control_debug_prod
-Checking test 007 fv3_ccpp_regional_control_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_regional_control_debug_prod
+Checking test 009 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -244,12 +353,12 @@ Checking test 007 fv3_ccpp_regional_control_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 007 fv3_ccpp_regional_control_debug PASS
+Test 009 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 008 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 010 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -312,12 +421,80 @@ Checking test 008 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 010 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_63726/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 009 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 011 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 011 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31259/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -380,9 +557,9 @@ Checking test 009 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 009 fv3_ccpp_gfs_v15p2_debug PASS
+Test 012 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 29 12:39:23 MDT 2020
-Elapsed time: 00h:33m:26s. Have a nice day!
+Thu Nov 12 17:05:12 MST 2020
+Elapsed time: 00h:34m:22s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,40 +1,59 @@
-Mon Oct  5 11:19:23 EDT 2020
+Fri Nov 13 12:26:34 EST 2020
 Start Regression test
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_regional_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing fv3_history2d.nc .........OK
- Comparing fv3_history.nc .........OK
- Comparing RESTART/fv_core.res.tile1_new.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf003.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf003.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_regional_restart_prod
-Checking test 002 fv3_ccpp_regional_restart results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_regional_2threads_prod
+Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing fv3_history2d.nc .........OK
- Comparing fv3_history.nc .........OK
-Test 002 fv3_ccpp_regional_restart PASS
-
-
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_regional_c768_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_regional_c768_prod
-Checking test 003 fv3_ccpp_regional_c768 results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf003.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf003.nc .........OK
-Test 003 fv3_ccpp_regional_c768 PASS
+ Comparing phyf006.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf003.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_regional_coldstart_prod
+Checking test 003 fv3_ccpp_regional_coldstart results ....
+ Comparing phyf000.nc .........OK
+ Comparing phyf003.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf003.nc .........OK
+Test 003 fv3_ccpp_regional_coldstart PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1beta_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -48,48 +67,36 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing phyf000.tile4.nc .........OK
  Comparing phyf000.tile5.nc .........OK
  Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
  Comparing phyf024.tile4.nc .........OK
  Comparing phyf024.tile5.nc .........OK
  Comparing phyf024.tile6.nc .........OK
- Comparing phyf027.tile1.nc .........OK
- Comparing phyf027.tile2.nc .........OK
- Comparing phyf027.tile3.nc .........OK
- Comparing phyf027.tile4.nc .........OK
- Comparing phyf027.tile5.nc .........OK
- Comparing phyf027.tile6.nc .........OK
- Comparing phyf048.tile1.nc .........OK
- Comparing phyf048.tile2.nc .........OK
- Comparing phyf048.tile3.nc .........OK
- Comparing phyf048.tile4.nc .........OK
- Comparing phyf048.tile5.nc .........OK
- Comparing phyf048.tile6.nc .........OK
  Comparing dynf000.tile1.nc .........OK
  Comparing dynf000.tile2.nc .........OK
  Comparing dynf000.tile3.nc .........OK
  Comparing dynf000.tile4.nc .........OK
  Comparing dynf000.tile5.nc .........OK
  Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
  Comparing dynf024.tile1.nc .........OK
  Comparing dynf024.tile2.nc .........OK
  Comparing dynf024.tile3.nc .........OK
  Comparing dynf024.tile4.nc .........OK
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
- Comparing dynf027.tile1.nc .........OK
- Comparing dynf027.tile2.nc .........OK
- Comparing dynf027.tile3.nc .........OK
- Comparing dynf027.tile4.nc .........OK
- Comparing dynf027.tile5.nc .........OK
- Comparing dynf027.tile6.nc .........OK
- Comparing dynf048.tile1.nc .........OK
- Comparing dynf048.tile2.nc .........OK
- Comparing dynf048.tile3.nc .........OK
- Comparing dynf048.tile4.nc .........OK
- Comparing dynf048.tile5.nc .........OK
- Comparing dynf048.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -125,9 +132,147 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
 Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_gfs_v15p2_prod
-Checking test 005 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1beta_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1beta_coldstart_prod
+Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 005 fv3_ccpp_rrfs_v1beta_coldstart PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_gfs_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_gfs_v15p2_prod
+Checking test 008 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -190,12 +335,30 @@ Checking test 005 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 005 fv3_ccpp_gfs_v15p2 PASS
+Test 008 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_regional_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_regional_control_debug_prod
+Checking test 009 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 009 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 010 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -258,12 +421,80 @@ Checking test 006 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 010 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201002/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3767/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 011 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 011 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_5748/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -326,9 +557,9 @@ Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_gfs_v15p2_debug PASS
+Test 012 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Oct  5 16:37:36 EDT 2020
-Elapsed time: 05h:18m:15s. Have a nice day!
+Fri Nov 13 13:44:23 EST 2020
+Elapsed time: 01h:17m:50s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Thu Oct 29 14:34:04 UTC 2020
+Fri Nov 13 15:36:29 UTC 2020
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,8 +42,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf003.nc .........OK
@@ -52,8 +52,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -132,8 +132,8 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
 Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_rrfs_v1beta_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_rrfs_v1beta_coldstart_prod
 Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -161,9 +161,118 @@ Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
 Test 005 fv3_ccpp_rrfs_v1beta_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_gfs_v15p2_prod
-Checking test 006 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_gfs_v15p2_prod
+Checking test 008 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -226,12 +335,80 @@ Checking test 006 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 006 fv3_ccpp_gfs_v15p2 PASS
+Test 008 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_255533/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 009 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 009 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_276846/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 010 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -294,9 +471,9 @@ Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_gfs_v15p2_debug PASS
+Test 010 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 29 15:17:42 UTC 2020
-Elapsed time: 00h:43m:39s. Have a nice day!
+Fri Nov 13 16:30:07 UTC 2020
+Elapsed time: 00h:53m:39s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Oct 28 21:48:14 UTC 2020
+Fri Nov 13 15:23:27 UTC 2020
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,8 +42,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf003.nc .........OK
@@ -52,8 +52,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1beta_prod
 Checking test 004 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -132,8 +132,8 @@ Checking test 004 fv3_ccpp_rrfs_v1beta results ....
 Test 004 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_rrfs_v1beta_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1beta_coldstart_prod
 Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -161,9 +161,118 @@ Checking test 005 fv3_ccpp_rrfs_v1beta_coldstart results ....
 Test 005 fv3_ccpp_rrfs_v1beta_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_gfs_v15p2_prod
-Checking test 006 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_gfs_v15p2_prod
+Checking test 008 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -226,12 +335,12 @@ Checking test 006 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 006 fv3_ccpp_gfs_v15p2 PASS
+Test 008 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_regional_control_debug_prod
-Checking test 007 fv3_ccpp_regional_control_debug results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_regional_control_debug_prod
+Checking test 009 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -244,12 +353,12 @@ Checking test 007 fv3_ccpp_regional_control_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 007 fv3_ccpp_regional_control_debug PASS
+Test 009 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 008 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 010 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -312,12 +421,80 @@ Checking test 008 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 010 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_119150/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 009 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 011 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 011 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_237229/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 012 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -380,9 +557,9 @@ Checking test 009 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 009 fv3_ccpp_gfs_v15p2_debug PASS
+Test 012 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Oct 28 22:27:10 UTC 2020
-Elapsed time: 00h:38m:57s. Have a nice day!
+Fri Nov 13 16:03:52 UTC 2020
+Elapsed time: 00h:40m:26s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,10 +1,119 @@
-Thu Oct 29 19:17:18 GMT 2020
+Fri Nov 13 17:01:28 GMT 2020
 Start Regression test
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_284289/fv3_ccpp_gfs_v15p2_prod
-Checking test 001 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 001 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 001 fv3_ccpp_rrfs_v1alpha PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 002 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 002 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_gfs_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_gfs_v15p2_prod
+Checking test 003 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -67,12 +176,12 @@ Checking test 001 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 001 fv3_ccpp_gfs_v15p2 PASS
+Test 003 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_284289/fv3_ccpp_regional_control_debug_prod
-Checking test 002 fv3_ccpp_regional_control_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_regional_control_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_regional_control_debug_prod
+Checking test 004 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -85,12 +194,12 @@ Checking test 002 fv3_ccpp_regional_control_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 002 fv3_ccpp_regional_control_debug PASS
+Test 004 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_284289/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 003 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 005 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -153,12 +262,80 @@ Checking test 003 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 003 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 005 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201027/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_284289/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 004 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201112/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_289743/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 007 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -221,9 +398,9 @@ Checking test 004 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 004 fv3_ccpp_gfs_v15p2_debug PASS
+Test 007 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Oct 29 20:01:29 GMT 2020
-Elapsed time: 00h:44m:13s. Have a nice day!
+Fri Nov 13 17:46:49 GMT 2020
+Elapsed time: 00h:45m:23s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -2,8 +2,9 @@
 # CCPP PROD TESTS                                                                                                             #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y                    | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y   | standard    |                | fv3         |
 
+# Regional tests
 RUN     | fv3_ccpp_regional_control                                              | standard    |                | fv3         |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_regional_decomp                                               | standard    |                |             |
@@ -11,22 +12,29 @@ RUN     | fv3_ccpp_regional_2threads                                            
 RUN     | fv3_ccpp_regional_coldstart                                            | standard    |                |             |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_regional_warmstart                                            | standard    |                |             | fv3_ccpp_regional_coldstart
-# The following test does NOT run because of the error "FATAL from PE     0: ==> External_ic::get_nggps_ic: more NGGPS tracers than defined in field_table gfs_ctrl.nc for NGGPS IC"
+# This test has problems
 #RUN     | fv3_ccpp_regional_v15p2                                                | standard    |                | fv3         |
+
+# Global tests
 RUN     | fv3_ccpp_rrfs_v1beta                                                   | standard    |                | fv3         |
 RUN     | fv3_ccpp_rrfs_v1beta_coldstart                                         | standard    |                |             |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_rrfs_v1beta_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1beta_coldstart
+RUN     | fv3_ccpp_rrfs_v1alpha                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_coldstart                                         | standard    |                |             |
+# The following test does NOT reproduce the control baseline - maybe, need to check
+#RUN     | fv3_ccpp_rrfs_v1alpha_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1alpha_coldstart
 RUN     | fv3_ccpp_gfs_v15p2                                                     | standard    |                | fv3         |
 
 ###############################################################################################################################
 # CCPP DEBUG TESTS                                                                                                            #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y            | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y | standard    |                | fv3         |
 
-RUN     | fv3_ccpp_regional_control_debug                                        | standard    |                | fv3         |
-# The following test does NOT run because of the error "FATAL from PE     0: ==> External_ic::get_nggps_ic: more NGGPS tracers than defined in field_table gfs_ctrl.nc for NGGPS IC"
-#RUN     | fv3_ccpp_regional_v15p2_debug                                          | standard    |                | fv3         |
-RUN     | fv3_ccpp_rrfs_v1beta_debug                                             | standard    |                | fv3         |
-RUN     | fv3_ccpp_gfs_v15p2_debug                                               | standard    |                | fv3         |
+RUN     | fv3_ccpp_regional_control_debug                                              | standard    |                | fv3         |
+# This test has problems
+#RUN     | fv3_ccpp_regional_v15p2_debug                                                | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1beta_debug                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_debug                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_gfs_v15p2_debug                                                     | standard    |                | fv3         |

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -339,7 +339,7 @@ fi
 mkdir -p ${STMP}/${USER}
 
 # Different own baseline directories for different compilers on Theia/Cheyenne
-NEW_BASELINE=${STMP}/${USER}/FV3_RT/REGRESSION_TEST
+NEW_BASELINE=${STMP}/${USER}/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]]; then
     NEW_BASELINE=${NEW_BASELINE}_${COMPILER^^}
 fi
@@ -418,9 +418,9 @@ if [[ $SINGLE_NAME != '' ]]; then
 fi
 
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201027/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201112/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201027}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201112}
 fi
 
 shift $((OPTIND-1))

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -2,8 +2,9 @@
 # CCPP PROD TESTS                                                                                                             #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y                    | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y   | standard    |                | fv3         |
 
+# Regional tests
 RUN     | fv3_ccpp_regional_control                                              | standard    |                | fv3         |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_regional_decomp                                               | standard    |                |             |
@@ -11,24 +12,31 @@ RUN     | fv3_ccpp_regional_2threads                                            
 RUN     | fv3_ccpp_regional_coldstart                                            | standard    |                |             |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_regional_warmstart                                            | standard    |                |             | fv3_ccpp_regional_coldstart
-# The following test does NOT run because of the error "FATAL from PE     0: ==> External_ic::get_nggps_ic: more NGGPS tracers than defined in field_table gfs_ctrl.nc for NGGPS IC"
+# This test has problems
 #RUN     | fv3_ccpp_regional_v15p2                                                | standard    |                | fv3         |
+
+# Global tests
 RUN     | fv3_ccpp_rrfs_v1beta                                                   | standard    |                | fv3         |
 RUN     | fv3_ccpp_rrfs_v1beta_coldstart                                         | standard    |                |             |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_rrfs_v1beta_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1beta_coldstart
+RUN     | fv3_ccpp_rrfs_v1alpha                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_coldstart                                         | standard    |                |             |
+# The following test does NOT reproduce the control baseline - maybe, need to check
+#RUN     | fv3_ccpp_rrfs_v1alpha_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1alpha_coldstart
 RUN     | fv3_ccpp_gfs_v15p2                                                     | standard    |                | fv3         |
 
 ###############################################################################################################################
 # CCPP DEBUG TESTS                                                                                                            #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y            | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y | standard    |                | fv3         |
 
 # The following test crashes with the GNU compiler, fix! Thompson MP line 2054 - something Dom encountered with HWRF testing, too?
-#RUN     | fv3_ccpp_regional_control_debug                                        | standard    |                | fv3         |
-# The following test does NOT run because of the error "FATAL from PE     0: ==> External_ic::get_nggps_ic: more NGGPS tracers than defined in field_table gfs_ctrl.nc for NGGPS IC"
-#RUN     | fv3_ccpp_regional_v15p2_debug                                          | standard    |                | fv3         |
+#RUN     | fv3_ccpp_regional_control_debug                                              | standard    |                | fv3         |
+# This test has problems
+#RUN     | fv3_ccpp_regional_v15p2_debug                                                | standard    |                | fv3         |
 # The following test crashes with the GNU compiler, fix! Thompson MP line 2054 - something Dom encountered with HWRF testing, too?
-#RUN     | fv3_ccpp_rrfs_v1beta_debug                                             | standard    |                | fv3         |
-RUN     | fv3_ccpp_gfs_v15p2_debug                                               | standard    |                | fv3         |
+#RUN     | fv3_ccpp_rrfs_v1beta_debug                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_debug                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_gfs_v15p2_debug                                                     | standard    |                | fv3         |

--- a/tests/rt_jet_intel.conf
+++ b/tests/rt_jet_intel.conf
@@ -2,7 +2,7 @@
 # CCPP PROD TESTS                                                                                                             #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y                    | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y   | standard    |                | fv3         |
 
 # None of these working on jet.intel right now
 # RUN     | fv3_ccpp_regional_control                                              | standard    |                | fv3         |
@@ -18,16 +18,21 @@ COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y                   
 # RUN     | fv3_ccpp_rrfs_v1beta_coldstart                                         | standard    |                |             |
 # The following test does NOT reproduce the control baseline
 #RUN     | fv3_ccpp_rrfs_v1beta_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1beta_coldstart
+RUN     | fv3_ccpp_rrfs_v1alpha                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_coldstart                                         | standard    |                |             |
+# The following test does NOT reproduce the control baseline - maybe, need to check
+#RUN     | fv3_ccpp_rrfs_v1alpha_warmstart                                         | standard    |                |             | fv3_ccpp_rrfs_v1alpha_coldstart
 RUN     | fv3_ccpp_gfs_v15p2                                                     | standard    |                | fv3         |
 
 ###############################################################################################################################
 # CCPP DEBUG TESTS                                                                                                            #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y            | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y | standard    |                | fv3         |
 
-RUN     | fv3_ccpp_regional_control_debug                                        | standard    |                | fv3         |
+RUN     | fv3_ccpp_regional_control_debug                                              | standard    |                | fv3         |
 # The following test does NOT run because of the error "FATAL from PE     0: ==> External_ic::get_nggps_ic: more NGGPS tracers than defined in field_table gfs_ctrl.nc for NGGPS IC"
-#RUN     | fv3_ccpp_regional_v15p2_debug                                          | standard    |                | fv3         |
-RUN     | fv3_ccpp_rrfs_v1beta_debug                                             | standard    |                | fv3         |
-RUN     | fv3_ccpp_gfs_v15p2_debug                                               | standard    |                | fv3         |
+#RUN     | fv3_ccpp_regional_v15p2_debug                                                | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1beta_debug                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1alpha_debug                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_gfs_v15p2_debug                                                     | standard    |                | fv3         |

--- a/tests/tests/fv3_ccpp_rrfs_v1alpha
+++ b/tests/tests/fv3_ccpp_rrfs_v1alpha
@@ -1,0 +1,125 @@
+###############################################################################
+#
+#  FV3 CCPP RRFS (Thompson MP + MYNN PBL + NOAH LSM + GFS SFC) test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP RRFS_v1alpha results with previous trunk version"
+
+export CNTL_DIR=fv3_rrfs_v1alpha
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf012.tile1.nc \
+                   phyf012.tile2.nc \
+                   phyf012.tile3.nc \
+                   phyf012.tile4.nc \
+                   phyf012.tile5.nc \
+                   phyf012.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf012.tile1.nc \
+                   dynf012.tile2.nc \
+                   dynf012.tile3.nc \
+                   dynf012.tile4.nc \
+                   dynf012.tile5.nc \
+                   dynf012.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export FHMAX=24
+export FDIAG=3
+
+export DT_ATMOS="600"
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_RRFS_v1alpha
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_global.nml.IN
+
+# Thompson microphysics
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+export NWAT=6
+export EFFR_IN=.T.
+
+# Ozone / stratospheric H2O
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+
+# Other namelist switches
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=-1
+export IMFDEEPCNV=-1
+export FHCYC=0
+export LSM=1
+#export LSOIL_LSM=4
+#export GWD_OPT=3
+#export DO_MYNNSFCLAY=.T.
+
+RUN_SCRIPT=rt_fv3.sh
+

--- a/tests/tests/fv3_ccpp_rrfs_v1alpha_coldstart
+++ b/tests/tests/fv3_ccpp_rrfs_v1alpha_coldstart
@@ -1,0 +1,74 @@
+###############################################################################
+#
+#  FV3 CCPP RRFS (Thompson MP + MYNN PBL + NOAH LSM + GFS SFC) test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP RRFS_v1alpha results with previous trunk version"
+
+export CNTL_DIR=fv3_rrfs_v1alpha
+
+export LIST_FILES="phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf012.tile1.nc \
+                   phyf012.tile2.nc \
+                   phyf012.tile3.nc \
+                   phyf012.tile4.nc \
+                   phyf012.tile5.nc \
+                   phyf012.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf012.tile1.nc \
+                   dynf012.tile2.nc \
+                   dynf012.tile3.nc \
+                   dynf012.tile4.nc \
+                   dynf012.tile5.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export FHMAX=12
+export FDIAG=3
+
+export DT_ATMOS="600"
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_RRFS_v1alpha
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_global.nml.IN
+
+# Thompson microphysics
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+export NWAT=6
+export EFFR_IN=.T.
+
+# Ozone / stratospheric H2O
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+
+# Other namelist switches
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=-1
+export IMFDEEPCNV=-1
+export FHCYC=0
+export LSM=1
+#export LSOIL_LSM=4
+#export GWD_OPT=3
+#export DO_MYNNSFCLAY=.T.
+
+RUN_SCRIPT=rt_fv3.sh
+

--- a/tests/tests/fv3_ccpp_rrfs_v1alpha_debug
+++ b/tests/tests/fv3_ccpp_rrfs_v1alpha_debug
@@ -1,0 +1,114 @@
+##########################################################################################
+#
+#  FV3 CCPP RRFS (Thompson MP + MYNN PBL + NOAH LSM + GFS SFC) test in DEBUG mode
+#
+##########################################################################################
+
+export TEST_DESCR="Compare FV3 CCPP RRFS_v1alpha DEBUG results with previous trunk version"
+
+export CNTL_DIR=fv3_rrfs_v1alpha_debug
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf003.tile1.nc \
+                   phyf003.tile2.nc \
+                   phyf003.tile3.nc \
+                   phyf003.tile4.nc \
+                   phyf003.tile5.nc \
+                   phyf003.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf003.tile1.nc \
+                   dynf003.tile2.nc \
+                   dynf003.tile3.nc \
+                   dynf003.tile4.nc \
+                   dynf003.tile5.nc \
+                   dynf003.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export FHMAX=3
+export FDIAG=3
+
+export DT_ATMOS="600"
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_RRFS_v1alpha
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_global.nml.IN
+
+# Thompson microphysics
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+export NWAT=6
+export EFFR_IN=.T.
+
+# Ozone / stratospheric H2O
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+
+# Other namelist switches
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=-1
+export IMFDEEPCNV=-1
+export FHCYC=0
+export LSM=1
+#export LSOIL_LSM=4
+#export GWD_OPT=3
+#export DO_MYNNSFCLAY=.T.
+
+RUN_SCRIPT=rt_fv3.sh
+
+export WLCLK=30

--- a/tests/tests/fv3_ccpp_rrfs_v1alpha_warmstart
+++ b/tests/tests/fv3_ccpp_rrfs_v1alpha_warmstart
@@ -1,0 +1,109 @@
+###############################################################################
+#
+#  FV3 CCPP RRFS (Thompson MP + MYNN PBL + NOAH LSM + GFS SFC) test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP RRFS_v1alpha results with previous trunk version"
+
+export CNTL_DIR=fv3_rrfs_v1alpha
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export WARM_START=.T.
+export NGGPS_IC=.F.
+export EXTERNAL_IC=.F.
+export MAKE_NH=.F.
+export MOUNTAIN=.T.
+export NA_INIT=0
+export NSTF_NAME=2,0,1,0,5
+
+export FHMAX=24
+export FDIAG=3
+
+export DT_ATMOS="600"
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_RRFS_v1alpha
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_global.nml.IN
+
+# Thompson microphysics
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+export NWAT=6
+export EFFR_IN=.T.
+
+# Ozone / stratospheric H2O
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+
+# Other namelist switches
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=-1
+export IMFDEEPCNV=-1
+export FHCYC=0
+export LSM=1
+#export LSOIL_LSM=4
+#export GWD_OPT=3
+#export DO_MYNNSFCLAY=.T.
+
+RUN_SCRIPT=rt_fv3.sh
+


### PR DESCRIPTION
## Description

- add regression tests for new suite FV3_RRFS_v1alpha
- remove redundant `effr_in=.true.` from namelist templates
- change `NEW_BASELINE` in rt.sh to avoid conflicts when creating new baselines for release/public-v2 and develop at the same time

## Testing

Regression tests were run on the following platforms as for the previous release/public-v2 PRs: cheyenne.{gnu,intel}, hera.{gnu,intel}, jet.intel, gaea.intel. Logs updated in the PR.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/518
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/61
https://github.com/NOAA-EMC/fv3atm/pull/197
https://github.com/ufs-community/ufs-weather-model/pull/276