### PR TITLE
release/public-v2: cherry-pick gfs.v16 update dz_min

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/llpcarson/fv3atm
-	branch = update_dz_min
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	url = https://github.com/llpcarson/fv3atm
+	branch = update_dz_min
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Mon Jan  4 15:59:41 MST 2021
+Wed Jan  6 14:24:41 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_25903/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan  4 16:15:21 MST 2021
-Elapsed time: 00h:15m:40s. Have a nice day!
+Wed Jan  6 16:02:14 MST 2021
+Elapsed time: 01h:37m:33s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Mon Jan  4 16:06:56 MST 2021
+Tue Jan  5 15:53:41 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_55231/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan  4 16:42:04 MST 2021
-Elapsed time: 00h:35m:09s. Have a nice day!
+Tue Jan  5 17:31:13 MST 2021
+Elapsed time: 01h:37m:33s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Mon Jan  4 22:26:50 EST 2021
+Thu Jan  7 12:43:26 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_control_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_31284/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jan  5 00:00:18 EST 2021
-Elapsed time: 01h:33m:29s. Have a nice day!
+Thu Jan  7 14:19:32 EST 2021
+Elapsed time: 01h:36m:07s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Tue Jan  5 03:25:49 UTC 2021
+Thu Jan  7 23:28:15 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_13599/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jan  5 04:33:25 UTC 2021
-Elapsed time: 01h:07m:37s. Have a nice day!
+Fri Jan  8 00:35:44 UTC 2021
+Elapsed time: 01h:07m:30s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Tue Jan  5 03:25:48 UTC 2021
+Wed Jan  6 20:21:45 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_2threads_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_coldstart_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_v15p2_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_120009/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jan  5 03:43:10 UTC 2021
-Elapsed time: 00h:17m:23s. Have a nice day!
+Thu Jan  7 00:24:49 UTC 2021
+Elapsed time: 04h:03m:06s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Tue Jan  5 03:26:28 GMT 2021
+Thu Jan  7 17:43:05 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_control_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_177881/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jan  5 04:31:57 GMT 2021
-Elapsed time: 01h:05m:31s. Have a nice day!
+Thu Jan  7 18:44:48 GMT 2021
+Elapsed time: 01h:01m:45s. Have a nice day!


### PR DESCRIPTION
## Description

The code changes in fv3 dycore were made to resolve the instability issue.  #211


### Issue(s) addressed


## Testing

Regression tests completed successfully for hera.intel, cheyenne.intel and cheyenne.gnu

## Dependencies

GFDL_atmos_cubed_sphere: https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/63
fv3atm: https://github.com/NOAA-EMC/fv3atm/pull/223


