### PR TITLE
Move LSM vegetation lookup tables into CCPP, clean up RUC snow cover on ice initialization (remove IPD step 2) 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = move_lsm_table_init_to_ccpp
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = move_lsm_table_init_to_ccpp
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Feb  3 07:58:47 MST 2021
+Fri Feb  5 12:04:56 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_control_debug_prod
 Checking test 015 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 015 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1001,7 +1001,7 @@ Test 016 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1069,7 +1069,7 @@ Test 017 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1137,7 +1137,7 @@ Test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1205,7 +1205,7 @@ Test 019 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1279,7 +1279,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1347,7 +1347,7 @@ Test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47161/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1365,5 +1365,5 @@ Test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 08:16:48 MST 2021
-Elapsed time: 00h:18m:01s. Have a nice day!
+Fri Feb  5 12:23:24 MST 2021
+Elapsed time: 00h:18m:29s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Feb  3 07:58:09 MST 2021
+Fri Feb  5 12:04:08 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_read_inc_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lndp_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_lndp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_iau_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_lheatstrg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_control_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_stretched_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_stretched_nest_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_regional_quilt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,18 +1229,18 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1270,7 +1270,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1290,7 +1290,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1338,7 +1338,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1434,7 +1434,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_csawmg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,7 +1530,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_satmedmfq_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,7 +1578,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1626,7 +1626,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1678,7 +1678,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_cpt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1732,7 +1732,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,7 +1824,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rap_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_rap_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1892,7 +1892,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_hrrr_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_hrrr_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1960,7 +1960,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2028,7 +2028,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2096,7 +2096,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2164,7 +2164,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_prod
 Checking test 042 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2244,7 +2244,7 @@ Test 042 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_restart_prod
 Checking test 043 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2294,7 +2294,7 @@ Test 043 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 044 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2362,7 +2362,7 @@ Test 044 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2430,7 +2430,7 @@ Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2492,7 +2492,7 @@ Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gocart_clm_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gocart_clm_prod
 Checking test 047 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2540,7 +2540,7 @@ Test 047 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_flake_prod
 Checking test 048 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2608,7 +2608,7 @@ Test 048 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2676,7 +2676,7 @@ Test 049 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2694,7 +2694,7 @@ Test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2762,7 +2762,7 @@ Test 051 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_debug_prod
 Checking test 052 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2830,7 +2830,7 @@ Test 052 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2898,7 +2898,7 @@ Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2966,7 +2966,7 @@ Test 054 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gsd_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gsd_debug_prod
 Checking test 055 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3034,7 +3034,7 @@ Test 055 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 056 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,7 +3102,7 @@ Test 056 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_thompson_debug_prod
 Checking test 057 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3170,7 +3170,7 @@ Test 057 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 058 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3238,7 +3238,7 @@ Test 058 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 059 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,7 +3306,7 @@ Test 059 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 060 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3374,7 +3374,7 @@ Test 060 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 061 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3392,7 +3392,7 @@ Test 061 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_control_prod
 Checking test 062 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3445,7 +3445,7 @@ Test 062 cpld_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_prod
 Checking test 063 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3498,7 +3498,7 @@ Test 063 cpld_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_controlfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_controlfrac_prod
 Checking test 064 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3551,7 +3551,7 @@ Test 064 cpld_controlfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restartfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restartfrac_prod
 Checking test 065 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3604,7 +3604,7 @@ Test 065 cpld_restartfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_2threads_prod
 Checking test 066 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3657,7 +3657,7 @@ Test 066 cpld_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_decomp_prod
 Checking test 067 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3710,7 +3710,7 @@ Test 067 cpld_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_satmedmf_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_satmedmf_prod
 Checking test 068 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3763,7 +3763,7 @@ Test 068 cpld_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_ca_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_ca_prod
 Checking test 069 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3816,7 +3816,7 @@ Test 069 cpld_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_control_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_control_c192_prod
 Checking test 070 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -3869,7 +3869,7 @@ Test 070 cpld_control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_c192_prod
 Checking test 071 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -3922,7 +3922,7 @@ Test 071 cpld_restart_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_controlfrac_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_controlfrac_c192_prod
 Checking test 072 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -3975,7 +3975,7 @@ Test 072 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restartfrac_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restartfrac_c192_prod
 Checking test 073 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4028,7 +4028,7 @@ Test 073 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_control_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_control_c384_prod
 Checking test 074 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4084,7 +4084,7 @@ Test 074 cpld_control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_c384_prod
 Checking test 075 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4140,7 +4140,7 @@ Test 075 cpld_restart_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_controlfrac_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_controlfrac_c384_prod
 Checking test 076 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4196,7 +4196,7 @@ Test 076 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restartfrac_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restartfrac_c384_prod
 Checking test 077 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4252,7 +4252,7 @@ Test 077 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmark_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmark_prod
 Checking test 078 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4308,7 +4308,7 @@ Test 078 cpld_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_bmark_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_bmark_prod
 Checking test 079 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4364,7 +4364,7 @@ Test 079 cpld_restart_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmarkfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmarkfrac_prod
 Checking test 080 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4420,7 +4420,7 @@ Test 080 cpld_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_bmarkfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_bmarkfrac_prod
 Checking test 081 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4476,7 +4476,7 @@ Test 081 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmarkfrac_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmarkfrac_v16_prod
 Checking test 082 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4532,7 +4532,7 @@ Test 082 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_restart_bmarkfrac_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_restart_bmarkfrac_v16_prod
 Checking test 083 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4588,7 +4588,7 @@ Test 083 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_wave_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmark_wave_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmark_wave_prod
 Checking test 084 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4647,7 +4647,7 @@ Test 084 cpld_bmark_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmarkfrac_wave_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmarkfrac_wave_prod
 Checking test 085 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4706,7 +4706,7 @@ Test 085 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_bmarkfrac_wave_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_bmarkfrac_wave_v16_prod
 Checking test 086 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4765,7 +4765,7 @@ Test 086 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_wave_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_control_wave_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_control_wave_prod
 Checking test 087 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4821,7 +4821,7 @@ Test 087 cpld_control_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_debug_prod
 Checking test 088 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4874,7 +4874,7 @@ Test 088 cpld_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debugfrac_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/cpld_debugfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/cpld_debugfrac_prod
 Checking test 089 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4927,7 +4927,7 @@ Test 089 cpld_debugfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_control_cfsr
 Checking test 090 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4936,7 +4936,7 @@ Test 090 datm_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_restart_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_restart_cfsr
 Checking test 091 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4945,7 +4945,7 @@ Test 091 datm_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_gefs
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_control_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_control_gefs
 Checking test 092 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4954,7 +4954,7 @@ Test 092 datm_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_bulk_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4963,7 +4963,7 @@ Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_bulk_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4972,7 +4972,7 @@ Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_mx025_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_mx025_cfsr
 Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4984,7 +4984,7 @@ Test 095 datm_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_mx025_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_mx025_gefs
 Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4996,7 +4996,7 @@ Test 096 datm_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/worthen/FV3_RT/rt_54735/datm_debug_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_51263/datm_debug_cfsr
 Checking test 097 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5005,5 +5005,5 @@ Test 097 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 09:17:36 MST 2021
-Elapsed time: 01h:19m:27s. Have a nice day!
+Fri Feb  5 13:24:01 MST 2021
+Elapsed time: 01h:19m:53s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Wed Feb  3 16:20:35 EST 2021
+Fri Feb  5 16:54:55 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_read_inc_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_read_inc_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stochy_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_stochy_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_ca_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_ca_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lndp_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_lndp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_iau_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_iau_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_lheatstrg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_multigases_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_multigases_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_32bit_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_control_32bit_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_stretched_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_stretched_nest_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_regional_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_regional_quilt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,18 +1229,18 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_control_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1270,7 +1270,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1290,7 +1290,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfdlmp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1338,7 +1338,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1434,7 +1434,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_csawmg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_satmedmf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,7 +1530,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_satmedmfq_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,7 +1578,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1626,7 +1626,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1678,7 +1678,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_cpt_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_cpt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1732,7 +1732,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gsd_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,7 +1824,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rap_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_rap_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1892,7 +1892,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_hrrr_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_hrrr_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1960,7 +1960,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2028,7 +2028,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2096,7 +2096,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2164,7 +2164,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2232,7 +2232,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_prod
 Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 043 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2362,7 +2362,7 @@ Test 044 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2430,7 +2430,7 @@ Test 045 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2498,7 +2498,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2566,7 +2566,7 @@ Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2628,7 +2628,7 @@ Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2676,7 +2676,7 @@ Test 049 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2724,7 +2724,7 @@ Test 050 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gocart_clm_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gocart_clm_prod
 Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2772,7 +2772,7 @@ Test 051 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_flake_prod
 Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2840,7 +2840,7 @@ Test 052 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2908,7 +2908,7 @@ Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2926,7 +2926,7 @@ Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2994,7 +2994,7 @@ Test 055 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_debug_prod
 Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3062,7 +3062,7 @@ Test 056 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3130,7 +3130,7 @@ Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3198,7 +3198,7 @@ Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gsd_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gsd_debug_prod
 Checking test 059 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3266,7 +3266,7 @@ Test 059 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 060 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3334,7 +3334,7 @@ Test 060 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_thompson_debug_prod
 Checking test 061 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3402,7 +3402,7 @@ Test 061 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 062 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3470,7 +3470,7 @@ Test 062 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 063 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3538,7 +3538,7 @@ Test 063 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3606,7 +3606,7 @@ Test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3624,7 +3624,7 @@ Test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_control_prod
 Checking test 066 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3677,7 +3677,7 @@ Test 066 cpld_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restart_prod
 Checking test 067 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3730,7 +3730,7 @@ Test 067 cpld_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_controlfrac_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_controlfrac_prod
 Checking test 068 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3783,7 +3783,7 @@ Test 068 cpld_controlfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restartfrac_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restartfrac_prod
 Checking test 069 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3836,7 +3836,7 @@ Test 069 cpld_restartfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_2threads_prod
 Checking test 070 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3889,7 +3889,7 @@ Test 070 cpld_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_decomp_prod
 Checking test 071 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3942,7 +3942,7 @@ Test 071 cpld_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_satmedmf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_satmedmf_prod
 Checking test 072 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3995,7 +3995,7 @@ Test 072 cpld_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_ca_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_ca_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_ca_prod
 Checking test 073 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4048,7 +4048,7 @@ Test 073 cpld_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_control_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_control_c192_prod
 Checking test 074 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4101,7 +4101,7 @@ Test 074 cpld_control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restart_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restart_c192_prod
 Checking test 075 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4154,7 +4154,7 @@ Test 075 cpld_restart_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_controlfrac_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_controlfrac_c192_prod
 Checking test 076 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4207,7 +4207,7 @@ Test 076 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restartfrac_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restartfrac_c192_prod
 Checking test 077 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4260,7 +4260,7 @@ Test 077 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_control_c384_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_control_c384_prod
 Checking test 078 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4316,7 +4316,7 @@ Test 078 cpld_control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restart_c384_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restart_c384_prod
 Checking test 079 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4372,7 +4372,7 @@ Test 079 cpld_restart_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_controlfrac_c384_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_controlfrac_c384_prod
 Checking test 080 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4428,7 +4428,7 @@ Test 080 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restartfrac_c384_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restartfrac_c384_prod
 Checking test 081 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4484,7 +4484,7 @@ Test 081 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_bmark_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_bmark_prod
 Checking test 082 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4540,7 +4540,7 @@ Test 082 cpld_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restart_bmark_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restart_bmark_prod
 Checking test 083 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4596,7 +4596,7 @@ Test 083 cpld_restart_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_bmarkfrac_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_bmarkfrac_prod
 Checking test 084 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4652,7 +4652,7 @@ Test 084 cpld_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_restart_bmarkfrac_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_restart_bmarkfrac_prod
 Checking test 085 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4708,7 +4708,7 @@ Test 085 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debug_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_debug_prod
 Checking test 086 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4761,7 +4761,7 @@ Test 086 cpld_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debugfrac_ccpp
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/cpld_debugfrac_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/cpld_debugfrac_prod
 Checking test 087 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4814,7 +4814,7 @@ Test 087 cpld_debugfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_control_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_control_cfsr
 Checking test 088 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4823,7 +4823,7 @@ Test 088 datm_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_restart_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_restart_cfsr
 Checking test 089 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4832,7 +4832,7 @@ Test 089 datm_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_control_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_control_gefs
 Checking test 090 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4841,7 +4841,7 @@ Test 090 datm_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_bulk_cfsr
 Checking test 091 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4850,7 +4850,7 @@ Test 091 datm_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_bulk_gefs
 Checking test 092 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4859,7 +4859,7 @@ Test 092 datm_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_cfsr
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_mx025_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_mx025_cfsr
 Checking test 093 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4871,7 +4871,7 @@ Test 093 datm_mx025_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_mx025_gefs
 Checking test 094 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -4883,7 +4883,7 @@ Test 094 datm_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/Denise.Worthen/FV3_RT/rt_48762/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_18272/datm_debug_cfsr
 Checking test 095 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -4892,5 +4892,5 @@ Test 095 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 18:11:31 EST 2021
-Elapsed time: 01h:50m:57s. Have a nice day!
+Fri Feb  5 18:14:37 EST 2021
+Elapsed time: 01h:19m:43s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Wed Feb  3 15:17:52 UTC 2021
+Fri Feb  5 18:40:14 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_control_debug_prod
 Checking test 015 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 015 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1001,7 +1001,7 @@ Test 016 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1069,7 +1069,7 @@ Test 017 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1137,7 +1137,7 @@ Test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1205,7 +1205,7 @@ Test 019 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1279,7 +1279,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1347,7 +1347,7 @@ Test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_131699/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_175539/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1365,5 +1365,5 @@ Test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 16:09:19 UTC 2021
-Elapsed time: 00h:51m:28s. Have a nice day!
+Fri Feb  5 22:25:58 UTC 2021
+Elapsed time: 03h:45m:45s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Feb  3 15:16:22 UTC 2021
+Sat Feb  6 03:19:22 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_read_inc_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lndp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_lndp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_iau_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_lheatstrg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmprad_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1080,7 +1080,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1154,7 +1154,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_control_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1222,7 +1222,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_stretched_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1278,7 +1278,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_stretched_nest_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1345,7 +1345,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1356,7 +1356,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1365,7 +1365,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_regional_quilt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1376,7 +1376,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1387,7 +1387,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_control_debug_prod
 Checking test 028 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1417,7 +1417,7 @@ Test 028 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_stretched_nest_debug_prod
 Checking test 029 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1437,7 +1437,7 @@ Test 029 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmp_prod
 Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1485,7 +1485,7 @@ Test 030 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1533,7 +1533,7 @@ Test 031 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1581,7 +1581,7 @@ Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_csawmg_prod
 Checking test 033 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1629,7 +1629,7 @@ Test 033 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_satmedmf_prod
 Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1677,7 +1677,7 @@ Test 034 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_satmedmfq_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_satmedmfq_prod
 Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1725,7 +1725,7 @@ Test 035 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1773,7 +1773,7 @@ Test 036 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1825,7 +1825,7 @@ Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_cpt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_cpt_prod
 Checking test 038 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1879,7 +1879,7 @@ Test 038 fv3_ccpp_cpt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gsd_prod
 Checking test 039 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1971,7 +1971,7 @@ Test 039 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rap_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_rap_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_rap_prod
 Checking test 040 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2039,7 +2039,7 @@ Test 040 fv3_ccpp_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_hrrr_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_hrrr_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_hrrr_prod
 Checking test 041 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2107,7 +2107,7 @@ Test 041 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_thompson_prod
 Checking test 042 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2175,7 +2175,7 @@ Test 042 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_thompson_no_aero_prod
 Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2243,7 +2243,7 @@ Test 043 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_rrfs_v1beta_prod
 Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2311,7 +2311,7 @@ Test 044 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v15p2_prod
 Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2379,7 +2379,7 @@ Test 045 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_prod
 Checking test 046 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2459,7 +2459,7 @@ Test 046 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_restart_prod
 Checking test 047 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2509,7 +2509,7 @@ Test 047 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2577,7 +2577,7 @@ Test 048 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2645,7 +2645,7 @@ Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2713,7 +2713,7 @@ Test 050 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2775,7 +2775,7 @@ Test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2823,7 +2823,7 @@ Test 052 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2871,7 +2871,7 @@ Test 053 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gocart_clm_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gocart_clm_prod
 Checking test 054 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2919,7 +2919,7 @@ Test 054 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_flake_prod
 Checking test 055 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2987,7 +2987,7 @@ Test 055 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3055,7 +3055,7 @@ Test 056 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3073,7 +3073,7 @@ Test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3141,7 +3141,7 @@ Test 058 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_debug_prod
 Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3209,7 +3209,7 @@ Test 059 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3277,7 +3277,7 @@ Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3345,7 +3345,7 @@ Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gsd_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gsd_debug_prod
 Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3413,7 +3413,7 @@ Test 062 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3481,7 +3481,7 @@ Test 063 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_thompson_debug_prod
 Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3549,7 +3549,7 @@ Test 064 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3617,7 +3617,7 @@ Test 065 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3685,7 +3685,7 @@ Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3753,7 +3753,7 @@ Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3771,7 +3771,7 @@ Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_control_prod
 Checking test 069 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3824,7 +3824,7 @@ Test 069 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_prod
 Checking test 070 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3877,7 +3877,7 @@ Test 070 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_controlfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_controlfrac_prod
 Checking test 071 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3930,7 +3930,7 @@ Test 071 cpld_controlfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restartfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restartfrac_prod
 Checking test 072 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3983,7 +3983,7 @@ Test 072 cpld_restartfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_2threads_prod
 Checking test 073 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4036,7 +4036,7 @@ Test 073 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_decomp_prod
 Checking test 074 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4089,7 +4089,7 @@ Test 074 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_satmedmf_prod
 Checking test 075 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4142,7 +4142,7 @@ Test 075 cpld_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_ca_prod
 Checking test 076 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4195,7 +4195,7 @@ Test 076 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_control_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_control_c192_prod
 Checking test 077 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4248,7 +4248,7 @@ Test 077 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_c192_prod
 Checking test 078 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4301,7 +4301,7 @@ Test 078 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_controlfrac_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_controlfrac_c192_prod
 Checking test 079 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4354,7 +4354,7 @@ Test 079 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restartfrac_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restartfrac_c192_prod
 Checking test 080 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4407,7 +4407,7 @@ Test 080 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_control_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_control_c384_prod
 Checking test 081 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4463,7 +4463,7 @@ Test 081 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_c384_prod
 Checking test 082 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4519,7 +4519,7 @@ Test 082 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_controlfrac_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_controlfrac_c384_prod
 Checking test 083 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4575,7 +4575,7 @@ Test 083 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restartfrac_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restartfrac_c384_prod
 Checking test 084 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4631,7 +4631,7 @@ Test 084 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmark_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmark_prod
 Checking test 085 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4687,7 +4687,7 @@ Test 085 cpld_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_bmark_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_bmark_prod
 Checking test 086 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4743,7 +4743,7 @@ Test 086 cpld_restart_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmarkfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmarkfrac_prod
 Checking test 087 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4799,7 +4799,7 @@ Test 087 cpld_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_bmarkfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_bmarkfrac_prod
 Checking test 088 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4855,7 +4855,7 @@ Test 088 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmarkfrac_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmarkfrac_v16_prod
 Checking test 089 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4911,7 +4911,7 @@ Test 089 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_restart_bmarkfrac_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_restart_bmarkfrac_v16_prod
 Checking test 090 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4967,7 +4967,7 @@ Test 090 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmark_wave_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmark_wave_prod
 Checking test 091 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5026,7 +5026,7 @@ Test 091 cpld_bmark_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmarkfrac_wave_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmarkfrac_wave_prod
 Checking test 092 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5085,7 +5085,7 @@ Test 092 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_bmarkfrac_wave_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_bmarkfrac_wave_v16_prod
 Checking test 093 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5144,7 +5144,7 @@ Test 093 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_control_wave_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_control_wave_prod
 Checking test 094 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5200,7 +5200,7 @@ Test 094 cpld_control_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_debug_prod
 Checking test 095 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5253,7 +5253,7 @@ Test 095 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debugfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/cpld_debugfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/cpld_debugfrac_prod
 Checking test 096 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5306,7 +5306,7 @@ Test 096 cpld_debugfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_control_cfsr
 Checking test 097 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5315,7 +5315,7 @@ Test 097 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_restart_cfsr
 Checking test 098 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5324,7 +5324,7 @@ Test 098 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_control_gefs
 Checking test 099 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5333,7 +5333,7 @@ Test 099 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_bulk_cfsr
 Checking test 100 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5342,7 +5342,7 @@ Test 100 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_bulk_gefs
 Checking test 101 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5351,7 +5351,7 @@ Test 101 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_mx025_cfsr
 Checking test 102 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5363,7 +5363,7 @@ Test 102 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_mx025_gefs
 Checking test 103 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5375,7 +5375,7 @@ Test 103 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Denise.Worthen/FV3_RT/rt_108826/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191433/datm_debug_cfsr
 Checking test 104 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5384,5 +5384,5 @@ Test 104 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 17:46:48 UTC 2021
-Elapsed time: 02h:30m:27s. Have a nice day!
+Sat Feb  6 06:35:00 UTC 2021
+Elapsed time: 03h:15m:39s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Wed Feb  3 16:55:37 GMT 2021
+Fri Feb  5 19:03:41 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
  Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_read_inc_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_read_inc_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_ca_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_ca_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lndp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_lndp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_iau_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_iau_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_lheatstrg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_multigases_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_multigases_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_control_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_stretched_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_stretched_nest_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_restart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_regional_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_regional_quilt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,7 +1229,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1240,7 +1240,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_control_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1270,7 +1270,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1290,7 +1290,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfdlmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1338,7 +1338,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1434,7 +1434,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_csawmg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_satmedmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,7 +1530,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_satmedmfq_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,7 +1578,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1626,7 +1626,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1678,7 +1678,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_cpt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_cpt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1732,7 +1732,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gsd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,7 +1824,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_thompson_prod
 Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1892,7 +1892,7 @@ Test 037 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_thompson_no_aero_prod
 Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1960,7 +1960,7 @@ Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v15p2_prod
 Checking test 039 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2028,7 +2028,7 @@ Test 039 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_prod
 Checking test 040 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2108,7 +2108,7 @@ Test 040 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_restart_prod
 Checking test 041 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2158,7 +2158,7 @@ Test 041 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 042 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2226,7 +2226,7 @@ Test 042 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 043 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2294,7 +2294,7 @@ Test 043 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 044 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2362,7 +2362,7 @@ Test 044 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 045 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2424,7 +2424,7 @@ Test 045 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 046 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2472,7 +2472,7 @@ Test 046 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 047 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2520,7 +2520,7 @@ Test 047 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gocart_clm_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gocart_clm_prod
 Checking test 048 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2568,7 +2568,7 @@ Test 048 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_flake_prod
 Checking test 049 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2636,7 +2636,7 @@ Test 049 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2704,7 +2704,7 @@ Test 050 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2722,7 +2722,7 @@ Test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2790,7 +2790,7 @@ Test 052 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_debug_prod
 Checking test 053 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2858,7 +2858,7 @@ Test 053 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2926,7 +2926,7 @@ Test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 055 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2994,7 +2994,7 @@ Test 055 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gsd_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gsd_debug_prod
 Checking test 056 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3062,7 +3062,7 @@ Test 056 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 057 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3130,7 +3130,7 @@ Test 057 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_thompson_debug_prod
 Checking test 058 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3198,7 +3198,7 @@ Test 058 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 059 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3266,7 +3266,7 @@ Test 059 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 060 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3334,7 +3334,7 @@ Test 060 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 061 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3402,7 +3402,7 @@ Test 061 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_209079/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_301881/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 062 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3420,5 +3420,5 @@ Test 062 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 19:21:57 GMT 2021
-Elapsed time: 02h:26m:21s. Have a nice day!
+Fri Feb  5 21:01:18 GMT 2021
+Elapsed time: 01h:57m:38s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Wed Feb  3 09:14:46 CST 2021
+Fri Feb  5 12:53:25 CST 2021
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_control_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_decomp_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_2threads_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_restart_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_read_inc_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -432,7 +432,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_stochy_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_ca_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lndp_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_lndp_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_iau_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_lheatstrg_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_lheatstrg_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmprad_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1080,7 +1080,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_multigases_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_multigases_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1154,7 +1154,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_control_32bit_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1222,7 +1222,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_stretched_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1278,7 +1278,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_stretched_nest_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1345,7 +1345,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1356,7 +1356,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_regional_restart_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1365,7 +1365,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_regional_quilt_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1376,7 +1376,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1387,7 +1387,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_control_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_control_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_control_debug_prod
 Checking test 028 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1417,7 +1417,7 @@ Test 028 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_stretched_nest_debug_prod
 Checking test 029 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1437,7 +1437,7 @@ Test 029 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmp_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmp_prod
 Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1485,7 +1485,7 @@ Test 030 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1533,7 +1533,7 @@ Test 031 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1581,7 +1581,7 @@ Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_csawmg_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_csawmg_prod
 Checking test 033 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1629,7 +1629,7 @@ Test 033 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_satmedmf_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_satmedmf_prod
 Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1677,7 +1677,7 @@ Test 034 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_satmedmfq_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_satmedmfq_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_satmedmfq_prod
 Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1725,7 +1725,7 @@ Test 035 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1773,7 +1773,7 @@ Test 036 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1825,7 +1825,7 @@ Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_cpt_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_cpt_prod
 Checking test 038 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1879,7 +1879,7 @@ Test 038 fv3_ccpp_cpt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gsd_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gsd_prod
 Checking test 039 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1971,7 +1971,7 @@ Test 039 fv3_ccpp_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rap_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_rap_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_rap_prod
 Checking test 040 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2039,7 +2039,7 @@ Test 040 fv3_ccpp_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_hrrr_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_hrrr_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_hrrr_prod
 Checking test 041 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2107,7 +2107,7 @@ Test 041 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_thompson_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_thompson_prod
 Checking test 042 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2175,7 +2175,7 @@ Test 042 fv3_ccpp_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_thompson_no_aero_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_thompson_no_aero_prod
 Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2243,7 +2243,7 @@ Test 043 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_rrfs_v1beta_prod
 Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2311,7 +2311,7 @@ Test 044 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v15p2_prod
 Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2379,7 +2379,7 @@ Test 045 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_prod
 Checking test 046 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2459,7 +2459,7 @@ Test 046 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_restart_prod
 Checking test 047 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2509,7 +2509,7 @@ Test 047 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2577,7 +2577,7 @@ Test 048 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2645,7 +2645,7 @@ Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2713,7 +2713,7 @@ Test 050 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2775,7 +2775,7 @@ Test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2823,7 +2823,7 @@ Test 052 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2871,7 +2871,7 @@ Test 053 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gocart_clm_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gocart_clm_prod
 Checking test 054 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2919,7 +2919,7 @@ Test 054 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_flake_prod
 Checking test 055 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2987,7 +2987,7 @@ Test 055 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3055,7 +3055,7 @@ Test 056 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3073,7 +3073,7 @@ Test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3141,7 +3141,7 @@ Test 058 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_debug_prod
 Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3209,7 +3209,7 @@ Test 059 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3277,7 +3277,7 @@ Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3345,7 +3345,7 @@ Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gsd_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gsd_debug_prod
 Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3413,7 +3413,7 @@ Test 062 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3481,7 +3481,7 @@ Test 063 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_thompson_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_thompson_debug_prod
 Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3549,7 +3549,7 @@ Test 064 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3617,7 +3617,7 @@ Test 065 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3685,7 +3685,7 @@ Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3753,7 +3753,7 @@ Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3771,7 +3771,7 @@ Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_control_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_control_prod
 Checking test 069 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3824,7 +3824,7 @@ Test 069 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_prod
 Checking test 070 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3877,7 +3877,7 @@ Test 070 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_controlfrac_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_controlfrac_prod
 Checking test 071 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3930,7 +3930,7 @@ Test 071 cpld_controlfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restartfrac_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restartfrac_prod
 Checking test 072 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3983,7 +3983,7 @@ Test 072 cpld_restartfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_2threads_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_2threads_prod
 Checking test 073 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4036,7 +4036,7 @@ Test 073 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_decomp_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_decomp_prod
 Checking test 074 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4089,7 +4089,7 @@ Test 074 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_satmedmf_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_satmedmf_prod
 Checking test 075 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4142,7 +4142,7 @@ Test 075 cpld_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_ca_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_ca_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_ca_prod
 Checking test 076 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4195,7 +4195,7 @@ Test 076 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_control_c192_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_control_c192_prod
 Checking test 077 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4248,7 +4248,7 @@ Test 077 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_c192_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_c192_prod
 Checking test 078 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4301,7 +4301,7 @@ Test 078 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_controlfrac_c192_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_controlfrac_c192_prod
 Checking test 079 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4354,7 +4354,7 @@ Test 079 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restartfrac_c192_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restartfrac_c192_prod
 Checking test 080 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4407,7 +4407,7 @@ Test 080 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_control_c384_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_control_c384_prod
 Checking test 081 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4463,7 +4463,7 @@ Test 081 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_c384_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_c384_prod
 Checking test 082 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4519,7 +4519,7 @@ Test 082 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_controlfrac_c384_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_controlfrac_c384_prod
 Checking test 083 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4575,7 +4575,7 @@ Test 083 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restartfrac_c384_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restartfrac_c384_prod
 Checking test 084 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4631,7 +4631,7 @@ Test 084 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmark_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmark_prod
 Checking test 085 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4687,7 +4687,7 @@ Test 085 cpld_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_bmark_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_bmark_prod
 Checking test 086 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4743,7 +4743,7 @@ Test 086 cpld_restart_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmarkfrac_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmarkfrac_prod
 Checking test 087 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4799,7 +4799,7 @@ Test 087 cpld_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_bmarkfrac_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_bmarkfrac_prod
 Checking test 088 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4855,7 +4855,7 @@ Test 088 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmarkfrac_v16_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmarkfrac_v16_prod
 Checking test 089 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4911,7 +4911,7 @@ Test 089 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_restart_bmarkfrac_v16_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_restart_bmarkfrac_v16_prod
 Checking test 090 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4967,7 +4967,7 @@ Test 090 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmark_wave_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmark_wave_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmark_wave_prod
 Checking test 091 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5026,7 +5026,7 @@ Test 091 cpld_bmark_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmarkfrac_wave_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmarkfrac_wave_prod
 Checking test 092 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5085,7 +5085,7 @@ Test 092 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_bmarkfrac_wave_v16_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_bmarkfrac_wave_v16_prod
 Checking test 093 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5144,7 +5144,7 @@ Test 093 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_control_wave_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_control_wave_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_control_wave_prod
 Checking test 094 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5200,7 +5200,7 @@ Test 094 cpld_control_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debug_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_debug_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_debug_prod
 Checking test 095 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5253,7 +5253,7 @@ Test 095 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/cpld_debugfrac_ccpp
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/cpld_debugfrac_prod
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/cpld_debugfrac_prod
 Checking test 096 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5306,7 +5306,7 @@ Test 096 cpld_debugfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_control_cfsr
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_control_cfsr
 Checking test 097 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5315,7 +5315,7 @@ Test 097 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_restart_cfsr
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_restart_cfsr
 Checking test 098 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5324,7 +5324,7 @@ Test 098 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_control_gefs
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_control_gefs
 Checking test 099 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5333,7 +5333,7 @@ Test 099 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_bulk_cfsr
 Checking test 100 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5342,7 +5342,7 @@ Test 100 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_bulk_gefs
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_bulk_gefs
 Checking test 101 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5351,7 +5351,7 @@ Test 101 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_mx025_cfsr
 Checking test 102 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5363,7 +5363,7 @@ Test 102 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_mx025_gefs
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_mx025_gefs
 Checking test 103 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5375,14 +5375,13 @@ Test 103 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_308104/datm_debug_cfsr
+working dir  = /work/noaa/stmp/dworthen/stmp/dworthen/FV3_RT/rt_262387/datm_debug_cfsr
 Checking test 104 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 Test 104 datm_debug_cfsr PASS
 
-
-REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 10:32:34 CST 2021
-Elapsed time: 01h:17m:49s. Have a nice day!
+REGRESSION TEST FAILED
+Fri Feb  5 14:17:06 CST 2021
+Elapsed time: 01h:23m:41s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Wed Feb  3 16:48:37 UTC 2021
+Fri Feb  5 18:49:39 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_control_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_decomp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_2threads_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_stochy_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_ca_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_ca_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_lndp_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_lndp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_iau_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_multigases_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_multigases_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_stretched_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,7 +1229,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1240,7 +1240,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1270,7 +1270,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1290,7 +1290,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1338,7 +1338,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1434,7 +1434,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,7 +1530,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,7 +1578,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1626,7 +1626,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1678,7 +1678,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_cpt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1732,7 +1732,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gsd_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,7 +1824,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rap_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_rap_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1892,7 +1892,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_hrrr_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1960,7 +1960,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2028,7 +2028,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2096,7 +2096,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2164,7 +2164,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2232,7 +2232,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_prod
 Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 043 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2362,7 +2362,7 @@ Test 044 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2430,7 +2430,7 @@ Test 045 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2498,7 +2498,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2566,7 +2566,7 @@ Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2628,7 +2628,7 @@ Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2676,7 +2676,7 @@ Test 049 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2724,7 +2724,7 @@ Test 050 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gocart_clm_prod
 Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2772,7 +2772,7 @@ Test 051 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_flake_prod
 Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2840,7 +2840,7 @@ Test 052 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2908,7 +2908,7 @@ Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2926,7 +2926,7 @@ Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2994,7 +2994,7 @@ Test 055 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_debug_prod
 Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3062,7 +3062,7 @@ Test 056 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3130,7 +3130,7 @@ Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3198,7 +3198,7 @@ Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gsd_debug_prod
 Checking test 059 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3266,7 +3266,7 @@ Test 059 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 060 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3334,7 +3334,7 @@ Test 060 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_thompson_debug_prod
 Checking test 061 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3402,7 +3402,7 @@ Test 061 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 062 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3470,7 +3470,7 @@ Test 062 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 063 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3538,7 +3538,7 @@ Test 063 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3606,7 +3606,7 @@ Test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_39366/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_25462/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3624,5 +3624,5 @@ Test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 17:28:23 UTC 2021
-Elapsed time: 00h:39m:46s. Have a nice day!
+Fri Feb  5 19:29:28 UTC 2021
+Elapsed time: 00h:39m:50s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Wed Feb  3 16:47:27 UTC 2021
+Fri Feb  5 18:46:41 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_control_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -429,9 +429,9 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
- Comparing dynf000.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_ca_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_lndp_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_lndp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_iau_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmprad_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_multigases_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_multigases_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_multigases_prod
 Checking test 019 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1105,7 +1105,7 @@ Test 019 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_control_32bit_prod
 Checking test 020 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1173,7 +1173,7 @@ Test 020 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_stretched_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_stretched_prod
 Checking test 021 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1229,7 +1229,7 @@ Test 021 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_stretched_nest_prod
 Checking test 022 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1296,7 +1296,7 @@ Test 022 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_regional_control_prod
 Checking test 023 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1307,7 +1307,7 @@ Test 023 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_regional_restart_prod
 Checking test 024 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1316,7 +1316,7 @@ Test 024 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_regional_quilt_prod
 Checking test 025 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1327,18 +1327,18 @@ Test 025 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 026 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 Test 026 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_control_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_control_debug_prod
 Checking test 027 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1368,7 +1368,7 @@ Test 027 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_stretched_nest_debug_prod
 Checking test 028 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1388,7 +1388,7 @@ Test 028 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmp_prod
 Checking test 029 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1436,7 +1436,7 @@ Test 029 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1484,7 +1484,7 @@ Test 030 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1532,7 +1532,7 @@ Test 031 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_csawmg_prod
 Checking test 032 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1580,7 +1580,7 @@ Test 032 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_satmedmf_prod
 Checking test 033 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1628,7 +1628,7 @@ Test 033 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_satmedmfq_prod
 Checking test 034 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1676,7 +1676,7 @@ Test 034 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1724,7 +1724,7 @@ Test 035 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1776,7 +1776,7 @@ Test 036 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_cpt_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_cpt_prod
 Checking test 037 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1830,7 +1830,7 @@ Test 037 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gsd_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gsd_prod
 Checking test 038 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1922,7 +1922,7 @@ Test 038 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rap_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_rap_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_rap_prod
 Checking test 039 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1990,7 +1990,7 @@ Test 039 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_hrrr_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_hrrr_prod
 Checking test 040 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2058,7 +2058,7 @@ Test 040 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_thompson_prod
 Checking test 041 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2126,7 +2126,7 @@ Test 041 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_thompson_no_aero_prod
 Checking test 042 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2194,7 +2194,7 @@ Test 042 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_rrfs_v1beta_prod
 Checking test 043 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2262,7 +2262,7 @@ Test 043 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v15p2_prod
 Checking test 044 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2330,7 +2330,7 @@ Test 044 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_prod
 Checking test 045 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2410,7 +2410,7 @@ Test 045 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_restart_prod
 Checking test 046 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2460,7 +2460,7 @@ Test 046 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 047 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2528,7 +2528,7 @@ Test 047 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 048 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2596,7 +2596,7 @@ Test 048 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2664,7 +2664,7 @@ Test 049 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 050 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2726,7 +2726,7 @@ Test 050 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2774,7 +2774,7 @@ Test 051 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2822,7 +2822,7 @@ Test 052 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gocart_clm_prod
 Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2870,7 +2870,7 @@ Test 053 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_flake_prod
 Checking test 054 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2938,7 +2938,7 @@ Test 054 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3006,7 +3006,7 @@ Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3024,7 +3024,7 @@ Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3092,7 +3092,7 @@ Test 057 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3160,7 +3160,7 @@ Test 058 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3228,7 +3228,7 @@ Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3296,7 +3296,7 @@ Test 060 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gsd_debug_prod
 Checking test 061 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3364,7 +3364,7 @@ Test 061 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3432,7 +3432,7 @@ Test 062 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_thompson_debug_prod
 Checking test 063 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3500,7 +3500,7 @@ Test 063 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3568,7 +3568,7 @@ Test 064 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3636,7 +3636,7 @@ Test 065 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3704,7 +3704,7 @@ Test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3722,7 +3722,7 @@ Test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_control_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_control_prod
 Checking test 068 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3775,7 +3775,7 @@ Test 068 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_prod
 Checking test 069 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3828,7 +3828,7 @@ Test 069 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_controlfrac_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_controlfrac_prod
 Checking test 070 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3881,7 +3881,7 @@ Test 070 cpld_controlfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restartfrac_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restartfrac_prod
 Checking test 071 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3934,7 +3934,7 @@ Test 071 cpld_restartfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_2threads_prod
 Checking test 072 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3987,7 +3987,7 @@ Test 072 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_decomp_prod
 Checking test 073 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4040,7 +4040,7 @@ Test 073 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_satmedmf_prod
 Checking test 074 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4093,7 +4093,7 @@ Test 074 cpld_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_ca_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_ca_prod
 Checking test 075 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4146,7 +4146,7 @@ Test 075 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_control_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_control_c192_prod
 Checking test 076 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4199,7 +4199,7 @@ Test 076 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_c192_prod
 Checking test 077 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4252,7 +4252,7 @@ Test 077 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_controlfrac_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_controlfrac_c192_prod
 Checking test 078 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4305,7 +4305,7 @@ Test 078 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restartfrac_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restartfrac_c192_prod
 Checking test 079 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4358,7 +4358,7 @@ Test 079 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_control_c384_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_control_c384_prod
 Checking test 080 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4414,7 +4414,7 @@ Test 080 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_c384_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_c384_prod
 Checking test 081 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4470,7 +4470,7 @@ Test 081 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_controlfrac_c384_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_controlfrac_c384_prod
 Checking test 082 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4526,7 +4526,7 @@ Test 082 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restartfrac_c384_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restartfrac_c384_prod
 Checking test 083 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4582,7 +4582,7 @@ Test 083 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmark_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmark_prod
 Checking test 084 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4638,7 +4638,7 @@ Test 084 cpld_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_bmark_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_bmark_prod
 Checking test 085 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4694,7 +4694,7 @@ Test 085 cpld_restart_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmarkfrac_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmarkfrac_prod
 Checking test 086 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4750,7 +4750,7 @@ Test 086 cpld_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_bmarkfrac_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_bmarkfrac_prod
 Checking test 087 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4806,7 +4806,7 @@ Test 087 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmarkfrac_v16_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmarkfrac_v16_prod
 Checking test 088 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4862,7 +4862,7 @@ Test 088 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_restart_bmarkfrac_v16_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_restart_bmarkfrac_v16_prod
 Checking test 089 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4918,7 +4918,7 @@ Test 089 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmark_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmark_wave_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmark_wave_prod
 Checking test 090 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4977,7 +4977,7 @@ Test 090 cpld_bmark_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmarkfrac_wave_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmarkfrac_wave_prod
 Checking test 091 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5036,7 +5036,7 @@ Test 091 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_bmarkfrac_wave_v16_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_bmarkfrac_wave_v16_prod
 Checking test 092 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5095,7 +5095,7 @@ Test 092 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_control_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_control_wave_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_control_wave_prod
 Checking test 093 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5151,7 +5151,7 @@ Test 093 cpld_control_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_debug_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_debug_prod
 Checking test 094 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5204,7 +5204,7 @@ Test 094 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/cpld_debugfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/cpld_debugfrac_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/cpld_debugfrac_prod
 Checking test 095 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5257,7 +5257,7 @@ Test 095 cpld_debugfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_control_cfsr
 Checking test 096 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5266,7 +5266,7 @@ Test 096 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_restart_cfsr
 Checking test 097 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5275,7 +5275,7 @@ Test 097 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_control_gefs
 Checking test 098 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5284,7 +5284,7 @@ Test 098 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_bulk_cfsr
 Checking test 099 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5293,7 +5293,7 @@ Test 099 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_bulk_gefs
 Checking test 100 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5302,7 +5302,7 @@ Test 100 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_mx025_cfsr
 Checking test 101 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5314,7 +5314,7 @@ Test 101 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_mx025_gefs
 Checking test 102 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5326,7 +5326,7 @@ Test 102 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210128/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_67081/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_191883/datm_debug_cfsr
 Checking test 103 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5335,5 +5335,5 @@ Test 103 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 19:46:49 UTC 2021
-Elapsed time: 02h:59m:24s. Have a nice day!
+Fri Feb  5 21:37:45 UTC 2021
+Elapsed time: 02h:51m:08s. Have a nice day!


### PR DESCRIPTION
## Description

The fv3atm and ccpp-physics PRs listed below move calls to initialize LSM lookup tables (soil vegetation parameters) from fv3atm (IPD physics0 to CCPP, remove the IPD source files and correct the logic for initializing snow cover over ice for RUC LSM in `FV3/io/FV3GFS_io.F90`.

See https://github.com/NOAA-EMC/fv3atm/issues/214 step 2 for more information.
 
### Issue(s) addressed

These PRs address step 2 of https://github.com/NOAA-EMC/fv3atm/issues/214 except for the remaining Noah MP tables.

## Testing

Regression testing done on all tier-1 platforms, logs updated in PR.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/564
https://github.com/NOAA-EMC/fv3atm/pull/244
https://github.com/ufs-community/ufs-weather-model/pull/407
