### PR TITLE
Updated submodule for "Added new logical flag do_ugwp_v0_nst_only"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/mdtoy/fv3atm
+  branch = unified_ugwp_jan_2021_update
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
Added new logical flag do_ugwp_v0_nst_only which allows non-stationary drag from ugwp_v0 to be run with GSL drag suite.

Note:  The same regression tests as before can be used.
