### PR TITLE
release/public-v2: noahmp_bugfix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/llpcarson/fv3atm
-	branch = public_release_v5_noahmp_bugfix
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	url = https://github.com/llpcarson/fv3atm
+	branch = public_release_v5_noahmp_bugfix
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Mon Jan 25 15:17:40 MST 2021
+Wed Jan 27 07:26:30 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 16:45:25 MST 2021
-Elapsed time: 01h:27m:45s. Have a nice day!
+Wed Jan 27 07:41:11 MST 2021
+Elapsed time: 00h:14m:42s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,576 +1,381 @@
-Wed Jan  6 14:24:41 MST 2021
+Mon Jan 25 10:08:08 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
+Moving baseline 001 fv3_ccpp_regional_control files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf006.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf006.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_2threads_prod
-Checking test 002 fv3_ccpp_regional_2threads results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 002 fv3_ccpp_regional_2threads PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_coldstart_prod
-Checking test 003 fv3_ccpp_regional_coldstart results ....
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
-Test 003 fv3_ccpp_regional_coldstart PASS
-
-
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_v15p2_prod
-Checking test 004 fv3_ccpp_regional_v15p2 results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 004 fv3_ccpp_regional_v15p2 PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_v15p2_prod
+Checking test 002 fv3_ccpp_regional_v15p2 results ....
+Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 002 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 005 fv3_ccpp_rrfs_v1alpha PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_decomp_prod
-Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_2threads_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_coldstart_prod
-Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
+Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf012.tile1.nc ......... OK
+ Moving phyf012.tile2.nc ......... OK
+ Moving phyf012.tile3.nc ......... OK
+ Moving phyf012.tile4.nc ......... OK
+ Moving phyf012.tile5.nc ......... OK
+ Moving phyf012.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf012.tile1.nc ......... OK
+ Moving dynf012.tile2.nc ......... OK
+ Moving dynf012.tile3.nc ......... OK
+ Moving dynf012.tile4.nc ......... OK
+ Moving dynf012.tile5.nc ......... OK
+ Moving dynf012.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 003 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_gfs_v15p2_prod
-Checking test 009 fv3_ccpp_gfs_v15p2 results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
-Test 009 fv3_ccpp_gfs_v15p2 PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_gfs_v15p2_prod
+Checking test 004 fv3_ccpp_gfs_v15p2 results ....
+Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+Test 004 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_control_debug_prod
-Checking test 010 fv3_ccpp_regional_control_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 010 fv3_ccpp_regional_control_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_control_debug_prod
+Checking test 005 fv3_ccpp_regional_control_debug results ....
+Moving baseline 005 fv3_ccpp_regional_control_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 005 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 011 fv3_ccpp_regional_v15p2_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
+Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 006 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
+Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf003.tile1.nc ......... OK
+ Moving phyf003.tile2.nc ......... OK
+ Moving phyf003.tile3.nc ......... OK
+ Moving phyf003.tile4.nc ......... OK
+ Moving phyf003.tile5.nc ......... OK
+ Moving phyf003.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf003.tile1.nc ......... OK
+ Moving dynf003.tile2.nc ......... OK
+ Moving dynf003.tile3.nc ......... OK
+ Moving dynf003.tile4.nc ......... OK
+ Moving dynf003.tile5.nc ......... OK
+ Moving dynf003.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_8365/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 013 fv3_ccpp_gfs_v15p2_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
+Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf006.tile1.nc ......... OK
+ Moving phyf006.tile2.nc ......... OK
+ Moving phyf006.tile3.nc ......... OK
+ Moving phyf006.tile4.nc ......... OK
+ Moving phyf006.tile5.nc ......... OK
+ Moving phyf006.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf006.tile1.nc ......... OK
+ Moving dynf006.tile2.nc ......... OK
+ Moving dynf006.tile3.nc ......... OK
+ Moving dynf006.tile4.nc ......... OK
+ Moving dynf006.tile5.nc ......... OK
+ Moving dynf006.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 008 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 16:02:14 MST 2021
-Elapsed time: 01h:37m:33s. Have a nice day!
+Mon Jan 25 10:55:53 MST 2021
+Elapsed time: 00h:48m:04s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,381 +1,576 @@
-Mon Jan 25 10:08:08 MST 2021
+Mon Jan 25 15:17:40 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_control_prod
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
-Moving baseline 001 fv3_ccpp_regional_control files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf006.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf006.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_v15p2_prod
-Checking test 002 fv3_ccpp_regional_v15p2 results ....
-Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 002 fv3_ccpp_regional_v15p2 PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_2threads_prod
+Checking test 002 fv3_ccpp_regional_2threads results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
-Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf012.tile1.nc ......... OK
- Moving phyf012.tile2.nc ......... OK
- Moving phyf012.tile3.nc ......... OK
- Moving phyf012.tile4.nc ......... OK
- Moving phyf012.tile5.nc ......... OK
- Moving phyf012.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf012.tile1.nc ......... OK
- Moving dynf012.tile2.nc ......... OK
- Moving dynf012.tile3.nc ......... OK
- Moving dynf012.tile4.nc ......... OK
- Moving dynf012.tile5.nc ......... OK
- Moving dynf012.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 003 fv3_ccpp_rrfs_v1alpha PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_coldstart_prod
+Checking test 003 fv3_ccpp_regional_coldstart results ....
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_gfs_v15p2_prod
-Checking test 004 fv3_ccpp_gfs_v15p2 results ....
-Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
-Test 004 fv3_ccpp_gfs_v15p2 PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_v15p2_prod
+Checking test 004 fv3_ccpp_regional_v15p2 results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_control_debug_prod
-Checking test 005 fv3_ccpp_regional_control_debug results ....
-Moving baseline 005 fv3_ccpp_regional_control_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 005 fv3_ccpp_regional_control_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
-Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 006 fv3_ccpp_regional_v15p2_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_decomp_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
-Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf003.tile1.nc ......... OK
- Moving phyf003.tile2.nc ......... OK
- Moving phyf003.tile3.nc ......... OK
- Moving phyf003.tile4.nc ......... OK
- Moving phyf003.tile5.nc ......... OK
- Moving phyf003.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf003.tile1.nc ......... OK
- Moving dynf003.tile2.nc ......... OK
- Moving dynf003.tile3.nc ......... OK
- Moving dynf003.tile4.nc ......... OK
- Moving dynf003.tile5.nc ......... OK
- Moving dynf003.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_2threads_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_53063/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
-Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf006.tile1.nc ......... OK
- Moving phyf006.tile2.nc ......... OK
- Moving phyf006.tile3.nc ......... OK
- Moving phyf006.tile4.nc ......... OK
- Moving phyf006.tile5.nc ......... OK
- Moving phyf006.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf006.tile1.nc ......... OK
- Moving dynf006.tile2.nc ......... OK
- Moving dynf006.tile3.nc ......... OK
- Moving dynf006.tile4.nc ......... OK
- Moving dynf006.tile5.nc ......... OK
- Moving dynf006.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 008 fv3_ccpp_gfs_v15p2_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_gfs_v15p2_prod
+Checking test 009 fv3_ccpp_gfs_v15p2 results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 009 fv3_ccpp_gfs_v15p2 PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_control_debug_prod
+Checking test 010 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 010 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 011 fv3_ccpp_regional_v15p2_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_17976/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 10:55:53 MST 2021
-Elapsed time: 00h:48m:04s. Have a nice day!
+Mon Jan 25 16:45:25 MST 2021
+Elapsed time: 01h:27m:45s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,381 +1,576 @@
-Mon Jan 25 12:04:15 MST 2021
+Mon Jan 25 13:32:57 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_control_prod
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
-Moving baseline 001 fv3_ccpp_regional_control files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf006.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf006.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_v15p2_prod
-Checking test 002 fv3_ccpp_regional_v15p2 results ....
-Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 002 fv3_ccpp_regional_v15p2 PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_2threads_prod
+Checking test 002 fv3_ccpp_regional_2threads results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
-Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf012.tile1.nc ......... OK
- Moving phyf012.tile2.nc ......... OK
- Moving phyf012.tile3.nc ......... OK
- Moving phyf012.tile4.nc ......... OK
- Moving phyf012.tile5.nc ......... OK
- Moving phyf012.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf012.tile1.nc ......... OK
- Moving dynf012.tile2.nc ......... OK
- Moving dynf012.tile3.nc ......... OK
- Moving dynf012.tile4.nc ......... OK
- Moving dynf012.tile5.nc ......... OK
- Moving dynf012.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 003 fv3_ccpp_rrfs_v1alpha PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_coldstart_prod
+Checking test 003 fv3_ccpp_regional_coldstart results ....
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_gfs_v15p2_prod
-Checking test 004 fv3_ccpp_gfs_v15p2 results ....
-Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
-Test 004 fv3_ccpp_gfs_v15p2 PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_v15p2_prod
+Checking test 004 fv3_ccpp_regional_v15p2 results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_control_debug_prod
-Checking test 005 fv3_ccpp_regional_control_debug results ....
-Moving baseline 005 fv3_ccpp_regional_control_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 005 fv3_ccpp_regional_control_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
-Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 006 fv3_ccpp_regional_v15p2_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_decomp_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
-Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf003.tile1.nc ......... OK
- Moving phyf003.tile2.nc ......... OK
- Moving phyf003.tile3.nc ......... OK
- Moving phyf003.tile4.nc ......... OK
- Moving phyf003.tile5.nc ......... OK
- Moving phyf003.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf003.tile1.nc ......... OK
- Moving dynf003.tile2.nc ......... OK
- Moving dynf003.tile3.nc ......... OK
- Moving dynf003.tile4.nc ......... OK
- Moving dynf003.tile5.nc ......... OK
- Moving dynf003.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_2threads_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
-Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
- mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf006.tile1.nc ......... OK
- Moving phyf006.tile2.nc ......... OK
- Moving phyf006.tile3.nc ......... OK
- Moving phyf006.tile4.nc ......... OK
- Moving phyf006.tile5.nc ......... OK
- Moving phyf006.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf006.tile1.nc ......... OK
- Moving dynf006.tile2.nc ......... OK
- Moving dynf006.tile3.nc ......... OK
- Moving dynf006.tile4.nc ......... OK
- Moving dynf006.tile5.nc ......... OK
- Moving dynf006.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 008 fv3_ccpp_gfs_v15p2_debug PASS
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_gfs_v15p2_prod
+Checking test 009 fv3_ccpp_gfs_v15p2 results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 009 fv3_ccpp_gfs_v15p2 PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_control_debug_prod
+Checking test 010 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 010 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 011 fv3_ccpp_regional_v15p2_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 13:13:09 MST 2021
-Elapsed time: 01h:09m:14s. Have a nice day!
+Mon Jan 25 15:16:15 MST 2021
+Elapsed time: 01h:43m:19s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Mon Jan 25 13:32:57 MST 2021
+Wed Jan 27 07:26:15 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_66671/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 15:16:15 MST 2021
-Elapsed time: 01h:43m:19s. Have a nice day!
+Wed Jan 27 08:02:35 MST 2021
+Elapsed time: 00h:36m:20s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,576 +1,381 @@
-Tue Jan  5 15:53:41 MST 2021
+Mon Jan 25 12:04:15 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
+Moving baseline 001 fv3_ccpp_regional_control files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf006.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf006.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_2threads_prod
-Checking test 002 fv3_ccpp_regional_2threads results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 002 fv3_ccpp_regional_2threads PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_coldstart_prod
-Checking test 003 fv3_ccpp_regional_coldstart results ....
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
-Test 003 fv3_ccpp_regional_coldstart PASS
-
-
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_v15p2_prod
-Checking test 004 fv3_ccpp_regional_v15p2 results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 004 fv3_ccpp_regional_v15p2 PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_v15p2_prod
+Checking test 002 fv3_ccpp_regional_v15p2 results ....
+Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 002 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 005 fv3_ccpp_rrfs_v1alpha PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_decomp_prod
-Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_2threads_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_coldstart_prod
-Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
+Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf012.tile1.nc ......... OK
+ Moving phyf012.tile2.nc ......... OK
+ Moving phyf012.tile3.nc ......... OK
+ Moving phyf012.tile4.nc ......... OK
+ Moving phyf012.tile5.nc ......... OK
+ Moving phyf012.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf012.tile1.nc ......... OK
+ Moving dynf012.tile2.nc ......... OK
+ Moving dynf012.tile3.nc ......... OK
+ Moving dynf012.tile4.nc ......... OK
+ Moving dynf012.tile5.nc ......... OK
+ Moving dynf012.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 003 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_gfs_v15p2_prod
-Checking test 009 fv3_ccpp_gfs_v15p2 results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
-Test 009 fv3_ccpp_gfs_v15p2 PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_gfs_v15p2_prod
+Checking test 004 fv3_ccpp_gfs_v15p2 results ....
+Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+Test 004 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_control_debug_prod
-Checking test 010 fv3_ccpp_regional_control_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 010 fv3_ccpp_regional_control_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_control_debug_prod
+Checking test 005 fv3_ccpp_regional_control_debug results ....
+Moving baseline 005 fv3_ccpp_regional_control_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 005 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 011 fv3_ccpp_regional_v15p2_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
+Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 006 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
+Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf003.tile1.nc ......... OK
+ Moving phyf003.tile2.nc ......... OK
+ Moving phyf003.tile3.nc ......... OK
+ Moving phyf003.tile4.nc ......... OK
+ Moving phyf003.tile5.nc ......... OK
+ Moving phyf003.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf003.tile1.nc ......... OK
+ Moving dynf003.tile2.nc ......... OK
+ Moving dynf003.tile3.nc ......... OK
+ Moving dynf003.tile4.nc ......... OK
+ Moving dynf003.tile5.nc ......... OK
+ Moving dynf003.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/carson/FV3_RT/rt_29863/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 013 fv3_ccpp_gfs_v15p2_debug PASS
+working dir  = /glade/scratch/carson/FV3_RT/rt_38823/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
+Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
+ mkdir -p /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf006.tile1.nc ......... OK
+ Moving phyf006.tile2.nc ......... OK
+ Moving phyf006.tile3.nc ......... OK
+ Moving phyf006.tile4.nc ......... OK
+ Moving phyf006.tile5.nc ......... OK
+ Moving phyf006.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf006.tile1.nc ......... OK
+ Moving dynf006.tile2.nc ......... OK
+ Moving dynf006.tile3.nc ......... OK
+ Moving dynf006.tile4.nc ......... OK
+ Moving dynf006.tile5.nc ......... OK
+ Moving dynf006.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 008 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jan  5 17:31:13 MST 2021
-Elapsed time: 01h:37m:33s. Have a nice day!
+Mon Jan 25 13:13:09 MST 2021
+Elapsed time: 01h:09m:14s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Thu Jan  7 12:43:26 EST 2021
+Wed Jan 27 11:12:08 EST 2021
 Start Regression test
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_coldstart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_v15p2_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_control_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3392/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jan  7 14:19:32 EST 2021
-Elapsed time: 01h:36m:07s. Have a nice day!
+Wed Jan 27 12:53:40 EST 2021
+Elapsed time: 01h:41m:33s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Thu Jan  7 23:28:15 UTC 2021
+Wed Jan 27 16:59:10 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_control_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_63585/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jan  8 00:35:44 UTC 2021
-Elapsed time: 01h:07m:30s. Have a nice day!
+Wed Jan 27 18:08:44 UTC 2021
+Elapsed time: 01h:09m:35s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,381 +1,576 @@
-Mon Jan 25 16:37:44 UTC 2021
+Mon Jan 25 20:35:43 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
-Moving baseline 001 fv3_ccpp_regional_control files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf006.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf006.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_v15p2_prod
-Checking test 002 fv3_ccpp_regional_v15p2 results ....
-Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf012.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf012.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 002 fv3_ccpp_regional_v15p2 PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_2threads_prod
+Checking test 002 fv3_ccpp_regional_2threads results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
-Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf012.tile1.nc ......... OK
- Moving phyf012.tile2.nc ......... OK
- Moving phyf012.tile3.nc ......... OK
- Moving phyf012.tile4.nc ......... OK
- Moving phyf012.tile5.nc ......... OK
- Moving phyf012.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf012.tile1.nc ......... OK
- Moving dynf012.tile2.nc ......... OK
- Moving dynf012.tile3.nc ......... OK
- Moving dynf012.tile4.nc ......... OK
- Moving dynf012.tile5.nc ......... OK
- Moving dynf012.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 003 fv3_ccpp_rrfs_v1alpha PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_coldstart_prod
+Checking test 003 fv3_ccpp_regional_coldstart results ....
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_gfs_v15p2_prod
-Checking test 004 fv3_ccpp_gfs_v15p2 results ....
-Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf024.tile1.nc ......... OK
- Moving phyf024.tile2.nc ......... OK
- Moving phyf024.tile3.nc ......... OK
- Moving phyf024.tile4.nc ......... OK
- Moving phyf024.tile5.nc ......... OK
- Moving phyf024.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf024.tile1.nc ......... OK
- Moving dynf024.tile2.nc ......... OK
- Moving dynf024.tile3.nc ......... OK
- Moving dynf024.tile4.nc ......... OK
- Moving dynf024.tile5.nc ......... OK
- Moving dynf024.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
-Test 004 fv3_ccpp_gfs_v15p2 PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_v15p2_prod
+Checking test 004 fv3_ccpp_regional_v15p2 results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf012.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf012.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_control_debug_prod
-Checking test 005 fv3_ccpp_regional_control_debug results ....
-Moving baseline 005 fv3_ccpp_regional_control_debug files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 005 fv3_ccpp_regional_control_debug PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
-Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.nc ......... OK
- Moving phyf000.nc ......... OK
- Moving phyf001.nc ......... OK
- Moving dynf000.nc ......... OK
- Moving dynf001.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/sfc_data.nc ......... OK
- Moving RESTART/phy_data.nc ......... OK
-Test 006 fv3_ccpp_regional_v15p2_debug PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_decomp_prod
+Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
-Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf003.tile1.nc ......... OK
- Moving phyf003.tile2.nc ......... OK
- Moving phyf003.tile3.nc ......... OK
- Moving phyf003.tile4.nc ......... OK
- Moving phyf003.tile5.nc ......... OK
- Moving phyf003.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf003.tile1.nc ......... OK
- Moving dynf003.tile2.nc ......... OK
- Moving dynf003.tile3.nc ......... OK
- Moving dynf003.tile4.nc ......... OK
- Moving dynf003.tile5.nc ......... OK
- Moving dynf003.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_2threads_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+ Comparing dynf012.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
-Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
- mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp/RESTART
- Moving atmos_4xdaily.tile1.nc ......... OK
- Moving atmos_4xdaily.tile2.nc ......... OK
- Moving atmos_4xdaily.tile3.nc ......... OK
- Moving atmos_4xdaily.tile4.nc ......... OK
- Moving atmos_4xdaily.tile5.nc ......... OK
- Moving atmos_4xdaily.tile6.nc ......... OK
- Moving phyf000.tile1.nc ......... OK
- Moving phyf000.tile2.nc ......... OK
- Moving phyf000.tile3.nc ......... OK
- Moving phyf000.tile4.nc ......... OK
- Moving phyf000.tile5.nc ......... OK
- Moving phyf000.tile6.nc ......... OK
- Moving phyf006.tile1.nc ......... OK
- Moving phyf006.tile2.nc ......... OK
- Moving phyf006.tile3.nc ......... OK
- Moving phyf006.tile4.nc ......... OK
- Moving phyf006.tile5.nc ......... OK
- Moving phyf006.tile6.nc ......... OK
- Moving dynf000.tile1.nc ......... OK
- Moving dynf000.tile2.nc ......... OK
- Moving dynf000.tile3.nc ......... OK
- Moving dynf000.tile4.nc ......... OK
- Moving dynf000.tile5.nc ......... OK
- Moving dynf000.tile6.nc ......... OK
- Moving dynf006.tile1.nc ......... OK
- Moving dynf006.tile2.nc ......... OK
- Moving dynf006.tile3.nc ......... OK
- Moving dynf006.tile4.nc ......... OK
- Moving dynf006.tile5.nc ......... OK
- Moving dynf006.tile6.nc ......... OK
- Moving RESTART/coupler.res ......... OK
- Moving RESTART/fv_core.res.nc ......... OK
- Moving RESTART/fv_core.res.tile1.nc ......... OK
- Moving RESTART/fv_core.res.tile2.nc ......... OK
- Moving RESTART/fv_core.res.tile3.nc ......... OK
- Moving RESTART/fv_core.res.tile4.nc ......... OK
- Moving RESTART/fv_core.res.tile5.nc ......... OK
- Moving RESTART/fv_core.res.tile6.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
- Moving RESTART/fv_tracer.res.tile1.nc ......... OK
- Moving RESTART/fv_tracer.res.tile2.nc ......... OK
- Moving RESTART/fv_tracer.res.tile3.nc ......... OK
- Moving RESTART/fv_tracer.res.tile4.nc ......... OK
- Moving RESTART/fv_tracer.res.tile5.nc ......... OK
- Moving RESTART/fv_tracer.res.tile6.nc ......... OK
- Moving RESTART/phy_data.tile1.nc ......... OK
- Moving RESTART/phy_data.tile2.nc ......... OK
- Moving RESTART/phy_data.tile3.nc ......... OK
- Moving RESTART/phy_data.tile4.nc ......... OK
- Moving RESTART/phy_data.tile5.nc ......... OK
- Moving RESTART/phy_data.tile6.nc ......... OK
- Moving RESTART/sfc_data.tile1.nc ......... OK
- Moving RESTART/sfc_data.tile2.nc ......... OK
- Moving RESTART/sfc_data.tile3.nc ......... OK
- Moving RESTART/sfc_data.tile4.nc ......... OK
- Moving RESTART/sfc_data.tile5.nc ......... OK
- Moving RESTART/sfc_data.tile6.nc ......... OK
-Test 008 fv3_ccpp_gfs_v15p2_debug PASS
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf012.tile1.nc .........OK
+ Comparing phyf012.tile2.nc .........OK
+ Comparing phyf012.tile3.nc .........OK
+ Comparing phyf012.tile4.nc .........OK
+ Comparing phyf012.tile5.nc .........OK
+ Comparing phyf012.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf012.tile1.nc .........OK
+ Comparing dynf012.tile2.nc .........OK
+ Comparing dynf012.tile3.nc .........OK
+ Comparing dynf012.tile4.nc .........OK
+ Comparing dynf012.tile5.nc .........OK
+Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_gfs_v15p2_prod
+Checking test 009 fv3_ccpp_gfs_v15p2 results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 009 fv3_ccpp_gfs_v15p2 PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_control_debug_prod
+Checking test 010 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 010 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/sfc_data.nc .........OK
+ Comparing RESTART/phy_data.nc .........OK
+Test 011 fv3_ccpp_regional_v15p2_debug PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+
+
+baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 17:37:09 UTC 2021
-Elapsed time: 00h:59m:49s. Have a nice day!
+Mon Jan 25 22:10:56 UTC 2021
+Elapsed time: 01h:35m:14s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,576 +1,381 @@
-Wed Jan  6 20:21:45 UTC 2021
+Mon Jan 25 16:37:44 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
+Moving baseline 001 fv3_ccpp_regional_control files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf006.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf006.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_2threads_prod
-Checking test 002 fv3_ccpp_regional_2threads results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 002 fv3_ccpp_regional_2threads PASS
-
-
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_coldstart_prod
-Checking test 003 fv3_ccpp_regional_coldstart results ....
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf006.nc .........OK
-Test 003 fv3_ccpp_regional_coldstart PASS
-
-
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_v15p2_prod
-Checking test 004 fv3_ccpp_regional_v15p2 results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf012.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf012.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 004 fv3_ccpp_regional_v15p2 PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_v15p2_prod
+Checking test 002 fv3_ccpp_regional_v15p2 results ....
+Moving baseline 002 fv3_ccpp_regional_v15p2 files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf012.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf012.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 002 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_prod
-Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 005 fv3_ccpp_rrfs_v1alpha PASS
-
-
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_decomp_prod
-Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
-
-
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_2threads_prod
-Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
- Comparing dynf012.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
-
-
-baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_coldstart_prod
-Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf012.tile1.nc .........OK
- Comparing phyf012.tile2.nc .........OK
- Comparing phyf012.tile3.nc .........OK
- Comparing phyf012.tile4.nc .........OK
- Comparing phyf012.tile5.nc .........OK
- Comparing phyf012.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf012.tile1.nc .........OK
- Comparing dynf012.tile2.nc .........OK
- Comparing dynf012.tile3.nc .........OK
- Comparing dynf012.tile4.nc .........OK
- Comparing dynf012.tile5.nc .........OK
-Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_rrfs_v1alpha_prod
+Checking test 003 fv3_ccpp_rrfs_v1alpha results ....
+Moving baseline 003 fv3_ccpp_rrfs_v1alpha files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf012.tile1.nc ......... OK
+ Moving phyf012.tile2.nc ......... OK
+ Moving phyf012.tile3.nc ......... OK
+ Moving phyf012.tile4.nc ......... OK
+ Moving phyf012.tile5.nc ......... OK
+ Moving phyf012.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf012.tile1.nc ......... OK
+ Moving dynf012.tile2.nc ......... OK
+ Moving dynf012.tile3.nc ......... OK
+ Moving dynf012.tile4.nc ......... OK
+ Moving dynf012.tile5.nc ......... OK
+ Moving dynf012.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 003 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_gfs_v15p2_prod
-Checking test 009 fv3_ccpp_gfs_v15p2 results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf024.tile1.nc .........OK
- Comparing phyf024.tile2.nc .........OK
- Comparing phyf024.tile3.nc .........OK
- Comparing phyf024.tile4.nc .........OK
- Comparing phyf024.tile5.nc .........OK
- Comparing phyf024.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf024.tile1.nc .........OK
- Comparing dynf024.tile2.nc .........OK
- Comparing dynf024.tile3.nc .........OK
- Comparing dynf024.tile4.nc .........OK
- Comparing dynf024.tile5.nc .........OK
- Comparing dynf024.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
-Test 009 fv3_ccpp_gfs_v15p2 PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_gfs_v15p2_prod
+Checking test 004 fv3_ccpp_gfs_v15p2 results ....
+Moving baseline 004 fv3_ccpp_gfs_v15p2 files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf024.tile1.nc ......... OK
+ Moving phyf024.tile2.nc ......... OK
+ Moving phyf024.tile3.nc ......... OK
+ Moving phyf024.tile4.nc ......... OK
+ Moving phyf024.tile5.nc ......... OK
+ Moving phyf024.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf024.tile1.nc ......... OK
+ Moving dynf024.tile2.nc ......... OK
+ Moving dynf024.tile3.nc ......... OK
+ Moving dynf024.tile4.nc ......... OK
+ Moving dynf024.tile5.nc ......... OK
+ Moving dynf024.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+Test 004 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_control_debug_prod
-Checking test 010 fv3_ccpp_regional_control_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 010 fv3_ccpp_regional_control_debug PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_control_debug_prod
+Checking test 005 fv3_ccpp_regional_control_debug results ....
+Moving baseline 005 fv3_ccpp_regional_control_debug files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 005 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_regional_v15p2_debug_prod
-Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/sfc_data.nc .........OK
- Comparing RESTART/phy_data.nc .........OK
-Test 011 fv3_ccpp_regional_v15p2_debug PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_regional_v15p2_debug_prod
+Checking test 006 fv3_ccpp_regional_v15p2_debug results ....
+Moving baseline 006 fv3_ccpp_regional_v15p2_debug files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.nc ......... OK
+ Moving phyf000.nc ......... OK
+ Moving phyf001.nc ......... OK
+ Moving dynf000.nc ......... OK
+ Moving dynf001.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/sfc_data.nc ......... OK
+ Moving RESTART/phy_data.nc ......... OK
+Test 006 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_rrfs_v1alpha_debug_prod
-Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf003.tile1.nc .........OK
- Comparing phyf003.tile2.nc .........OK
- Comparing phyf003.tile3.nc .........OK
- Comparing phyf003.tile4.nc .........OK
- Comparing phyf003.tile5.nc .........OK
- Comparing phyf003.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf003.tile1.nc .........OK
- Comparing dynf003.tile2.nc .........OK
- Comparing dynf003.tile3.nc .........OK
- Comparing dynf003.tile4.nc .........OK
- Comparing dynf003.tile5.nc .........OK
- Comparing dynf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_rrfs_v1alpha_debug_prod
+Checking test 007 fv3_ccpp_rrfs_v1alpha_debug results ....
+Moving baseline 007 fv3_ccpp_rrfs_v1alpha_debug files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf003.tile1.nc ......... OK
+ Moving phyf003.tile2.nc ......... OK
+ Moving phyf003.tile3.nc ......... OK
+ Moving phyf003.tile4.nc ......... OK
+ Moving phyf003.tile5.nc ......... OK
+ Moving phyf003.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf003.tile1.nc ......... OK
+ Moving dynf003.tile2.nc ......... OK
+ Moving dynf003.tile3.nc ......... OK
+ Moving dynf003.tile4.nc ......... OK
+ Moving dynf003.tile5.nc ......... OK
+ Moving dynf003.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 007 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/Laurie.Carson/stmp2/Laurie.Carson/FV3_RT/rt_272343/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 013 fv3_ccpp_gfs_v15p2_debug PASS
+working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_203198/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 008 fv3_ccpp_gfs_v15p2_debug results ....
+Moving baseline 008 fv3_ccpp_gfs_v15p2_debug files ....
+ mkdir -p /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp/RESTART
+ Moving atmos_4xdaily.tile1.nc ......... OK
+ Moving atmos_4xdaily.tile2.nc ......... OK
+ Moving atmos_4xdaily.tile3.nc ......... OK
+ Moving atmos_4xdaily.tile4.nc ......... OK
+ Moving atmos_4xdaily.tile5.nc ......... OK
+ Moving atmos_4xdaily.tile6.nc ......... OK
+ Moving phyf000.tile1.nc ......... OK
+ Moving phyf000.tile2.nc ......... OK
+ Moving phyf000.tile3.nc ......... OK
+ Moving phyf000.tile4.nc ......... OK
+ Moving phyf000.tile5.nc ......... OK
+ Moving phyf000.tile6.nc ......... OK
+ Moving phyf006.tile1.nc ......... OK
+ Moving phyf006.tile2.nc ......... OK
+ Moving phyf006.tile3.nc ......... OK
+ Moving phyf006.tile4.nc ......... OK
+ Moving phyf006.tile5.nc ......... OK
+ Moving phyf006.tile6.nc ......... OK
+ Moving dynf000.tile1.nc ......... OK
+ Moving dynf000.tile2.nc ......... OK
+ Moving dynf000.tile3.nc ......... OK
+ Moving dynf000.tile4.nc ......... OK
+ Moving dynf000.tile5.nc ......... OK
+ Moving dynf000.tile6.nc ......... OK
+ Moving dynf006.tile1.nc ......... OK
+ Moving dynf006.tile2.nc ......... OK
+ Moving dynf006.tile3.nc ......... OK
+ Moving dynf006.tile4.nc ......... OK
+ Moving dynf006.tile5.nc ......... OK
+ Moving dynf006.tile6.nc ......... OK
+ Moving RESTART/coupler.res ......... OK
+ Moving RESTART/fv_core.res.nc ......... OK
+ Moving RESTART/fv_core.res.tile1.nc ......... OK
+ Moving RESTART/fv_core.res.tile2.nc ......... OK
+ Moving RESTART/fv_core.res.tile3.nc ......... OK
+ Moving RESTART/fv_core.res.tile4.nc ......... OK
+ Moving RESTART/fv_core.res.tile5.nc ......... OK
+ Moving RESTART/fv_core.res.tile6.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile1.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile2.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile3.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile4.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile5.nc ......... OK
+ Moving RESTART/fv_srf_wnd.res.tile6.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile1.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile2.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile3.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile4.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile5.nc ......... OK
+ Moving RESTART/fv_tracer.res.tile6.nc ......... OK
+ Moving RESTART/phy_data.tile1.nc ......... OK
+ Moving RESTART/phy_data.tile2.nc ......... OK
+ Moving RESTART/phy_data.tile3.nc ......... OK
+ Moving RESTART/phy_data.tile4.nc ......... OK
+ Moving RESTART/phy_data.tile5.nc ......... OK
+ Moving RESTART/phy_data.tile6.nc ......... OK
+ Moving RESTART/sfc_data.tile1.nc ......... OK
+ Moving RESTART/sfc_data.tile2.nc ......... OK
+ Moving RESTART/sfc_data.tile3.nc ......... OK
+ Moving RESTART/sfc_data.tile4.nc ......... OK
+ Moving RESTART/sfc_data.tile5.nc ......... OK
+ Moving RESTART/sfc_data.tile6.nc ......... OK
+Test 008 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jan  7 00:24:49 UTC 2021
-Elapsed time: 04h:03m:06s. Have a nice day!
+Mon Jan 25 17:37:09 UTC 2021
+Elapsed time: 00h:59m:49s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Mon Jan 25 20:35:43 UTC 2021
+Wed Jan 27 15:28:02 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_control_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/BMC/gmtb/stmp2/Laurie.Carson/FV3_RT/rt_102217/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jan 25 22:10:56 UTC 2021
-Elapsed time: 01h:35m:14s. Have a nice day!
+Wed Jan 27 15:51:12 UTC 2021
+Elapsed time: 00h:23m:12s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Thu Jan  7 17:43:05 GMT 2021
+Wed Jan 27 17:00:40 GMT 2021
 Start Regression test
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_control_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -22,8 +22,8 @@ Checking test 001 fv3_ccpp_regional_control results ....
 Test 001 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_2threads_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -40,8 +40,8 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
 Test 002 fv3_ccpp_regional_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_coldstart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -50,8 +50,8 @@ Checking test 003 fv3_ccpp_regional_coldstart results ....
 Test 003 fv3_ccpp_regional_coldstart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_v15p2_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -68,8 +68,8 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
 Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -148,8 +148,8 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
 Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_decomp_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -222,8 +222,8 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
 Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_2threads_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,8 +302,8 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
 Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -331,8 +331,8 @@ Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
 Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,8 +399,8 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
 Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_control_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -417,8 +417,8 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
 Test 010 fv3_ccpp_regional_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_regional_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_regional_v15p2_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -435,8 +435,8 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
 Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_rrfs_v1alpha_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -503,8 +503,8 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
 Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210104/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_198965/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jan  7 18:44:48 GMT 2021
-Elapsed time: 01h:01m:45s. Have a nice day!
+Wed Jan 27 18:01:32 GMT 2021
+Elapsed time: 01h:00m:55s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -418,9 +418,9 @@ if [[ $SINGLE_NAME != '' ]]; then
 fi
 
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210104/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210126/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210104}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/ufs-public-release-v2-20210126}
 fi
 
 shift $((OPTIND-1))


### PR DESCRIPTION
## Description

(1) Some updates to prevent the model from crashing. 
(2) Include opt_stc=3 bug fix in both noahmp land and glacier code (no initialization for some parameters)
(3) The wrong downward longwave forcing to Noah MP. Noah MP expects the
downward longwave before surface emission, however the current driver passed the
one after emission. Inside Noah MP it is multiplied by surface emissivity
again. So generally Noah MP is getting less downward longwave.

### Issue(s) addressed

https://github.com/NCAR/ccpp-physics/issues/556

## Testing

RT completed for cheyenne.intel, cheyenne.gnu and hera.intel
Baseline changed for all tests using NOAH-MP (control, RRFS)
New baselines are:
hera.intel: /scratch1/BMC/gmtb/stmp4/Laurie.Carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL/
cheyenne.intel: /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_INTEL
cheyenne.gnu: /glade/work/carson/FV3_RT/REGRESSION_TEST_RELEASE_PUBLIC_V2_GNU


## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/557
- waiting on https://github.com/NOAA-EMC/fv3atm/pull/240
