### PR TITLE
Adding a regression test "cpld_bmark_wave_frac"

### DIFF
--- a/tests/fv3_conf/cpld_bmark_run.IN
+++ b/tests/fv3_conf/cpld_bmark_run.IN
@@ -9,7 +9,13 @@ fi
 ICERES="${OCNRES:0:1}.${OCNRES:1}"
 
 BM_IC=BM_IC/${SYEAR}${SMONTH}${SDAY}${SHOUR}
-FV3_IC=${BM_IC}/gfs/@[ATMRES]/INPUT
+if [ ${FRAC_GRID_INPUT} = .F. ]; then
+  FV3_IC=${BM_IC}/gfs/@[ATMRES]/INPUT
+elif [ @[NPZ] == 127 ]; then
+  FV3_IC=FV3_input_frac/${BM_IC}/gfs/@[ATMRES]_L@[NPZ]/INPUT
+else
+  FV3_IC=FV3_input_frac/${BM_IC}/gfs/@[ATMRES]/INPUT
+fi
 MOM6_IC=${BM_IC}/mom6_da
 CICE_IC=${BM_IC}/cpc
 WW3_IC=${BM_IC}/ww3
@@ -29,9 +35,19 @@ cp    @[INPUTDATA_ROOT]/${FV3_DIR}/*grb .
 cp    @[INPUTDATA_ROOT]/${FV3_DIR}/@[FIELD_TABLE] ./field_table
 cp    @[INPUTDATA_ROOT]/CPL_FIX/a@[ATMRES]o@[OCNRES]/grid_spec.nc ./INPUT
 cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/@[ATMRES]_grid*.nc ./INPUT
-cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/oro_data*.nc ./INPUT
+if [ ${FRAC_GRID_INPUT} = .F. ]; then
+  cp  @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/oro_data*.nc ./INPUT
+else
+  cp  @[INPUTDATA_ROOT]/FV3_input_frac/@[ATMRES].mx@[OCNRES]_frac/oro_data*.nc ./INPUT
+fi
+
 cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/grid_spec.nc ./INPUT/@[ATMRES]_mosaic.nc
-cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/gfs_ctrl.nc ./INPUT
+if [ $NPZ == 127 ]; then
+  cp  @[INPUTDATA_ROOT]/FV3_input_data_127/INPUT/gfs_ctrl.nc ./INPUT
+else
+  cp  @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/gfs_ctrl.nc ./INPUT
+fi
+
 
 # MOM6 fixed input
 cp    @[INPUTDATA_ROOT]/MOM6_FIX/@[OCNRES]/* ./INPUT

--- a/tests/fv3_conf/cpld_control_run.IN
+++ b/tests/fv3_conf/cpld_control_run.IN
@@ -1,7 +1,11 @@
 mkdir INPUT RESTART history MOM6_OUTPUT
 
 if [[ $ATMRES == 'C96' ]]; then
+ if [ $NPZ == 127 ]; then
+  FV3_DIR=FV3_input_data_127
+ else
   FV3_DIR=FV3_input_data
+ fi
 else
   FV3_DIR=FV3_input_data${ATMRES#C}
 fi
@@ -29,7 +33,11 @@ else
   cp  @[INPUTDATA_ROOT]/FV3_input_frac/@[ATMRES].mx@[OCNRES]_frac/oro_data*.nc ./INPUT
 fi
 cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/grid_spec.nc ./INPUT/@[ATMRES]_mosaic.nc
-cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/gfs_ctrl.nc ./INPUT
+if [ $NPZ == 127 ]; then
+  cp  @[INPUTDATA_ROOT]/FV3_input_data_127/INPUT/gfs_ctrl.nc ./INPUT
+else
+  cp  @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT/gfs_ctrl.nc ./INPUT
+fi
 
 # MOM6 fixed input
 cp    @[INPUTDATA_ROOT]/MOM6_FIX/@[OCNRES]/* ./INPUT

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -401,7 +401,8 @@ else
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20201204}
 fi
 
-INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20201201/}
+#INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20201201/}
+ INPUTDATA_ROOT=/scratch2/BMC/gsd-fv3-dev/FV3-MOM6-CICE5/input-data-20201201_frac/
 
 shift $((OPTIND-1))
 [[ $# -gt 1 ]] && usage

--- a/tests/rt_frac.conf
+++ b/tests/rt_frac.conf
@@ -1,0 +1,3 @@
+COMPILE | CCPP=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled S2S=Y WW3=Y                  | standard | hera.intel orion.intel wcoss_dell_p3 | fv3 |
+#RUN     | cpld_bmark_wave                                                                                                     | standard | hera.intel orion.intel wcoss_dell_p3 | fv3 |
+RUN     | cpld_bmark_wave_frac                                                                                                 | standard | hera.intel orion.intel wcoss_dell_p3 | fv3 |

--- a/tests/tests/cpld_bmark_wave_frac
+++ b/tests/tests/cpld_bmark_wave_frac
@@ -1,0 +1,146 @@
+#
+#  cpld_bmark_wave_frac test
+#
+export TEST_DESCR="Fully coupled FV3-CCPP-MOM6-CICE-CMEPS-WW3-FRAC system - C384 MX025 - Benchmark test with waves"
+
+export CNTL_DIR="cpld_bmark_wave_frac"
+
+export LIST_FILES="phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   20130402.000000.out_grd.gwes_30m \
+                   20130402.000000.out_pnt.points \
+                   20130402.000000.restart.gwes_30m \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc \
+                   RESTART/MOM.res.nc \
+                   RESTART/MOM.res_1.nc \
+                   RESTART/MOM.res_2.nc \
+                   RESTART/MOM.res_3.nc \
+                   RESTART/iced.2013-04-02-00000.nc \
+                   RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc"
+
+export_fv3
+export_cpl
+
+export SYEAR="2013"
+export SMONTH="04"
+export SDAY="01"
+export SHOUR="00"
+
+export WLCLK=60
+
+export TASKS=$TASKS_cpl_wwav
+export TPN=$TPN_cpl_wwav
+export INPES=$INPES_cpl_wwav
+export JNPES=$JNPES_cpl_wwav
+export THRD=$THRD_cpl_wwav
+export WRTTASK_PER_GROUP=$WPG_cpl_wwav
+
+export med_petlist_bounds=$MPB_cpl_wwav
+export atm_petlist_bounds=$APB_cpl_wwav
+export ocn_petlist_bounds=$OPB_cpl_wwav
+export ice_petlist_bounds=$IPB_cpl_wwav
+export wav_petlist_bounds=$WPB_cpl_wwav
+
+# atm/ocn/ice resolution
+export ATMRES='C384'
+export NPX=385
+export NPY=385
+export IMO=1536
+export JMO=768
+
+export OCNRES='025'
+export ICERES='0.25'
+export NX_GLB=1440
+export NY_GLB=1080
+export NPROC_ICE='48'
+
+# set component and coupling timesteps
+export DT_ATMOS='450'
+export DT_CICE=${DT_ATMOS}
+export DT_DYNAM_MOM6='900'
+export DT_THERM_MOM6='1800'
+export CPL_SLOW=${DT_THERM_MOM6}
+export CPL_FAST=${DT_ATMOS}
+
+# nems.configure
+export NEMS_CONFIGURE="nems.configure.cpld_wave.IN"
+export coupling_interval_slow_sec=${CPL_SLOW}
+export coupling_interval_fast_sec=${CPL_FAST}
+
+export FRAC_GRID_INPUT='.T.'
+export FRAC_GRID='.T.'
+export CPLMODE="nems_frac"
+
+export CPLWAV='.T.'
+export CPLWAV2ATM='.T.'
+
+# resolution dependent files
+export MOM_INPUT="MOM_input_template_${OCNRES}"
+export MESHICE="mesh.mx${OCNRES}.nc"
+export CICEGRID="grid_cice_NEMS_mx${OCNRES}.nc"
+export CICEMASK="kmtu_cice_NEMS_mx${OCNRES}.nc"
+export CHLCLIM="seawifs-clim-1997-2010.${NX_GLB}x${NY_GLB}.v20180328.nc"
+export FRUNOFF="runoff.daitren.clim.${NX_GLB}x${NY_GLB}.v20180328.nc"
+
+export FNALBC="'global_snowfree_albedo.bosu.t766.1536.768.rg.grb',"
+export FNVETC="'global_vegtype.igbp.t766.1536.768.rg.grb',"
+export FNSOTC="'global_soiltype.statsgo.t766.1536.768.rg.grb',"
+export FNSMCC="'global_soilmgldas.statsgo.t766.1536.768.grb',"
+export FNABSC="'global_mxsnoalb.uariz.t766.1536.768.rg.grb',"
+
+export OZ_PHYS_NEW=".T."
+
+export MOM6_USE_WAVES='True'
+export MOM6_RIVER_RUNOFF='True'
+export MOM6_RESTART_SETTING="r"
+export MOM6_REPRO_LA='True'
+
+export RUNID="cpcice"
+
+export INPUT_NML=input.benchmark_ccpp.nml.IN
+
+export FIELD_TABLE="field_table.gfdlmp"
+export SUITE_NAME="FV3_GFS_v15p2_coupled"
+
+export FV3_RUN=cpld_bmark_run.IN

--- a/tests/tests/cpld_bmark_wave_frac_35d
+++ b/tests/tests/cpld_bmark_wave_frac_35d
@@ -1,0 +1,108 @@
+#
+#  cpld_bmark_wave_frac 35D
+#
+export TEST_DESCR="Fully coupled FV3-CCPP-MOM6-CICE-CMEPS-WW3-FRAC system - C384 MX025 - Benchmark 35d test with waves"
+
+export_35d_run
+export_fv3
+export_cpl
+
+export SYEAR
+export SMONTH
+export SDAY="01"
+export SHOUR="00"
+
+export DAYS="35"
+export FHMAX="840"
+export RESTART_N=${FHMAX}
+export WLCLK=480
+
+#export TASKS=$TASKS_cpl_wwav
+#export TPN=$TPN_cpl_wwav
+#export INPES=$INPES_cpl_wwav
+#export JNPES=$JNPES_cpl_wwav
+#export THRD=$THRD_cpl_wwav
+#export WRTTASK_PER_GROUP=$WPG_cpl_wwav
+
+#export med_petlist_bounds=$MPB_cpl_wwav
+#export atm_petlist_bounds=$APB_cpl_wwav
+#export ocn_petlist_bounds=$OPB_cpl_wwav
+#export ice_petlist_bounds=$IPB_cpl_wwav
+#export wav_petlist_bounds=$WPB_cpl_wwav
+
+export TASKS=866
+export TPN=40
+export INPES=6
+export JNPES=12
+export THRD=1
+export WRTTASK_PER_GROUP=24
+
+export med_petlist_bounds="0 431"
+export atm_petlist_bounds="0 455"
+export ocn_petlist_bounds="456 695"
+export ice_petlist_bounds="696 743"
+export wav_petlist_bounds="744 865"
+
+# atm/ocn/ice resolution
+export ATMRES='C384'
+export NPX=385
+export NPY=385
+export IMO=1536
+export JMO=768
+
+export OCNRES='025'
+export ICERES='0.25'
+export NX_GLB=1440
+export NY_GLB=1080
+export NPROC_ICE='48'
+
+# set component and coupling timesteps
+export DT_ATMOS='450'
+export DT_CICE=${DT_ATMOS}
+export DT_DYNAM_MOM6='900'
+export DT_THERM_MOM6='1800'
+export CPL_SLOW=${DT_THERM_MOM6}
+export CPL_FAST=${DT_ATMOS}
+
+# nems.configure
+export NEMS_CONFIGURE="nems.configure.cpld_wave.IN"
+export coupling_interval_slow_sec=${CPL_SLOW}
+export coupling_interval_fast_sec=${CPL_FAST}
+
+export FRAC_GRID_INPUT='.T.'
+export FRAC_GRID='.T.'
+export CPLMODE="nems_frac"
+
+export CPLWAV='.T.'
+export CPLWAV2ATM='.T.'
+
+# resolution dependent files
+export MOM_INPUT="MOM_input_template_${OCNRES}"
+export MESHICE="mesh.mx${OCNRES}.nc"
+export CICEGRID="grid_cice_NEMS_mx${OCNRES}.nc"
+export CICEMASK="kmtu_cice_NEMS_mx${OCNRES}.nc"
+export CHLCLIM="seawifs-clim-1997-2010.${NX_GLB}x${NY_GLB}.v20180328.nc"
+export FRUNOFF="runoff.daitren.clim.${NX_GLB}x${NY_GLB}.v20180328.nc"
+
+export FNALBC="'global_snowfree_albedo.bosu.t766.1536.768.rg.grb',"
+export FNVETC="'global_vegtype.igbp.t766.1536.768.rg.grb',"
+export FNSOTC="'global_soiltype.statsgo.t766.1536.768.rg.grb',"
+export FNSMCC="'global_soilmgldas.statsgo.t766.1536.768.grb',"
+export FNABSC="'global_mxsnoalb.uariz.t766.1536.768.rg.grb',"
+
+export OZ_PHYS_NEW=".T."
+
+export MOM6_USE_WAVES='True'
+export MOM6_RIVER_RUNOFF='True'
+export MOM6_RESTART_SETTING="r"
+export MOM6_REPRO_LA='True'
+
+export RUNID="cpcice"
+
+export INPUT_NML=input.benchmark_ccpp.nml.IN
+
+export FIELD_TABLE="field_table.gfdlmp"
+export SUITE_NAME="FV3_GFS_v15p2_coupled"
+
+export RT35D='.T.'
+export FV3_RUN=cpld_bmark_run.IN


### PR DESCRIPTION
This is a benchmark regression test for C384L64, based on "cpld_bmark_wave", where rt.sh points to a temporary data dir /scratch2/BMC/gsd-fv3-dev/FV3-MOM6-CICE5/input-data-20201201_frac/FV3_input_frac/, until these data are copied to the default path. 

This refers to Issue #285.
