### PR TITLE
release/public-v2: Make 32bit dynamics default (32BIT=ON) and set DYN32 accordingly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(ufs-weather-model
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(32BIT           OFF CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)")
+set(32BIT           ON  CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)")
 set(AVX2            ON  CACHE BOOL "Enable AVX2 instruction set")
 set(SIMDMULTIARCH   OFF CACHE BOOL "Enable multi-target SIMD instruction sets")
 set(CCPP            ON  CACHE BOOL "Enable CCPP")
@@ -42,6 +42,12 @@ endif()
 # OpenMP broken for clang compiler
 if(${CMAKE_C_COMPILER_ID} MATCHES "^(Clang|AppleClang)$")
   set(OPENMP        OFF CACHE BOOL "Enable OpenMP threading" FORCE)
+endif()
+
+if(32BIT)
+  set(DYN32 ON CACHE BOOL "Enable support for 32bit fast physics in CCPP")
+else()
+  set(DYN32 OFF CACHE BOOL "Enable support for 32bit fast physics in CCPP")
 endif()
 
 message("")

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Jan 27 07:26:30 MST 2021
+Wed Jan 27 16:38:08 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_38065/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_38759/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 07:41:11 MST 2021
-Elapsed time: 00h:14m:42s. Have a nice day!
+Wed Jan 27 16:53:50 MST 2021
+Elapsed time: 00h:15m:42s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Jan 27 07:26:15 MST 2021
+Wed Jan 27 16:39:53 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -13,7 +13,7 @@ Checking test 001 fv3_ccpp_regional_control results ....
  Comparing dynf006.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -31,7 +31,7 @@ Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -59,7 +59,7 @@ Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing dynf000.nc .........OK
  Comparing dynf012.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -114,7 +114,7 @@ Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -194,7 +194,7 @@ Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -268,7 +268,7 @@ Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -365,7 +365,7 @@ Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing dynf024.tile5.nc .........OK
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -408,7 +408,7 @@ Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -426,7 +426,7 @@ Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing dynf003.tile5.nc .........OK
  Comparing dynf003.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_45721/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_29755/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -537,7 +537,7 @@ Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
  Comparing RESTART/fv_core.res.tile2.nc .........OK
  Comparing RESTART/fv_core.res.tile3.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 08:02:35 MST 2021
-Elapsed time: 00h:36m:20s. Have a nice day!
+Wed Jan 27 17:15:42 MST 2021
+Elapsed time: 00h:35m:50s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Wed Jan 27 11:12:08 EST 2021
+Wed Jan 27 18:00:41 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_control_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_29215/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_8479/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 12:53:40 EST 2021
-Elapsed time: 01h:41m:33s. Have a nice day!
+Wed Jan 27 19:42:22 EST 2021
+Elapsed time: 01h:41m:42s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Wed Jan 27 16:59:10 UTC 2021
+Wed Jan 27 23:36:07 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_284383/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_70074/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 18:08:44 UTC 2021
-Elapsed time: 01h:09m:35s. Have a nice day!
+Thu Jan 28 00:43:36 UTC 2021
+Elapsed time: 01h:07m:30s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Jan 27 15:28:02 UTC 2021
+Wed Jan 27 22:58:44 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_246427/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_173855/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 15:51:12 UTC 2021
-Elapsed time: 00h:23m:12s. Have a nice day!
+Wed Jan 27 23:16:59 UTC 2021
+Elapsed time: 00h:18m:16s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Wed Jan 27 17:00:40 GMT 2021
+Wed Jan 27 23:00:56 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_2threads_prod
 Checking test 002 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -41,7 +41,7 @@ Test 002 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_coldstart_prod
 Checking test 003 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -51,7 +51,7 @@ Test 003 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_v15p2_prod
 Checking test 004 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -69,7 +69,7 @@ Test 004 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 005 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -149,7 +149,7 @@ Test 005 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 006 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -223,7 +223,7 @@ Test 006 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 007 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -303,7 +303,7 @@ Test 007 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 008 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -332,7 +332,7 @@ Test 008 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_gfs_v15p2_prod
 Checking test 009 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,7 +400,7 @@ Test 009 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_control_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_control_debug_prod
 Checking test 010 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -418,7 +418,7 @@ Test 010 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_regional_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 011 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -436,7 +436,7 @@ Test 011 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,7 +504,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210126/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_58890/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_18559/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 013 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,5 +572,5 @@ Test 013 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 27 18:01:32 GMT 2021
-Elapsed time: 01h:00m:55s. Have a nice day!
+Thu Jan 28 00:02:48 GMT 2021
+Elapsed time: 01h:01m:54s. Have a nice day!

--- a/tests/compile_cmake.sh
+++ b/tests/compile_cmake.sh
@@ -77,8 +77,8 @@ elif [[ "${MAKE_OPT}" == *"REPRO=Y"* ]]; then
   CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DREPRO=Y"
 fi
 
-if [[ "${MAKE_OPT}" == *"32BIT=Y"* ]]; then
-  CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -D32BIT=Y"
+if [[ "${MAKE_OPT}" == *"32BIT=N"* ]]; then
+  CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -D32BIT=OFF"
 fi
 
 if [[ "${MAKE_OPT}" == *"OPENMP=N"* ]]; then
@@ -111,12 +111,6 @@ if [[ "${MAKE_OPT}" == *"CCPP=Y"* ]]; then
     if [[ "${MACHINE_ID}" == "jet.intel" ]]; then
       CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DSIMDMULTIARCH=ON"
     fi
-  fi
-
-  if [[ "${MAKE_OPT}" == *"32BIT=Y"* ]]; then
-    CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DDYN32=ON"
-  else
-    CCPP_CMAKE_FLAGS="${CCPP_CMAKE_FLAGS} -DDYN32=OFF"
   fi
 
     # Check if suites argument is provided or not

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -2,7 +2,7 @@
 # CCPP PROD TESTS                                                                                                             #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1alpha 32BIT=Y                   | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1alpha                           | standard    |                | fv3         |
 
 # Regional tests
 RUN     | fv3_ccpp_regional_control                                              | standard    |                | fv3         |
@@ -27,7 +27,7 @@ RUN     | fv3_ccpp_gfs_v15p2                                                    
 # CCPP DEBUG TESTS                                                                                                            #
 ###############################################################################################################################
 
-COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y           | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1alpha DEBUG=Y                   | standard    |                | fv3         |
 
 RUN     | fv3_ccpp_regional_control_debug                                        | standard    |                | fv3         |
 RUN     | fv3_ccpp_regional_v15p2_debug                                          | standard    |                | fv3         |


### PR DESCRIPTION
## Description

The SRW App release team has decided that the default build for the ufs-weather-model should be with 32bit dynamics. 

Also, the CCPP switch that goes along with `32BIT=ON` for cmake should be set automatically in the cmake build, not in `compile_cmake.sh`. (A similar change was made for develop recently, but in a slightly different place due to the ongoing infrastructure updates in develop.)

Since all regression tests for release/public-v2 were run with `32BIT=Y`, no updates to the baselines are required.

## Issues

n/a

## Testing

Regression tests were run on all tier-1 platforms for release/public-v2, logs updated in the PR.

To make sure that compiling with 64bit dynamics still works, I also ran the following command on Jet:
```
./compile_cmake.sh $PWD/.. jet.intel 'CCPP=Y SUITES=FV3_GFS_v15p2,FV3_RRFS_v1alpha DEBUG=Y 32BIT=N' '' NO NO 2>&1 | tee compile_jet_intel_64bit.log
```
Compilation was successful and dynamics were compiled with double precision, see attached log: [compile_jet_intel_64bit.log](https://github.com/ufs-community/ufs-weather-model/files/5883920/compile_jet_intel_64bit.log)

## Dependencies

n/a