### PR TITLE
point fv3 to EMC develop branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = remove_ipd_step3_and_5
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description

Fix the fv3 submodule to point to the EMC develop branch

## Dependencies

This is to fix the fv3 submodule link in previous PR [#357](https://github.com/ufs-community/ufs-weather-model/pull/357)