### PR TITLE
production/GFS.v16: reduce initialization time on atm wave connector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/junwang-noaa/fv3atm
-	branch = reduce_inittime
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = production/GFS.v16
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = production/GFS.v16
+	url = https://github.com/junwang-noaa/fv3atm
+	branch = reduce_inittime
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description

There is a request to further reduce the time taken in the model initialization for GFS.v16 implementation, especially the initialization time on atm-wave connector becomes longer when larger number of nodes are used. Following the suggestion from ESMF group, the number of export/import fields in fv3 and ww3 have been reduced to the coupled fields required by atm->ww3.


### Issue(s) addressed
ufs-weather-model issue[ #362](https://github.com/ufs-community/ufs-weather-model/issues/362)

## Testing

Tests have been done on hera and wcoss. On hera, the tests were done with 152 nodes, 3s improvement is seen. On wcoss, Fanglin's test shows 20s improves with 220 nodes. The code changes have no impact on model results.

## Dependencies

- fv3atm [PR#228](https://github.com/NOAA-EMC/fv3atm/pull/228)
- WW3 [PR #295](https://github.com/NOAA-EMC/WW3/pull/295)
- -ufs-weather-model [PR#363](https://github.com/ufs-community/ufs-weather-model/pull/363)