### PR TITLE
release/public-v2: bugfixes for GNU 10 crashes, update modulefile for cheyenne.gnu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v2
-	url = https://github.com/climbfuji/fv3atm
-	branch = release_public_v2_gnu10_crashes
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v2
+	url = https://github.com/climbfuji/fv3atm
+	branch = release_public_v2_gnu10_crashes
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/modulefiles/cheyenne.gnu/fv3
+++ b/modulefiles/cheyenne.gnu/fv3
@@ -16,14 +16,14 @@ module-whatis "loads NEMS FV3 prerequisites for Cheyenne/GNU"
 ## this typically includes compiler, MPI and job scheduler
 ##
 module load ncarenv/1.3
-module load gnu/9.1.0
+module load gnu/10.1.0
 module load mpt/2.19
 module load ncarcompilers/0.5.0
 
 ##
 ## use pre-compiled NetCDF, ESMF and NCEP libraries for above compiler / MPI combination
 ##
-module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19/modules
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-10.1.0/mpt-2.19/modules
 module load NCEPLIBS/2.0.0
 
 ##

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Dec  2 15:53:40 MST 2020
+Mon Jan  4 15:59:41 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_52813/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Dec  2 16:10:13 MST 2020
-Elapsed time: 00h:16m:33s. Have a nice day!
+Mon Jan  4 16:15:21 MST 2021
+Elapsed time: 00h:15m:40s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Dec  2 15:49:47 MST 2020
+Mon Jan  4 16:06:56 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_16797/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Dec  2 16:24:51 MST 2020
-Elapsed time: 00h:35m:04s. Have a nice day!
+Mon Jan  4 16:42:04 MST 2021
+Elapsed time: 00h:35m:09s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Wed Dec  2 21:54:32 EST 2020
+Mon Jan  4 22:26:50 EST 2021
 Start Regression test
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_coldstart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_v15p2_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_control_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_6127/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Dec  2 23:28:41 EST 2020
-Elapsed time: 01h:34m:10s. Have a nice day!
+Tue Jan  5 00:00:18 EST 2021
+Elapsed time: 01h:33m:29s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Thu Dec  3 16:41:01 UTC 2020
+Tue Jan  5 03:25:49 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_control_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_297846/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Dec  3 17:53:50 UTC 2020
-Elapsed time: 01h:12m:51s. Have a nice day!
+Tue Jan  5 04:33:25 UTC 2021
+Elapsed time: 01h:07m:37s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Dec  2 23:07:33 UTC 2020
+Tue Jan  5 03:25:48 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_control_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_179366/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Dec  2 23:26:02 UTC 2020
-Elapsed time: 00h:18m:32s. Have a nice day!
+Tue Jan  5 03:43:10 UTC 2021
+Elapsed time: 00h:17m:23s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Thu Dec  3 02:51:08 GMT 2020
+Tue Jan  5 03:26:28 GMT 2021
 Start Regression test
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_control_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_2threads_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_coldstart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_v15p2_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_control_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_regional_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20201202/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_211719/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Dec  3 03:52:05 GMT 2020
-Elapsed time: 01h:01m:00s. Have a nice day!
+Tue Jan  5 04:31:57 GMT 2021
+Elapsed time: 01h:05m:31s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -418,9 +418,9 @@ if [[ $SINGLE_NAME != '' ]]; then
 fi
 
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201202/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210104/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20201202}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210104}
 fi
 
 shift $((OPTIND-1))


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for fv3atm and ccpp-physics to fix crashes of the model run with GNU 10. It also updates the modulefile for cheyenne.gnu to use GNU 10.1.0 instead of GNU 9.1.0 so that we have one tier-1 platform for the UFS SRW App release that uses the GNU 10 compilers.

### Issue(s) addressed

These PRs address step 2 of https://github.com/ufs-community/ufs-weather-model/issues/288 (but not step 1).

## Testing

With these changes, all regression tests pass with GNU 10.1.0 on Cheyenne (create new baseline and verify against it).

Regression tests passed on all tier-1 platforms for the release/public-v2 branch, logs updated in the PR.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/540
https://github.com/NOAA-EMC/fv3atm/pull/221
https://github.com/ufs-community/ufs-weather-model/pull/355
