### PR TITLE
Add datm-mom6-cice6 and coupled-model tests on Gaea.

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -168,6 +168,42 @@ elif [[ $MACHINE_ID = gaea.* ]]; then
   TASKS_stretch=48 ; TPN_stretch=18 ; INPES_stretch=2 ; JNPES_stretch=4
   TASKS_strnest=96 ; TPN_strnest=18 ; INPES_strnest=2 ; JNPES_strnest=4
 
+  TASKS_cpl_dflt=192; TPN_cpl_dflt=36; INPES_cpl_dflt=3; JNPES_cpl_dflt=8
+  THRD_cpl_dflt=1; WPG_cpl_dflt=6;  MPB_cpl_dflt="0 143"; APB_cpl_dflt="0 149"
+  OPB_cpl_dflt="150 179"; IPB_cpl_dflt="180 191"
+
+  TASKS_cpl_dflt_wwav=204; TPN_cpl_dflt_wwav=36; INPES_cpl_dflt_wwav=3; JNPES_cpl_dflt_wwav=8
+  THRD_cpl_dflt_wwav=1; WPG_cpl_dflt_wwav=6;  MPB_cpl_dflt_wwav="0 143"; APB_cpl_dflt_wwav="0 149"
+  OPB_cpl_dflt_wwav="150 179"; IPB_cpl_dflt_wwav="180 191"; WPB_cpl_dflt_wwav="192 203"
+
+  TASKS_cpl_thrd=120; TPN_cpl_thrd=18; INPES_cpl_thrd=3; JNPES_cpl_thrd=4
+  THRD_cpl_thrd=2; WPG_cpl_thrd=6;  MPB_cpl_thrd="0 77";  APB_cpl_thrd="0 77"
+  OPB_cpl_thrd="78 107";  IPB_cpl_thrd="108 119"
+
+  TASKS_cpl_bmrk=480; TPN_cpl_bmrk=36; INPES_cpl_bmrk=6; JNPES_cpl_bmrk=8
+  THRD_cpl_bmrk=1; WPG_cpl_bmrk=24; MPB_cpl_bmrk="0 287"; APB_cpl_bmrk="0 311"
+  OPB_cpl_bmrk="312 431"; IPB_cpl_bmrk="432 479"
+
+  TASKS_cpl_wwav=520; TPN_cpl_wwav=36; INPES_cpl_wwav=6; JNPES_cpl_wwav=8
+  THRD_cpl_wwav=1; WPG_cpl_wwav=24; MPB_cpl_wwav="0 287"; APB_cpl_wwav="0 311"
+  OPB_cpl_wwav="312 431"; IPB_cpl_wwav="432 479"; WPB_cpl_wwav="480 519"
+
+  TASKS_cpl_c192=288; TPN_cpl_c192=36; INPES_cpl_c192=4; JNPES_cpl_c192=8
+  THRD_cpl_c192=1; WPG_cpl_c192=12;  MPB_cpl_c192="0 191"; APB_cpl_c192="0 203"
+  OPB_cpl_c192="204 263"; IPB_cpl_c192="264 287"
+
+  TASKS_cpl_c384=318; TPN_cpl_c384=36; INPES_cpl_c384=3; JNPES_cpl_c384=8
+  THRD_cpl_c384=1; WPG_cpl_c384=6;  MPB_cpl_c384="0 143"; APB_cpl_c384="0 149"
+  OPB_cpl_c384="150 269"; IPB_cpl_c384="270 317"
+
+  TASKS_datm_100=120; TPN_datm_100=36
+  MPB_datm_100="16 77"; APB_datm_100="0 15"
+  OPB_datm_100="78 107"; IPB_datm_100="108 119"
+
+  TASKS_datm_025=208; TPN_datm_025=36
+  MPB_datm_025="0 39"; APB_datm_025="0 39"
+  OPB_datm_025="40 159"; IPB_datm_025="160 207"
+
 elif [[ $MACHINE_ID = cheyenne.* ]]; then
 
   TASKS_dflt=150 ; TPN_dflt=36 ; INPES_dflt=3 ; JNPES_dflt=8

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -129,36 +129,36 @@ RUN     | fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug                              
 # CPLD tests                                                                                                                                                                      #
 ###################################################################################################################################################################################
 
-COMPILE | SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled S2S=Y               | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_control                                                                                                            | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart                                                                                                            | - wcoss_cray gaea.intel jet.intel       |     | cpld_control
-RUN     | cpld_controlfrac                                                                                                        | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restartfrac                                                                                                        | - wcoss_cray gaea.intel jet.intel       |     | cpld_controlfrac
+COMPILE | SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled S2S=Y               | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_control                                                                                                            | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart                                                                                                            | - wcoss_cray jet.intel       |     | cpld_control
+RUN     | cpld_controlfrac                                                                                                        | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restartfrac                                                                                                        | - wcoss_cray jet.intel       |     | cpld_controlfrac
 
-RUN     | cpld_2threads                                                                                                           | - wcoss_cray gaea.intel jet.intel       |     |
-RUN     | cpld_decomp                                                                                                             | - wcoss_cray gaea.intel jet.intel       |     |
-RUN     | cpld_satmedmf                                                                                                           | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_ca                                                                                                                 | - wcoss_cray gaea.intel jet.intel       | fv3 |
+RUN     | cpld_2threads                                                                                                           | - wcoss_cray jet.intel       |     |
+RUN     | cpld_decomp                                                                                                             | - wcoss_cray jet.intel       |     |
+RUN     | cpld_satmedmf                                                                                                           | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_ca                                                                                                                 | - wcoss_cray jet.intel       | fv3 |
 
 #12h/36h/48h restart tests
-RUN     | cpld_control_c192                                                                                                       | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart_c192                                                                                                       | - wcoss_cray gaea.intel jet.intel       |     | cpld_control_c192
-RUN     | cpld_controlfrac_c192                                                                                                   | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restartfrac_c192                                                                                                   | - wcoss_cray gaea.intel jet.intel       |     | cpld_controlfrac_c192
+RUN     | cpld_control_c192                                                                                                       | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart_c192                                                                                                       | - wcoss_cray jet.intel       |     | cpld_control_c192
+RUN     | cpld_controlfrac_c192                                                                                                   | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restartfrac_c192                                                                                                   | - wcoss_cray jet.intel       |     | cpld_controlfrac_c192
 
-RUN     | cpld_control_c384                                                                                                       | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart_c384                                                                                                       | - wcoss_cray gaea.intel jet.intel       |     | cpld_control_c384
-RUN     | cpld_controlfrac_c384                                                                                                   | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restartfrac_c384                                                                                                   | - wcoss_cray gaea.intel jet.intel       |     | cpld_controlfrac_c384
+RUN     | cpld_control_c384                                                                                                       | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart_c384                                                                                                       | - wcoss_cray jet.intel       |     | cpld_control_c384
+RUN     | cpld_controlfrac_c384                                                                                                   | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restartfrac_c384                                                                                                   | - wcoss_cray jet.intel       |     | cpld_controlfrac_c384
 
-RUN     | cpld_bmark                                                                                                              | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart_bmark                                                                                                      | - wcoss_cray gaea.intel jet.intel       |     | cpld_bmark
-RUN     | cpld_bmarkfrac                                                                                                          | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart_bmarkfrac                                                                                                  | - wcoss_cray gaea.intel jet.intel       |     | cpld_bmarkfrac
+RUN     | cpld_bmark                                                                                                              | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart_bmark                                                                                                      | - wcoss_cray jet.intel       |     | cpld_bmark
+RUN     | cpld_bmarkfrac                                                                                                          | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart_bmarkfrac                                                                                                  | - wcoss_cray jet.intel       |     | cpld_bmarkfrac
 
 #6h/6h/12h restart test
-RUN     | cpld_bmarkfrac_v16                                                                                                      | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_restart_bmarkfrac_v16                                                                                              | - wcoss_cray gaea.intel jet.intel       |     | cpld_bmarkfrac_v16
+RUN     | cpld_bmarkfrac_v16                                                                                                      | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_restart_bmarkfrac_v16                                                                                              | - wcoss_cray jet.intel       |     | cpld_bmarkfrac_v16
 
 COMPILE | SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled S2S=Y WW3=Y         | - wcoss_cray gaea.intel jet.intel       | fv3 |
 RUN     | cpld_bmark_wave                                                                                                         | - wcoss_cray gaea.intel jet.intel       | fv3 |
@@ -166,24 +166,24 @@ RUN     | cpld_bmarkfrac_wave                                                   
 RUN     | cpld_bmarkfrac_wave_v16                                                                                                 | - wcoss_cray gaea.intel jet.intel       | fv3 |
 RUN     | cpld_control_wave                                                                                                       | - wcoss_cray gaea.intel jet.intel       | fv3 |
 
-COMPILE | DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled S2S=Y       | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_debug                                                                                                              | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | cpld_debugfrac                                                                                                          | - wcoss_cray gaea.intel jet.intel       | fv3 |
+COMPILE | DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled S2S=Y       | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_debug                                                                                                              | - wcoss_cray jet.intel       | fv3 |
+RUN     | cpld_debugfrac                                                                                                          | - wcoss_cray jet.intel       | fv3 |
 
 ###################################################################################################################################################################################
 # Data Atmosphere tests                                                                                                                                                           #
 ###################################################################################################################################################################################
 
-COMPILE | DATM=Y S2S=Y                                                                                                            | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | datm_control_cfsr                                                                                                       | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | datm_restart_cfsr                                                                                                       | - wcoss_cray gaea.intel jet.intel       |     | datm_control_cfsr
-RUN     | datm_control_gefs                                                                                                       | - wcoss_cray gaea.intel jet.intel       | fv3 |
+COMPILE | DATM=Y S2S=Y                                                                                                            | - wcoss_cray jet.intel       | fv3 |
+RUN     | datm_control_cfsr                                                                                                       | - wcoss_cray jet.intel       | fv3 |
+RUN     | datm_restart_cfsr                                                                                                       | - wcoss_cray jet.intel       |     | datm_control_cfsr
+RUN     | datm_control_gefs                                                                                                       | - wcoss_cray jet.intel       | fv3 |
 
-RUN     | datm_bulk_cfsr                                                                                                          | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | datm_bulk_gefs                                                                                                          | - wcoss_cray gaea.intel jet.intel       | fv3 |
+RUN     | datm_bulk_cfsr                                                                                                          | - wcoss_cray jet.intel       | fv3 |
+RUN     | datm_bulk_gefs                                                                                                          | - wcoss_cray jet.intel       | fv3 |
 
-RUN     | datm_mx025_cfsr                                                                                                         | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | datm_mx025_gefs                                                                                                         | - wcoss_cray gaea.intel jet.intel       | fv3 |
+RUN     | datm_mx025_cfsr                                                                                                         | - wcoss_cray jet.intel       | fv3 |
+RUN     | datm_mx025_gefs                                                                                                         | - wcoss_cray jet.intel       | fv3 |
 
-COMPILE | DATM=Y S2S=Y DEBUG=Y                                                                                                    | - wcoss_cray gaea.intel jet.intel       | fv3 |
-RUN     | datm_debug_cfsr                                                                                                         | - wcoss_cray gaea.intel jet.intel       | fv3 |
+COMPILE | DATM=Y S2S=Y DEBUG=Y                                                                                                    | - wcoss_cray jet.intel       | fv3 |
+RUN     | datm_debug_cfsr                                                                                                         | - wcoss_cray jet.intel       | fv3 |


### PR DESCRIPTION
## Description

New baseline is created on Gaea for datm-mom6-cice6 and the coupled model. This PR will not change answers for existing tests.

### Issue(s) addressed
- fixes #317 

## Testing
What compilers / HPCs was it tested with? 
Intel compiler/Gaea

Are the changes covered by regression tests? 
Yes.

## Dependencies
No.