### PR TITLE
Update ccpp-physics. Make RRTMGP thread safe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/dustinswales/fv3atm
+  branch = hotfix_GPthreading
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/dustinswales/fv3atm
-  branch = hotfix_GPthreading
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Feb 17 13:05:22 MST 2021
+Wed Feb 24 11:31:32 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfsv16_ugwpv1_prod
 Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -965,7 +965,7 @@ Test 015 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
 Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1027,7 +1027,7 @@ Test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_control_debug_prod
 Checking test 017 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1057,7 +1057,7 @@ Test 017 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1125,7 +1125,7 @@ Test 018 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1193,7 +1193,7 @@ Test 019 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1261,7 +1261,7 @@ Test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1329,7 +1329,7 @@ Test 021 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_multigases_prod
 Checking test 022 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1403,7 +1403,7 @@ Test 022 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_regional_control_debug_prod
 Checking test 023 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1414,7 +1414,7 @@ Test 023 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 024 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 024 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gsd_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gsd_debug_prod
 Checking test 025 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1550,7 +1550,7 @@ Test 025 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_thompson_debug_prod
 Checking test 026 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1618,7 +1618,7 @@ Test 026 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 027 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1686,7 +1686,7 @@ Test 027 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1754,7 +1754,7 @@ Test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1772,7 +1772,7 @@ Test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_2817/fv3_ccpp_gfsv16_ugwpv1_debug_prod
 Checking test 030 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1834,5 +1834,5 @@ Test 030 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 17 13:22:49 MST 2021
-Elapsed time: 00h:17m:28s. Have a nice day!
+Wed Feb 24 11:50:16 MST 2021
+Elapsed time: 00h:18m:44s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Feb 17 13:30:04 MST 2021
+Wed Feb 24 12:37:37 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_read_inc_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -430,7 +430,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_lndp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_iau_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_lheatstrg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_nest_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_quilt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,18 +1229,18 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1336,7 +1336,7 @@ Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1384,7 +1384,7 @@ Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_csawmg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1432,7 +1432,7 @@ Test 028 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1480,7 +1480,7 @@ Test 029 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_satmedmfq_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1528,7 +1528,7 @@ Test 030 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1576,7 +1576,7 @@ Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1628,7 +1628,7 @@ Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_cpt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_cpt_prod
 Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1682,7 +1682,7 @@ Test 033 fv3_ccpp_cpt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gsd_prod
 Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1774,7 +1774,7 @@ Test 034 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rap_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_rap_prod
 Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 035 fv3_ccpp_rap PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_hrrr_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_hrrr_prod
 Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 036 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_thompson_prod
 Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 037 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_thompson_no_aero_prod
 Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_rrfs_v1beta_prod
 Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_prod
 Checking test 040 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2194,7 +2194,7 @@ Test 040 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_restart_prod
 Checking test 041 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2244,7 +2244,7 @@ Test 041 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 042 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 042 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 043 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 043 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2441,9 +2441,77 @@ Checking test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 045 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 045 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gocart_clm_prod
-Checking test 045 fv3_ccpp_gocart_clm results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gocart_clm_prod
+Checking test 046 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2486,12 +2554,12 @@ Checking test 045 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gocart_clm PASS
+Test 046 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_flake_prod
-Checking test 046 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_flake_prod
+Checking test 047 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2554,12 +2622,12 @@ Checking test 046 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16_flake PASS
+Test 047 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 048 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2622,12 +2690,12 @@ Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 048 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 049 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2640,12 +2708,12 @@ Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 049 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 050 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2702,12 +2770,12 @@ Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 050 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 051 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2764,12 +2832,12 @@ Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 051 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2832,12 +2900,12 @@ Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfs_v15p2_debug PASS
+Test 052 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_debug_prod
-Checking test 052 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_debug_prod
+Checking test 053 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2900,12 +2968,12 @@ Checking test 052 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v16_debug PASS
+Test 053 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2968,12 +3036,12 @@ Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 055 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3036,23 +3104,23 @@ Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 055 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_control_debug_prod
-Checking test 055 fv3_ccpp_regional_control_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_regional_control_debug_prod
+Checking test 056 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 055 fv3_ccpp_regional_control_debug PASS
+Test 056 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_debug_prod
-Checking test 056 fv3_ccpp_control_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_control_debug_prod
+Checking test 057 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3077,12 +3145,12 @@ Checking test 056 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 056 fv3_ccpp_control_debug PASS
+Test 057 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_nest_debug_prod
-Checking test 057 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_stretched_nest_debug_prod
+Checking test 058 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3097,12 +3165,12 @@ Checking test 057 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 057 fv3_ccpp_stretched_nest_debug PASS
+Test 058 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_debug_prod
-Checking test 058 fv3_ccpp_gsd_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gsd_debug_prod
+Checking test 059 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3165,12 +3233,12 @@ Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gsd_debug PASS
+Test 059 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 060 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3233,12 +3301,12 @@ Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gsd_diag3d_debug PASS
+Test 060 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_debug_prod
-Checking test 060 fv3_ccpp_thompson_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_thompson_debug_prod
+Checking test 061 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3301,12 +3369,12 @@ Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_thompson_debug PASS
+Test 061 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 062 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3369,12 +3437,12 @@ Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_thompson_no_aero_debug PASS
+Test 062 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 063 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3437,12 +3505,12 @@ Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 063 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3505,12 +3573,12 @@ Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3523,12 +3591,12 @@ Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 066 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3585,12 +3653,12 @@ Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 066 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_prod
-Checking test 066 cpld_control results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_control_prod
+Checking test 067 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3638,12 +3706,12 @@ Checking test 066 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 066 cpld_control PASS
+Test 067 cpld_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_prod
-Checking test 067 cpld_restart results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_prod
+Checking test 068 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3691,12 +3759,12 @@ Checking test 067 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 067 cpld_restart PASS
+Test 068 cpld_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_prod
-Checking test 068 cpld_controlfrac results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_controlfrac_prod
+Checking test 069 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3744,12 +3812,12 @@ Checking test 068 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 068 cpld_controlfrac PASS
+Test 069 cpld_controlfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_prod
-Checking test 069 cpld_restartfrac results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restartfrac_prod
+Checking test 070 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3797,12 +3865,12 @@ Checking test 069 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 069 cpld_restartfrac PASS
+Test 070 cpld_restartfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_2threads_prod
-Checking test 070 cpld_2threads results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_2threads_prod
+Checking test 071 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3850,12 +3918,12 @@ Checking test 070 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 070 cpld_2threads PASS
+Test 071 cpld_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_decomp_prod
-Checking test 071 cpld_decomp results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_decomp_prod
+Checking test 072 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3903,12 +3971,12 @@ Checking test 071 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 071 cpld_decomp PASS
+Test 072 cpld_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_satmedmf_prod
-Checking test 072 cpld_satmedmf results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_satmedmf_prod
+Checking test 073 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3956,12 +4024,12 @@ Checking test 072 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_satmedmf PASS
+Test 073 cpld_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_ca_prod
-Checking test 073 cpld_ca results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_ca_prod
+Checking test 074 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4009,12 +4077,12 @@ Checking test 073 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_ca PASS
+Test 074 cpld_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_c192_prod
-Checking test 074 cpld_control_c192 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_control_c192_prod
+Checking test 075 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4062,12 +4130,12 @@ Checking test 074 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 074 cpld_control_c192 PASS
+Test 075 cpld_control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_c192_prod
-Checking test 075 cpld_restart_c192 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_c192_prod
+Checking test 076 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4115,12 +4183,12 @@ Checking test 075 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 075 cpld_restart_c192 PASS
+Test 076 cpld_restart_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_c192_prod
-Checking test 076 cpld_controlfrac_c192 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_controlfrac_c192_prod
+Checking test 077 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4168,12 +4236,12 @@ Checking test 076 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 076 cpld_controlfrac_c192 PASS
+Test 077 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_c192_prod
-Checking test 077 cpld_restartfrac_c192 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restartfrac_c192_prod
+Checking test 078 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4221,12 +4289,12 @@ Checking test 077 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 077 cpld_restartfrac_c192 PASS
+Test 078 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_c384_prod
-Checking test 078 cpld_control_c384 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_control_c384_prod
+Checking test 079 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4277,12 +4345,12 @@ Checking test 078 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_control_c384 PASS
+Test 079 cpld_control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_c384_prod
-Checking test 079 cpld_restart_c384 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_c384_prod
+Checking test 080 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4333,12 +4401,12 @@ Checking test 079 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_restart_c384 PASS
+Test 080 cpld_restart_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_c384_prod
-Checking test 080 cpld_controlfrac_c384 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_controlfrac_c384_prod
+Checking test 081 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4389,12 +4457,12 @@ Checking test 080 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 080 cpld_controlfrac_c384 PASS
+Test 081 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_c384_prod
-Checking test 081 cpld_restartfrac_c384 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restartfrac_c384_prod
+Checking test 082 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4445,12 +4513,12 @@ Checking test 081 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 081 cpld_restartfrac_c384 PASS
+Test 082 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmark_prod
-Checking test 082 cpld_bmark results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmark_prod
+Checking test 083 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4501,12 +4569,12 @@ Checking test 082 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 082 cpld_bmark PASS
+Test 083 cpld_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmark_prod
-Checking test 083 cpld_restart_bmark results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_bmark_prod
+Checking test 084 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4557,12 +4625,12 @@ Checking test 083 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 083 cpld_restart_bmark PASS
+Test 084 cpld_restart_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_prod
-Checking test 084 cpld_bmarkfrac results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmarkfrac_prod
+Checking test 085 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4613,12 +4681,12 @@ Checking test 084 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 084 cpld_bmarkfrac PASS
+Test 085 cpld_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmarkfrac_prod
-Checking test 085 cpld_restart_bmarkfrac results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_bmarkfrac_prod
+Checking test 086 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4669,12 +4737,12 @@ Checking test 085 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 085 cpld_restart_bmarkfrac PASS
+Test 086 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_v16_prod
-Checking test 086 cpld_bmarkfrac_v16 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmarkfrac_v16_prod
+Checking test 087 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4725,12 +4793,12 @@ Checking test 086 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 086 cpld_bmarkfrac_v16 PASS
+Test 087 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmarkfrac_v16_prod
-Checking test 087 cpld_restart_bmarkfrac_v16 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_restart_bmarkfrac_v16_prod
+Checking test 088 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4781,12 +4849,12 @@ Checking test 087 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 087 cpld_restart_bmarkfrac_v16 PASS
+Test 088 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmark_wave_prod
-Checking test 088 cpld_bmark_wave results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmark_wave_prod
+Checking test 089 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4840,12 +4908,12 @@ Checking test 088 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmark_wave PASS
+Test 089 cpld_bmark_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_wave_prod
-Checking test 089 cpld_bmarkfrac_wave results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmarkfrac_wave_prod
+Checking test 090 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4899,12 +4967,12 @@ Checking test 089 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_bmarkfrac_wave PASS
+Test 090 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_wave_v16_prod
-Checking test 090 cpld_bmarkfrac_wave_v16 results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_bmarkfrac_wave_v16_prod
+Checking test 091 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4958,12 +5026,12 @@ Checking test 090 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 090 cpld_bmarkfrac_wave_v16 PASS
+Test 091 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_wave_prod
-Checking test 091 cpld_control_wave results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_control_wave_prod
+Checking test 092 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5014,12 +5082,12 @@ Checking test 091 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 091 cpld_control_wave PASS
+Test 092 cpld_control_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_debug_prod
-Checking test 092 cpld_debug results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_debug_prod
+Checking test 093 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5067,12 +5135,12 @@ Checking test 092 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 092 cpld_debug PASS
+Test 093 cpld_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_debugfrac_prod
-Checking test 093 cpld_debugfrac results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/cpld_debugfrac_prod
+Checking test 094 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5120,87 +5188,87 @@ Checking test 093 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 093 cpld_debugfrac PASS
+Test 094 cpld_debugfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_control_cfsr
-Checking test 094 datm_control_cfsr results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_control_cfsr
+Checking test 095 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 094 datm_control_cfsr PASS
+Test 095 datm_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_restart_cfsr
-Checking test 095 datm_restart_cfsr results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_restart_cfsr
+Checking test 096 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 095 datm_restart_cfsr PASS
+Test 096 datm_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_control_gefs
-Checking test 096 datm_control_gefs results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_control_gefs
+Checking test 097 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 096 datm_control_gefs PASS
+Test 097 datm_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_bulk_cfsr
-Checking test 097 datm_bulk_cfsr results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_bulk_cfsr
+Checking test 098 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 097 datm_bulk_cfsr PASS
+Test 098 datm_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_bulk_gefs
-Checking test 098 datm_bulk_gefs results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_bulk_gefs
+Checking test 099 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 098 datm_bulk_gefs PASS
+Test 099 datm_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_mx025_cfsr
-Checking test 099 datm_mx025_cfsr results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_mx025_cfsr
+Checking test 100 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 099 datm_mx025_cfsr PASS
+Test 100 datm_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_mx025_gefs
-Checking test 100 datm_mx025_gefs results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_mx025_gefs
+Checking test 101 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 100 datm_mx025_gefs PASS
+Test 101 datm_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_debug_cfsr
-Checking test 101 datm_debug_cfsr results ....
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_40081/datm_debug_cfsr
+Checking test 102 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 101 datm_debug_cfsr PASS
+Test 102 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 17 14:49:52 MST 2021
-Elapsed time: 01h:19m:48s. Have a nice day!
+Wed Feb 24 13:57:44 MST 2021
+Elapsed time: 01h:20m:08s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Wed Feb 17 18:30:56 EST 2021
+Tue Feb 23 19:30:29 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_decomp_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_2threads_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_restart_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_read_inc_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stochy_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_ca_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_lndp_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_iau_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_lheatstrg_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_multigases_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_32bit_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_nest_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_restart_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_quilt_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,7 +1229,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1240,7 +1240,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmp_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1336,7 +1336,7 @@ Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1384,7 +1384,7 @@ Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_csawmg_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1432,7 +1432,7 @@ Test 028 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_satmedmf_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1480,7 +1480,7 @@ Test 029 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_satmedmfq_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1528,7 +1528,7 @@ Test 030 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1576,7 +1576,7 @@ Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1628,7 +1628,7 @@ Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_cpt_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_cpt_prod
 Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1682,7 +1682,7 @@ Test 033 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gsd_prod
 Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1774,7 +1774,7 @@ Test 034 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rap_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_rap_prod
 Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 035 fv3_ccpp_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_hrrr_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_hrrr_prod
 Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 036 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_thompson_prod
 Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 037 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_thompson_no_aero_prod
 Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_rrfs_v1beta_prod
 Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v15p2_prod
 Checking test 040 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 040 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_prod
 Checking test 041 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2262,7 +2262,7 @@ Test 041 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_restart_prod
 Checking test 042 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 042 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 043 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 043 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 044 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2448,7 +2448,7 @@ Test 044 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2516,7 +2516,7 @@ Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2577,9 +2577,77 @@ Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 047 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 047 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 047 fv3_ccpp_gfsv16_csawmg results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 048 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2622,12 +2690,12 @@ Checking test 047 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfsv16_csawmg PASS
+Test 048 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 048 fv3_ccpp_gfsv16_csawmgt results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 049 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2670,12 +2738,12 @@ Checking test 048 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfsv16_csawmgt PASS
+Test 049 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gocart_clm_prod
-Checking test 049 fv3_ccpp_gocart_clm results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gocart_clm_prod
+Checking test 050 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2718,12 +2786,12 @@ Checking test 049 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gocart_clm PASS
+Test 050 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_flake_prod
-Checking test 050 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_flake_prod
+Checking test 051 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2786,12 +2854,12 @@ Checking test 050 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfs_v16_flake PASS
+Test 051 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 051 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 052 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2854,12 +2922,12 @@ Checking test 051 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 052 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2872,12 +2940,12 @@ Checking test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 053 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 054 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2934,12 +3002,12 @@ Checking test 053 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 054 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 055 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2996,12 +3064,12 @@ Checking test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 055 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 056 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3064,12 +3132,12 @@ Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfs_v15p2_debug PASS
+Test 056 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_debug_prod
-Checking test 056 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_debug_prod
+Checking test 057 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3132,12 +3200,12 @@ Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfs_v16_debug PASS
+Test 057 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 058 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3200,12 +3268,12 @@ Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 058 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 059 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3268,23 +3336,23 @@ Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 059 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_control_debug_prod
-Checking test 059 fv3_ccpp_regional_control_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_regional_control_debug_prod
+Checking test 060 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 059 fv3_ccpp_regional_control_debug PASS
+Test 060 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_debug_prod
-Checking test 060 fv3_ccpp_control_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_control_debug_prod
+Checking test 061 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3309,12 +3377,12 @@ Checking test 060 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 060 fv3_ccpp_control_debug PASS
+Test 061 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_nest_debug_prod
-Checking test 061 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_stretched_nest_debug_prod
+Checking test 062 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3329,12 +3397,12 @@ Checking test 061 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 061 fv3_ccpp_stretched_nest_debug PASS
+Test 062 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_debug_prod
-Checking test 062 fv3_ccpp_gsd_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gsd_debug_prod
+Checking test 063 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3397,12 +3465,12 @@ Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gsd_debug PASS
+Test 063 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 064 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3465,12 +3533,12 @@ Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_gsd_diag3d_debug PASS
+Test 064 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_debug_prod
-Checking test 064 fv3_ccpp_thompson_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_thompson_debug_prod
+Checking test 065 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3533,12 +3601,12 @@ Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_thompson_debug PASS
+Test 065 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 066 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3601,12 +3669,12 @@ Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_thompson_no_aero_debug PASS
+Test 066 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 067 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3669,12 +3737,12 @@ Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 067 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 068 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3737,12 +3805,12 @@ Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 068 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 069 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3755,12 +3823,12 @@ Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 069 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 069 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 070 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3817,12 +3885,12 @@ Checking test 069 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 069 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 070 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_prod
-Checking test 070 cpld_control results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_control_prod
+Checking test 071 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3870,12 +3938,12 @@ Checking test 070 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 070 cpld_control PASS
+Test 071 cpld_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_prod
-Checking test 071 cpld_restart results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restart_prod
+Checking test 072 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3923,12 +3991,12 @@ Checking test 071 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 071 cpld_restart PASS
+Test 072 cpld_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_prod
-Checking test 072 cpld_controlfrac results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_controlfrac_prod
+Checking test 073 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3976,12 +4044,12 @@ Checking test 072 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_controlfrac PASS
+Test 073 cpld_controlfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_prod
-Checking test 073 cpld_restartfrac results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restartfrac_prod
+Checking test 074 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4029,12 +4097,12 @@ Checking test 073 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_restartfrac PASS
+Test 074 cpld_restartfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_2threads_prod
-Checking test 074 cpld_2threads results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_2threads_prod
+Checking test 075 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4082,12 +4150,12 @@ Checking test 074 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_2threads PASS
+Test 075 cpld_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_decomp_prod
-Checking test 075 cpld_decomp results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_decomp_prod
+Checking test 076 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4135,12 +4203,12 @@ Checking test 075 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_decomp PASS
+Test 076 cpld_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_satmedmf_prod
-Checking test 076 cpld_satmedmf results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_satmedmf_prod
+Checking test 077 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4188,12 +4256,12 @@ Checking test 076 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_satmedmf PASS
+Test 077 cpld_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_ca_prod
-Checking test 077 cpld_ca results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_ca_prod
+Checking test 078 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4241,12 +4309,12 @@ Checking test 077 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_ca PASS
+Test 078 cpld_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_c192_prod
-Checking test 078 cpld_control_c192 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_control_c192_prod
+Checking test 079 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4294,12 +4362,12 @@ Checking test 078 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 078 cpld_control_c192 PASS
+Test 079 cpld_control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_c192_prod
-Checking test 079 cpld_restart_c192 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restart_c192_prod
+Checking test 080 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4347,12 +4415,12 @@ Checking test 079 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 079 cpld_restart_c192 PASS
+Test 080 cpld_restart_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_c192_prod
-Checking test 080 cpld_controlfrac_c192 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_controlfrac_c192_prod
+Checking test 081 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4400,12 +4468,12 @@ Checking test 080 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_controlfrac_c192 PASS
+Test 081 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_c192_prod
-Checking test 081 cpld_restartfrac_c192 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restartfrac_c192_prod
+Checking test 082 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4453,12 +4521,12 @@ Checking test 081 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_restartfrac_c192 PASS
+Test 082 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_c384_prod
-Checking test 082 cpld_control_c384 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_control_c384_prod
+Checking test 083 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4509,12 +4577,12 @@ Checking test 082 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 082 cpld_control_c384 PASS
+Test 083 cpld_control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_c384_prod
-Checking test 083 cpld_restart_c384 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restart_c384_prod
+Checking test 084 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4565,12 +4633,12 @@ Checking test 083 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 083 cpld_restart_c384 PASS
+Test 084 cpld_restart_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_c384_prod
-Checking test 084 cpld_controlfrac_c384 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_controlfrac_c384_prod
+Checking test 085 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4621,12 +4689,12 @@ Checking test 084 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_controlfrac_c384 PASS
+Test 085 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_c384_prod
-Checking test 085 cpld_restartfrac_c384 results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restartfrac_c384_prod
+Checking test 086 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4677,12 +4745,12 @@ Checking test 085 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_restartfrac_c384 PASS
+Test 086 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_bmark_prod
-Checking test 086 cpld_bmark results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_bmark_prod
+Checking test 087 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4733,12 +4801,12 @@ Checking test 086 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 086 cpld_bmark PASS
+Test 087 cpld_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_bmark_prod
-Checking test 087 cpld_restart_bmark results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restart_bmark_prod
+Checking test 088 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4789,12 +4857,12 @@ Checking test 087 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 087 cpld_restart_bmark PASS
+Test 088 cpld_restart_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_bmarkfrac_prod
-Checking test 088 cpld_bmarkfrac results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_bmarkfrac_prod
+Checking test 089 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4845,12 +4913,12 @@ Checking test 088 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmarkfrac PASS
+Test 089 cpld_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_bmarkfrac_prod
-Checking test 089 cpld_restart_bmarkfrac results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_restart_bmarkfrac_prod
+Checking test 090 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4901,12 +4969,12 @@ Checking test 089 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_restart_bmarkfrac PASS
+Test 090 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_debug_prod
-Checking test 090 cpld_debug results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_debug_prod
+Checking test 091 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -4954,12 +5022,12 @@ Checking test 090 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 090 cpld_debug PASS
+Test 091 cpld_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_debugfrac_prod
-Checking test 091 cpld_debugfrac results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/cpld_debugfrac_prod
+Checking test 092 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5007,87 +5075,87 @@ Checking test 091 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 091 cpld_debugfrac PASS
+Test 092 cpld_debugfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_control_cfsr
-Checking test 092 datm_control_cfsr results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_control_cfsr
+Checking test 093 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 092 datm_control_cfsr PASS
+Test 093 datm_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_restart_cfsr
-Checking test 093 datm_restart_cfsr results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_restart_cfsr
+Checking test 094 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 093 datm_restart_cfsr PASS
+Test 094 datm_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_control_gefs
-Checking test 094 datm_control_gefs results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_control_gefs
+Checking test 095 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 094 datm_control_gefs PASS
+Test 095 datm_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_bulk_cfsr
-Checking test 095 datm_bulk_cfsr results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_bulk_cfsr
+Checking test 096 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 095 datm_bulk_cfsr PASS
+Test 096 datm_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_bulk_gefs
-Checking test 096 datm_bulk_gefs results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_bulk_gefs
+Checking test 097 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 096 datm_bulk_gefs PASS
+Test 097 datm_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_mx025_cfsr
-Checking test 097 datm_mx025_cfsr results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_mx025_cfsr
+Checking test 098 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 097 datm_mx025_cfsr PASS
+Test 098 datm_mx025_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_mx025_gefs
-Checking test 098 datm_mx025_gefs results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_mx025_gefs
+Checking test 099 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 098 datm_mx025_gefs PASS
+Test 099 datm_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_debug_cfsr
-Checking test 099 datm_debug_cfsr results ....
+working dir  = /lustre/f2/scratch/Dusan.Jovic/FV3_RT/rt_20298/datm_debug_cfsr
+Checking test 100 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 099 datm_debug_cfsr PASS
+Test 100 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 17 20:13:13 EST 2021
-Elapsed time: 01h:42m:18s. Have a nice day!
+Tue Feb 23 20:51:42 EST 2021
+Elapsed time: 01h:21m:13s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Wed Feb 17 20:45:37 UTC 2021
+Wed Feb 24 04:48:13 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfsv16_ugwpv1_prod
 Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -965,7 +965,7 @@ Test 015 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
 Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1027,7 +1027,7 @@ Test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_control_debug_prod
 Checking test 017 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1057,7 +1057,7 @@ Test 017 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1125,7 +1125,7 @@ Test 018 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1193,7 +1193,7 @@ Test 019 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1261,7 +1261,7 @@ Test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1329,7 +1329,7 @@ Test 021 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_multigases_prod
 Checking test 022 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1403,7 +1403,7 @@ Test 022 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_regional_control_debug_prod
 Checking test 023 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1414,7 +1414,7 @@ Test 023 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 024 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 024 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gsd_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gsd_debug_prod
 Checking test 025 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1550,7 +1550,7 @@ Test 025 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_thompson_debug_prod
 Checking test 026 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1618,7 +1618,7 @@ Test 026 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 027 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1686,7 +1686,7 @@ Test 027 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1754,7 +1754,7 @@ Test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1772,7 +1772,7 @@ Test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_289552/fv3_ccpp_gfsv16_ugwpv1_debug_prod
 Checking test 030 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1834,5 +1834,5 @@ Test 030 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 17 21:14:47 UTC 2021
-Elapsed time: 00h:29m:11s. Have a nice day!
+Wed Feb 24 05:56:35 UTC 2021
+Elapsed time: 01h:08m:22s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Thu Feb 18 02:57:16 UTC 2021
+Wed Feb 24 00:14:15 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_read_inc_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -429,10 +429,10 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_lndp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_iau_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_lheatstrg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1080,7 +1080,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1154,7 +1154,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1222,7 +1222,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1278,7 +1278,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_nest_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1345,7 +1345,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1356,7 +1356,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1365,7 +1365,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_quilt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1376,7 +1376,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1387,7 +1387,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmp_prod
 Checking test 028 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1435,7 +1435,7 @@ Test 028 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 029 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1483,7 +1483,7 @@ Test 029 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 030 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1531,7 +1531,7 @@ Test 030 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_csawmg_prod
 Checking test 031 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1579,7 +1579,7 @@ Test 031 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_satmedmf_prod
 Checking test 032 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1627,7 +1627,7 @@ Test 032 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_satmedmfq_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_satmedmfq_prod
 Checking test 033 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1675,7 +1675,7 @@ Test 033 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 034 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1723,7 +1723,7 @@ Test 034 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 035 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1775,7 +1775,7 @@ Test 035 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_cpt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_cpt_prod
 Checking test 036 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1829,7 +1829,7 @@ Test 036 fv3_ccpp_cpt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gsd_prod
 Checking test 037 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1921,7 +1921,7 @@ Test 037 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rap_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_rap_prod
 Checking test 038 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1989,7 +1989,7 @@ Test 038 fv3_ccpp_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_hrrr_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_hrrr_prod
 Checking test 039 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2057,7 +2057,7 @@ Test 039 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_thompson_prod
 Checking test 040 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2125,7 +2125,7 @@ Test 040 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_thompson_no_aero_prod
 Checking test 041 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2193,7 +2193,7 @@ Test 041 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_rrfs_v1beta_prod
 Checking test 042 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2261,7 +2261,7 @@ Test 042 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v15p2_prod
 Checking test 043 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2329,7 +2329,7 @@ Test 043 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_prod
 Checking test 044 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2409,7 +2409,7 @@ Test 044 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_restart_prod
 Checking test 045 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2459,7 +2459,7 @@ Test 045 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 046 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2527,7 +2527,7 @@ Test 046 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2595,7 +2595,7 @@ Test 047 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 048 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2663,7 +2663,7 @@ Test 048 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2724,9 +2724,77 @@ Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 050 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 050 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2769,12 +2837,12 @@ Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_csawmg PASS
+Test 051 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2817,12 +2885,12 @@ Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfsv16_csawmgt PASS
+Test 052 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gocart_clm_prod
-Checking test 052 fv3_ccpp_gocart_clm results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gocart_clm_prod
+Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2865,12 +2933,12 @@ Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gocart_clm PASS
+Test 053 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_flake_prod
-Checking test 053 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_flake_prod
+Checking test 054 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2933,12 +3001,12 @@ Checking test 053 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v16_flake PASS
+Test 054 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3001,12 +3069,12 @@ Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -3019,12 +3087,12 @@ Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 057 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3081,12 +3149,12 @@ Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 057 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3143,12 +3211,12 @@ Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 059 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3211,12 +3279,12 @@ Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v15p2_debug PASS
+Test 059 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_debug_prod
-Checking test 059 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_debug_prod
+Checking test 060 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3279,12 +3347,12 @@ Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v16_debug PASS
+Test 060 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3347,12 +3415,12 @@ Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 062 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3415,23 +3483,23 @@ Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 062 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_control_debug_prod
-Checking test 062 fv3_ccpp_regional_control_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_regional_control_debug_prod
+Checking test 063 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 062 fv3_ccpp_regional_control_debug PASS
+Test 063 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_debug_prod
-Checking test 063 fv3_ccpp_control_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_control_debug_prod
+Checking test 064 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3456,12 +3524,12 @@ Checking test 063 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 063 fv3_ccpp_control_debug PASS
+Test 064 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_nest_debug_prod
-Checking test 064 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_stretched_nest_debug_prod
+Checking test 065 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3476,12 +3544,12 @@ Checking test 064 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 064 fv3_ccpp_stretched_nest_debug PASS
+Test 065 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_debug_prod
-Checking test 065 fv3_ccpp_gsd_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gsd_debug_prod
+Checking test 066 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3544,12 +3612,12 @@ Checking test 065 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gsd_debug PASS
+Test 066 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 067 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3612,12 +3680,12 @@ Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_gsd_diag3d_debug PASS
+Test 067 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_debug_prod
-Checking test 067 fv3_ccpp_thompson_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_thompson_debug_prod
+Checking test 068 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3680,12 +3748,12 @@ Checking test 067 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_thompson_debug PASS
+Test 068 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 069 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3748,12 +3816,12 @@ Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 068 fv3_ccpp_thompson_no_aero_debug PASS
+Test 069 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 070 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3816,12 +3884,12 @@ Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 069 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 070 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 071 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3884,12 +3952,12 @@ Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 071 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 072 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3902,12 +3970,12 @@ Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 072 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 073 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3964,12 +4032,12 @@ Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 072 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 073 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_prod
-Checking test 073 cpld_control results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_control_prod
+Checking test 074 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4017,12 +4085,12 @@ Checking test 073 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_control PASS
+Test 074 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_prod
-Checking test 074 cpld_restart results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_prod
+Checking test 075 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4070,12 +4138,12 @@ Checking test 074 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_restart PASS
+Test 075 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_prod
-Checking test 075 cpld_controlfrac results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_controlfrac_prod
+Checking test 076 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4123,12 +4191,12 @@ Checking test 075 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_controlfrac PASS
+Test 076 cpld_controlfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_prod
-Checking test 076 cpld_restartfrac results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restartfrac_prod
+Checking test 077 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4176,12 +4244,12 @@ Checking test 076 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_restartfrac PASS
+Test 077 cpld_restartfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_2threads_prod
-Checking test 077 cpld_2threads results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_2threads_prod
+Checking test 078 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4229,12 +4297,12 @@ Checking test 077 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_2threads PASS
+Test 078 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_decomp_prod
-Checking test 078 cpld_decomp results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_decomp_prod
+Checking test 079 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4282,12 +4350,12 @@ Checking test 078 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_decomp PASS
+Test 079 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_satmedmf_prod
-Checking test 079 cpld_satmedmf results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_satmedmf_prod
+Checking test 080 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4335,12 +4403,12 @@ Checking test 079 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_satmedmf PASS
+Test 080 cpld_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_ca_prod
-Checking test 080 cpld_ca results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_ca_prod
+Checking test 081 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4388,12 +4456,12 @@ Checking test 080 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 080 cpld_ca PASS
+Test 081 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_c192_prod
-Checking test 081 cpld_control_c192 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_control_c192_prod
+Checking test 082 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4441,12 +4509,12 @@ Checking test 081 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_control_c192 PASS
+Test 082 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_c192_prod
-Checking test 082 cpld_restart_c192 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_c192_prod
+Checking test 083 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4494,12 +4562,12 @@ Checking test 082 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_restart_c192 PASS
+Test 083 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_c192_prod
-Checking test 083 cpld_controlfrac_c192 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_controlfrac_c192_prod
+Checking test 084 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4547,12 +4615,12 @@ Checking test 083 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 083 cpld_controlfrac_c192 PASS
+Test 084 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_c192_prod
-Checking test 084 cpld_restartfrac_c192 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restartfrac_c192_prod
+Checking test 085 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4600,12 +4668,12 @@ Checking test 084 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 084 cpld_restartfrac_c192 PASS
+Test 085 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_c384_prod
-Checking test 085 cpld_control_c384 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_control_c384_prod
+Checking test 086 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4656,12 +4724,12 @@ Checking test 085 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_control_c384 PASS
+Test 086 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_c384_prod
-Checking test 086 cpld_restart_c384 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_c384_prod
+Checking test 087 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4712,12 +4780,12 @@ Checking test 086 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_restart_c384 PASS
+Test 087 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_c384_prod
-Checking test 087 cpld_controlfrac_c384 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_controlfrac_c384_prod
+Checking test 088 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4768,12 +4836,12 @@ Checking test 087 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 087 cpld_controlfrac_c384 PASS
+Test 088 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_c384_prod
-Checking test 088 cpld_restartfrac_c384 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restartfrac_c384_prod
+Checking test 089 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4824,12 +4892,12 @@ Checking test 088 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 088 cpld_restartfrac_c384 PASS
+Test 089 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmark_prod
-Checking test 089 cpld_bmark results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmark_prod
+Checking test 090 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4880,12 +4948,12 @@ Checking test 089 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_bmark PASS
+Test 090 cpld_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmark_prod
-Checking test 090 cpld_restart_bmark results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_bmark_prod
+Checking test 091 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4936,12 +5004,12 @@ Checking test 090 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_restart_bmark PASS
+Test 091 cpld_restart_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_prod
-Checking test 091 cpld_bmarkfrac results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmarkfrac_prod
+Checking test 092 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4992,12 +5060,12 @@ Checking test 091 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 091 cpld_bmarkfrac PASS
+Test 092 cpld_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmarkfrac_prod
-Checking test 092 cpld_restart_bmarkfrac results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_bmarkfrac_prod
+Checking test 093 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5048,12 +5116,12 @@ Checking test 092 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 092 cpld_restart_bmarkfrac PASS
+Test 093 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_v16_prod
-Checking test 093 cpld_bmarkfrac_v16 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmarkfrac_v16_prod
+Checking test 094 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5104,12 +5172,12 @@ Checking test 093 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 093 cpld_bmarkfrac_v16 PASS
+Test 094 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmarkfrac_v16_prod
-Checking test 094 cpld_restart_bmarkfrac_v16 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_restart_bmarkfrac_v16_prod
+Checking test 095 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5160,12 +5228,12 @@ Checking test 094 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 094 cpld_restart_bmarkfrac_v16 PASS
+Test 095 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmark_wave_prod
-Checking test 095 cpld_bmark_wave results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmark_wave_prod
+Checking test 096 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5219,12 +5287,12 @@ Checking test 095 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 095 cpld_bmark_wave PASS
+Test 096 cpld_bmark_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_wave_prod
-Checking test 096 cpld_bmarkfrac_wave results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmarkfrac_wave_prod
+Checking test 097 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5278,12 +5346,12 @@ Checking test 096 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 096 cpld_bmarkfrac_wave PASS
+Test 097 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_wave_v16_prod
-Checking test 097 cpld_bmarkfrac_wave_v16 results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_bmarkfrac_wave_v16_prod
+Checking test 098 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5337,12 +5405,12 @@ Checking test 097 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 097 cpld_bmarkfrac_wave_v16 PASS
+Test 098 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_wave_prod
-Checking test 098 cpld_control_wave results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_control_wave_prod
+Checking test 099 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5393,12 +5461,12 @@ Checking test 098 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 098 cpld_control_wave PASS
+Test 099 cpld_control_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_debug_prod
-Checking test 099 cpld_debug results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_debug_prod
+Checking test 100 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5446,12 +5514,12 @@ Checking test 099 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 099 cpld_debug PASS
+Test 100 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_debugfrac_prod
-Checking test 100 cpld_debugfrac results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/cpld_debugfrac_prod
+Checking test 101 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5499,87 +5567,87 @@ Checking test 100 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 100 cpld_debugfrac PASS
+Test 101 cpld_debugfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_control_cfsr
-Checking test 101 datm_control_cfsr results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_control_cfsr
+Checking test 102 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_control_cfsr PASS
+Test 102 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_restart_cfsr
-Checking test 102 datm_restart_cfsr results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_restart_cfsr
+Checking test 103 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_restart_cfsr PASS
+Test 103 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_control_gefs
-Checking test 103 datm_control_gefs results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_control_gefs
+Checking test 104 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_control_gefs PASS
+Test 104 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_bulk_cfsr
-Checking test 104 datm_bulk_cfsr results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_bulk_cfsr
+Checking test 105 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_bulk_cfsr PASS
+Test 105 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_bulk_gefs
-Checking test 105 datm_bulk_gefs results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_bulk_gefs
+Checking test 106 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_bulk_gefs PASS
+Test 106 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_mx025_cfsr
-Checking test 106 datm_mx025_cfsr results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_mx025_cfsr
+Checking test 107 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 106 datm_mx025_cfsr PASS
+Test 107 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_mx025_gefs
-Checking test 107 datm_mx025_gefs results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_mx025_gefs
+Checking test 108 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 107 datm_mx025_gefs PASS
+Test 108 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_debug_cfsr
-Checking test 108 datm_debug_cfsr results ....
+working dir  = /scratch1/NCEPDEV/stmp2/Dusan.Jovic/FV3_RT/rt_168882/datm_debug_cfsr
+Checking test 109 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 108 datm_debug_cfsr PASS
+Test 109 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Feb 18 04:38:47 UTC 2021
-Elapsed time: 01h:41m:32s. Have a nice day!
+Wed Feb 24 07:06:43 UTC 2021
+Elapsed time: 06h:52m:29s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Wed Feb 17 22:55:09 GMT 2021
+Wed Feb 24 02:19:55 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_2threads_prod
 Checking test 002 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_restart_prod
 Checking test 003 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -189,7 +189,7 @@ Test 003 fv3_ccpp_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_read_inc_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_read_inc_prod
 Checking test 004 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 005 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -305,7 +305,7 @@ Test 005 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -353,7 +353,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -401,7 +401,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -449,7 +449,7 @@ Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -497,7 +497,7 @@ Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -545,7 +545,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_ca_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_ca_prod
 Checking test 012 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_ca PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_lndp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_lndp_prod
 Checking test 013 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_iau_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_iau_prod
 Checking test 014 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_iau PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_lheatstrg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_lheatstrg_prod
 Checking test 015 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -865,7 +865,7 @@ Test 015 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_multigases_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_multigases_prod
 Checking test 016 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -939,7 +939,7 @@ Test 016 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_control_32bit_prod
 Checking test 017 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_stretched_prod
 Checking test 018 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1063,7 +1063,7 @@ Test 018 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_nest_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_stretched_nest_prod
 Checking test 019 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1130,7 +1130,7 @@ Test 019 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_regional_control_prod
 Checking test 020 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1141,7 +1141,7 @@ Test 020 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_regional_restart_prod
 Checking test 021 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1150,7 +1150,7 @@ Test 021 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_quilt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_regional_quilt_prod
 Checking test 022 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1161,7 +1161,7 @@ Test 022 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 023 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1172,7 +1172,7 @@ Test 023 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfdlmp_prod
 Checking test 024 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1220,7 +1220,7 @@ Test 024 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1268,7 +1268,7 @@ Test 025 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1316,7 +1316,7 @@ Test 026 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_csawmg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_csawmg_prod
 Checking test 027 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1364,7 +1364,7 @@ Test 027 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_satmedmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_satmedmf_prod
 Checking test 028 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1412,7 +1412,7 @@ Test 028 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_satmedmfq_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_satmedmfq_prod
 Checking test 029 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1460,7 +1460,7 @@ Test 029 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 030 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1508,7 +1508,7 @@ Test 030 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 031 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1560,7 +1560,7 @@ Test 031 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_cpt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_cpt_prod
 Checking test 032 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1614,7 +1614,7 @@ Test 032 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gsd_prod
 Checking test 033 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1706,7 +1706,7 @@ Test 033 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_thompson_prod
 Checking test 034 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1774,7 +1774,7 @@ Test 034 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_thompson_no_aero_prod
 Checking test 035 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 035 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v15p2_prod
 Checking test 036 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 036 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_prod
 Checking test 037 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1990,7 +1990,7 @@ Test 037 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_restart_prod
 Checking test 038 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2040,7 +2040,7 @@ Test 038 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 039 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2108,7 +2108,7 @@ Test 039 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 040 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2176,7 +2176,7 @@ Test 040 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 041 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2244,7 +2244,7 @@ Test 041 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 042 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2305,9 +2305,77 @@ Checking test 042 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 042 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 043 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 043 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 043 fv3_ccpp_gfsv16_csawmg results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 044 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2350,12 +2418,12 @@ Checking test 043 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfsv16_csawmg PASS
+Test 044 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 044 fv3_ccpp_gfsv16_csawmgt results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 045 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2398,12 +2466,12 @@ Checking test 044 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfsv16_csawmgt PASS
+Test 045 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gocart_clm_prod
-Checking test 045 fv3_ccpp_gocart_clm results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gocart_clm_prod
+Checking test 046 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2446,12 +2514,12 @@ Checking test 045 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gocart_clm PASS
+Test 046 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_flake_prod
-Checking test 046 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_flake_prod
+Checking test 047 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2514,12 +2582,12 @@ Checking test 046 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16_flake PASS
+Test 047 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 048 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2582,12 +2650,12 @@ Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 048 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 049 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2600,12 +2668,12 @@ Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 049 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 050 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2662,12 +2730,12 @@ Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 050 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 051 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2724,12 +2792,12 @@ Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 051 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2792,12 +2860,12 @@ Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfs_v15p2_debug PASS
+Test 052 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_debug_prod
-Checking test 052 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_debug_prod
+Checking test 053 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2860,12 +2928,12 @@ Checking test 052 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v16_debug PASS
+Test 053 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2928,12 +2996,12 @@ Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 055 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2996,23 +3064,23 @@ Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 055 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_control_debug_prod
-Checking test 055 fv3_ccpp_regional_control_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_regional_control_debug_prod
+Checking test 056 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 055 fv3_ccpp_regional_control_debug PASS
+Test 056 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_debug_prod
-Checking test 056 fv3_ccpp_control_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_control_debug_prod
+Checking test 057 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3037,12 +3105,12 @@ Checking test 056 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 056 fv3_ccpp_control_debug PASS
+Test 057 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_nest_debug_prod
-Checking test 057 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_stretched_nest_debug_prod
+Checking test 058 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3057,12 +3125,12 @@ Checking test 057 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 057 fv3_ccpp_stretched_nest_debug PASS
+Test 058 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_debug_prod
-Checking test 058 fv3_ccpp_gsd_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gsd_debug_prod
+Checking test 059 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3125,12 +3193,12 @@ Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gsd_debug PASS
+Test 059 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 060 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3193,12 +3261,12 @@ Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gsd_diag3d_debug PASS
+Test 060 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_debug_prod
-Checking test 060 fv3_ccpp_thompson_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_thompson_debug_prod
+Checking test 061 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3261,12 +3329,12 @@ Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_thompson_debug PASS
+Test 061 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 062 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3329,12 +3397,12 @@ Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_thompson_no_aero_debug PASS
+Test 062 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 063 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3397,12 +3465,12 @@ Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 063 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3465,12 +3533,12 @@ Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 064 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3483,12 +3551,12 @@ Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 065 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_256415/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 066 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3545,9 +3613,9 @@ Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 066 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Feb 18 00:55:53 GMT 2021
-Elapsed time: 02h:00m:45s. Have a nice day!
+Wed Feb 24 04:54:11 GMT 2021
+Elapsed time: 02h:34m:16s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Thu Feb 18 10:57:36 CST 2021
+Thu Feb 25 07:06:43 CST 2021
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_read_inc_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_lndp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_iau_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_lheatstrg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1080,7 +1080,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_multigases_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1154,7 +1154,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1222,7 +1222,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1278,7 +1278,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_nest_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1345,7 +1345,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1356,7 +1356,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1365,7 +1365,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_quilt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1376,7 +1376,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1387,7 +1387,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmp_prod
 Checking test 028 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1435,7 +1435,7 @@ Test 028 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 029 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1483,7 +1483,7 @@ Test 029 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 030 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1531,7 +1531,7 @@ Test 030 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_csawmg_prod
 Checking test 031 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1579,7 +1579,7 @@ Test 031 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_satmedmf_prod
 Checking test 032 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1627,7 +1627,7 @@ Test 032 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_satmedmfq_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_satmedmfq_prod
 Checking test 033 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1675,7 +1675,7 @@ Test 033 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 034 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1723,7 +1723,7 @@ Test 034 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 035 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1775,7 +1775,7 @@ Test 035 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_cpt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_cpt_prod
 Checking test 036 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1829,7 +1829,7 @@ Test 036 fv3_ccpp_cpt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gsd_prod
 Checking test 037 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1921,7 +1921,7 @@ Test 037 fv3_ccpp_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rap_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_rap_prod
 Checking test 038 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1989,7 +1989,7 @@ Test 038 fv3_ccpp_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_hrrr_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_hrrr_prod
 Checking test 039 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2057,7 +2057,7 @@ Test 039 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_thompson_prod
 Checking test 040 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2125,7 +2125,7 @@ Test 040 fv3_ccpp_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_no_aero_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_thompson_no_aero_prod
 Checking test 041 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2193,7 +2193,7 @@ Test 041 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_rrfs_v1beta_prod
 Checking test 042 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2261,7 +2261,7 @@ Test 042 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v15p2_prod
 Checking test 043 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2329,7 +2329,7 @@ Test 043 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_prod
 Checking test 044 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2409,7 +2409,7 @@ Test 044 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_restart_prod
 Checking test 045 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2459,7 +2459,7 @@ Test 045 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 046 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2527,7 +2527,7 @@ Test 046 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2595,7 +2595,7 @@ Test 047 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 048 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2663,7 +2663,7 @@ Test 048 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2724,9 +2724,77 @@ Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 050 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 050 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2769,12 +2837,12 @@ Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_csawmg PASS
+Test 051 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2817,12 +2885,12 @@ Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfsv16_csawmgt PASS
+Test 052 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gocart_clm_prod
-Checking test 052 fv3_ccpp_gocart_clm results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gocart_clm_prod
+Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2865,12 +2933,12 @@ Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gocart_clm PASS
+Test 053 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_flake_prod
-Checking test 053 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_flake_prod
+Checking test 054 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2933,12 +3001,12 @@ Checking test 053 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v16_flake PASS
+Test 054 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3001,12 +3069,12 @@ Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -3019,12 +3087,12 @@ Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 057 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3081,12 +3149,12 @@ Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 057 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3143,12 +3211,12 @@ Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 059 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3211,12 +3279,12 @@ Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v15p2_debug PASS
+Test 059 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_debug_prod
-Checking test 059 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_debug_prod
+Checking test 060 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3279,12 +3347,12 @@ Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v16_debug PASS
+Test 060 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3347,12 +3415,12 @@ Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 062 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3415,23 +3483,23 @@ Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 062 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_control_debug_prod
-Checking test 062 fv3_ccpp_regional_control_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_regional_control_debug_prod
+Checking test 063 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 062 fv3_ccpp_regional_control_debug PASS
+Test 063 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_debug_prod
-Checking test 063 fv3_ccpp_control_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_control_debug_prod
+Checking test 064 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3456,12 +3524,12 @@ Checking test 063 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 063 fv3_ccpp_control_debug PASS
+Test 064 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_nest_debug_prod
-Checking test 064 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_stretched_nest_debug_prod
+Checking test 065 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3476,12 +3544,12 @@ Checking test 064 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 064 fv3_ccpp_stretched_nest_debug PASS
+Test 065 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_debug_prod
-Checking test 065 fv3_ccpp_gsd_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gsd_debug_prod
+Checking test 066 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3544,12 +3612,12 @@ Checking test 065 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gsd_debug PASS
+Test 066 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 067 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3612,12 +3680,12 @@ Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_gsd_diag3d_debug PASS
+Test 067 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_debug_prod
-Checking test 067 fv3_ccpp_thompson_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_thompson_debug_prod
+Checking test 068 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3680,12 +3748,12 @@ Checking test 067 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_thompson_debug PASS
+Test 068 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 069 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3748,12 +3816,12 @@ Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 068 fv3_ccpp_thompson_no_aero_debug PASS
+Test 069 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 070 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3816,12 +3884,12 @@ Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 069 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 070 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 071 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3884,12 +3952,12 @@ Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 071 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 072 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3902,12 +3970,12 @@ Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 072 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 073 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3964,12 +4032,12 @@ Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 072 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 073 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_prod
-Checking test 073 cpld_control results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_control_prod
+Checking test 074 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4017,12 +4085,12 @@ Checking test 073 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_control PASS
+Test 074 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_prod
-Checking test 074 cpld_restart results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_prod
+Checking test 075 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4070,12 +4138,12 @@ Checking test 074 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_restart PASS
+Test 075 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_prod
-Checking test 075 cpld_controlfrac results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_controlfrac_prod
+Checking test 076 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4123,12 +4191,12 @@ Checking test 075 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_controlfrac PASS
+Test 076 cpld_controlfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_prod
-Checking test 076 cpld_restartfrac results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restartfrac_prod
+Checking test 077 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4176,12 +4244,12 @@ Checking test 076 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_restartfrac PASS
+Test 077 cpld_restartfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_2threads_prod
-Checking test 077 cpld_2threads results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_2threads_prod
+Checking test 078 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4229,12 +4297,12 @@ Checking test 077 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_2threads PASS
+Test 078 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_decomp_prod
-Checking test 078 cpld_decomp results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_decomp_prod
+Checking test 079 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4282,12 +4350,12 @@ Checking test 078 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_decomp PASS
+Test 079 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_satmedmf_prod
-Checking test 079 cpld_satmedmf results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_satmedmf_prod
+Checking test 080 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4335,12 +4403,12 @@ Checking test 079 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_satmedmf PASS
+Test 080 cpld_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_ca_prod
-Checking test 080 cpld_ca results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_ca_prod
+Checking test 081 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4388,12 +4456,12 @@ Checking test 080 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 080 cpld_ca PASS
+Test 081 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_c192_prod
-Checking test 081 cpld_control_c192 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_control_c192_prod
+Checking test 082 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4441,12 +4509,12 @@ Checking test 081 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_control_c192 PASS
+Test 082 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_c192_prod
-Checking test 082 cpld_restart_c192 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_c192_prod
+Checking test 083 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4494,12 +4562,12 @@ Checking test 082 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_restart_c192 PASS
+Test 083 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_c192_prod
-Checking test 083 cpld_controlfrac_c192 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_controlfrac_c192_prod
+Checking test 084 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4547,12 +4615,12 @@ Checking test 083 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 083 cpld_controlfrac_c192 PASS
+Test 084 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_c192_prod
-Checking test 084 cpld_restartfrac_c192 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restartfrac_c192_prod
+Checking test 085 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4600,12 +4668,12 @@ Checking test 084 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 084 cpld_restartfrac_c192 PASS
+Test 085 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_c384_prod
-Checking test 085 cpld_control_c384 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_control_c384_prod
+Checking test 086 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4656,12 +4724,12 @@ Checking test 085 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_control_c384 PASS
+Test 086 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_c384_prod
-Checking test 086 cpld_restart_c384 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_c384_prod
+Checking test 087 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4712,12 +4780,12 @@ Checking test 086 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_restart_c384 PASS
+Test 087 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_c384_prod
-Checking test 087 cpld_controlfrac_c384 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_controlfrac_c384_prod
+Checking test 088 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4768,12 +4836,12 @@ Checking test 087 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 087 cpld_controlfrac_c384 PASS
+Test 088 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_c384_prod
-Checking test 088 cpld_restartfrac_c384 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restartfrac_c384_prod
+Checking test 089 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4824,12 +4892,12 @@ Checking test 088 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 088 cpld_restartfrac_c384 PASS
+Test 089 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmark_prod
-Checking test 089 cpld_bmark results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmark_prod
+Checking test 090 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4880,12 +4948,12 @@ Checking test 089 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_bmark PASS
+Test 090 cpld_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmark_prod
-Checking test 090 cpld_restart_bmark results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_bmark_prod
+Checking test 091 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4936,12 +5004,12 @@ Checking test 090 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_restart_bmark PASS
+Test 091 cpld_restart_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_prod
-Checking test 091 cpld_bmarkfrac results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmarkfrac_prod
+Checking test 092 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4992,12 +5060,12 @@ Checking test 091 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 091 cpld_bmarkfrac PASS
+Test 092 cpld_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmarkfrac_prod
-Checking test 092 cpld_restart_bmarkfrac results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_bmarkfrac_prod
+Checking test 093 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5048,12 +5116,12 @@ Checking test 092 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 092 cpld_restart_bmarkfrac PASS
+Test 093 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_v16_prod
-Checking test 093 cpld_bmarkfrac_v16 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmarkfrac_v16_prod
+Checking test 094 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5104,12 +5172,12 @@ Checking test 093 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 093 cpld_bmarkfrac_v16 PASS
+Test 094 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmarkfrac_v16_prod
-Checking test 094 cpld_restart_bmarkfrac_v16 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_restart_bmarkfrac_v16_prod
+Checking test 095 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5160,12 +5228,12 @@ Checking test 094 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 094 cpld_restart_bmarkfrac_v16 PASS
+Test 095 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmark_wave_prod
-Checking test 095 cpld_bmark_wave results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmark_wave_prod
+Checking test 096 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5219,12 +5287,12 @@ Checking test 095 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 095 cpld_bmark_wave PASS
+Test 096 cpld_bmark_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_wave_prod
-Checking test 096 cpld_bmarkfrac_wave results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmarkfrac_wave_prod
+Checking test 097 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5278,12 +5346,12 @@ Checking test 096 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 096 cpld_bmarkfrac_wave PASS
+Test 097 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_wave_v16_prod
-Checking test 097 cpld_bmarkfrac_wave_v16 results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_bmarkfrac_wave_v16_prod
+Checking test 098 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5337,12 +5405,12 @@ Checking test 097 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 097 cpld_bmarkfrac_wave_v16 PASS
+Test 098 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_wave_prod
-Checking test 098 cpld_control_wave results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_control_wave_prod
+Checking test 099 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5393,12 +5461,12 @@ Checking test 098 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 098 cpld_control_wave PASS
+Test 099 cpld_control_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_debug_prod
-Checking test 099 cpld_debug results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_debug_prod
+Checking test 100 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5446,12 +5514,12 @@ Checking test 099 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 099 cpld_debug PASS
+Test 100 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_debugfrac_prod
-Checking test 100 cpld_debugfrac results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/cpld_debugfrac_prod
+Checking test 101 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5499,87 +5567,87 @@ Checking test 100 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 100 cpld_debugfrac PASS
+Test 101 cpld_debugfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_control_cfsr
-Checking test 101 datm_control_cfsr results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_control_cfsr
+Checking test 102 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_control_cfsr PASS
+Test 102 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_restart_cfsr
-Checking test 102 datm_restart_cfsr results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_restart_cfsr
+Checking test 103 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_restart_cfsr PASS
+Test 103 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_control_gefs
-Checking test 103 datm_control_gefs results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_control_gefs
+Checking test 104 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_control_gefs PASS
+Test 104 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_bulk_cfsr
-Checking test 104 datm_bulk_cfsr results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_bulk_cfsr
+Checking test 105 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_bulk_cfsr PASS
+Test 105 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_bulk_gefs
-Checking test 105 datm_bulk_gefs results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_bulk_gefs
+Checking test 106 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_bulk_gefs PASS
+Test 106 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_mx025_cfsr
-Checking test 106 datm_mx025_cfsr results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_mx025_cfsr
+Checking test 107 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 106 datm_mx025_cfsr PASS
+Test 107 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_mx025_gefs
-Checking test 107 datm_mx025_gefs results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_mx025_gefs
+Checking test 108 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 107 datm_mx025_gefs PASS
+Test 108 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_debug_cfsr
-Checking test 108 datm_debug_cfsr results ....
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_388225/datm_debug_cfsr
+Checking test 109 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 108 datm_debug_cfsr PASS
+Test 109 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Feb 18 21:22:48 CST 2021
-Elapsed time: 10h:25m:12s. Have a nice day!
+Thu Feb 25 08:57:39 CST 2021
+Elapsed time: 01h:50m:57s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Thu Feb 18 16:08:52 UTC 2021
+Wed Feb 24 18:26:04 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_decomp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_2threads_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stochy_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ca_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_ca_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lndp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_lndp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_iau_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_multigases_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_multigases_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1007,7 +1007,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1075,7 +1075,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1131,7 +1131,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1198,7 +1198,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1209,7 +1209,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1218,7 +1218,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1229,7 +1229,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1240,7 +1240,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfdlmp_prod
 Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1336,7 +1336,7 @@ Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1384,7 +1384,7 @@ Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1432,7 +1432,7 @@ Test 028 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1480,7 +1480,7 @@ Test 029 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1528,7 +1528,7 @@ Test 030 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1576,7 +1576,7 @@ Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1628,7 +1628,7 @@ Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_cpt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_cpt_prod
 Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1682,7 +1682,7 @@ Test 033 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gsd_prod
 Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1774,7 +1774,7 @@ Test 034 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rap_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rap_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_rap_prod
 Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 035 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_hrrr_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_hrrr_prod
 Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 036 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_thompson_prod
 Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 037 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_thompson_no_aero_prod
 Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_rrfs_v1beta_prod
 Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v15p2_prod
 Checking test 040 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 040 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_prod
 Checking test 041 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2262,7 +2262,7 @@ Test 041 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_restart_prod
 Checking test 042 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 042 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 043 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 043 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 044 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2448,7 +2448,7 @@ Test 044 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2516,7 +2516,7 @@ Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2578,7 +2578,7 @@ Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 047 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2626,7 +2626,7 @@ Test 047 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 048 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2674,7 +2674,7 @@ Test 048 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gocart_clm_prod
 Checking test 049 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2722,7 +2722,7 @@ Test 049 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_flake_prod
 Checking test 050 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2790,7 +2790,7 @@ Test 050 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 051 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2858,7 +2858,7 @@ Test 051 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2876,7 +2876,7 @@ Test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfsv16_ugwpv1_prod
 Checking test 053 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2938,7 +2938,7 @@ Test 053 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
 Checking test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3000,7 +3000,7 @@ Test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3068,7 +3068,7 @@ Test 055 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_debug_prod
 Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3136,7 +3136,7 @@ Test 056 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,7 +3204,7 @@ Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3272,7 +3272,7 @@ Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_control_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_regional_control_debug_prod
 Checking test 059 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -3283,7 +3283,7 @@ Test 059 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_control_debug_prod
 Checking test 060 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3313,7 +3313,7 @@ Test 060 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_stretched_nest_debug_prod
 Checking test 061 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -3333,7 +3333,7 @@ Test 061 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gsd_debug_prod
 Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3401,7 +3401,7 @@ Test 062 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,7 +3469,7 @@ Test 063 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_thompson_debug_prod
 Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3537,7 +3537,7 @@ Test 064 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3605,7 +3605,7 @@ Test 065 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3673,7 +3673,7 @@ Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3741,7 +3741,7 @@ Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3759,7 +3759,7 @@ Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_34115/fv3_ccpp_gfsv16_ugwpv1_debug_prod
 Checking test 069 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3821,5 +3821,5 @@ Test 069 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Feb 18 16:51:34 UTC 2021
-Elapsed time: 00h:42m:42s. Have a nice day!
+Wed Feb 24 19:09:15 UTC 2021
+Elapsed time: 00h:43m:11s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Thu Feb 18 21:24:50 UTC 2021
+Wed Feb 24 00:11:28 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -257,7 +257,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -325,7 +325,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -373,7 +373,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -421,7 +421,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -430,9 +430,9 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -469,7 +469,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -517,7 +517,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -565,7 +565,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_ca_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lndp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_lndp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_iau_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -982,7 +982,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1031,7 +1031,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_multigases_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_multigases_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_multigases_prod
 Checking test 019 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1105,7 +1105,7 @@ Test 019 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_control_32bit_prod
 Checking test 020 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1173,7 +1173,7 @@ Test 020 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_stretched_prod
 Checking test 021 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1229,7 +1229,7 @@ Test 021 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_stretched_nest_prod
 Checking test 022 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1296,7 +1296,7 @@ Test 022 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_regional_control_prod
 Checking test 023 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1307,7 +1307,7 @@ Test 023 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_regional_restart_prod
 Checking test 024 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1316,7 +1316,7 @@ Test 024 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_regional_quilt_prod
 Checking test 025 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1327,7 +1327,7 @@ Test 025 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 026 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1338,7 +1338,7 @@ Test 026 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1434,7 +1434,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1482,7 +1482,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,7 +1530,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,7 +1578,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1626,7 +1626,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1674,7 +1674,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1726,7 +1726,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_cpt_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1780,7 +1780,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1872,7 +1872,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rap_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rap_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1940,7 +1940,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_hrrr_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2008,7 +2008,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2076,7 +2076,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2144,7 +2144,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2212,7 +2212,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2280,7 +2280,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_prod
 Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2360,7 +2360,7 @@ Test 043 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2410,7 +2410,7 @@ Test 044 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2478,7 +2478,7 @@ Test 045 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2546,7 +2546,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2614,7 +2614,7 @@ Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
 Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -2675,9 +2675,77 @@ Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
 Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_RRTMGP_2thrd_prod
+Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_2thrd results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf024.tile1.nc .........OK
+ Comparing phyf024.tile2.nc .........OK
+ Comparing phyf024.tile3.nc .........OK
+ Comparing phyf024.tile4.nc .........OK
+ Comparing phyf024.tile5.nc .........OK
+ Comparing phyf024.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf024.tile1.nc .........OK
+ Comparing dynf024.tile2.nc .........OK
+ Comparing dynf024.tile3.nc .........OK
+ Comparing dynf024.tile4.nc .........OK
+ Comparing dynf024.tile5.nc .........OK
+ Comparing dynf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+Test 049 fv3_ccpp_gfs_v16_RRTMGP_2thrd PASS
+
+
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2720,12 +2788,12 @@ Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfsv16_csawmg PASS
+Test 050 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2768,12 +2836,12 @@ Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_csawmgt PASS
+Test 051 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gocart_clm_prod
-Checking test 051 fv3_ccpp_gocart_clm results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gocart_clm_prod
+Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2816,12 +2884,12 @@ Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gocart_clm PASS
+Test 052 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_flake_prod
-Checking test 052 fv3_ccpp_gfs_v16_flake results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_flake_prod
+Checking test 053 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2884,12 +2952,12 @@ Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v16_flake PASS
+Test 053 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2952,12 +3020,12 @@ Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2970,12 +3038,12 @@ Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3032,12 +3100,12 @@ Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 056 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3094,12 +3162,12 @@ Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3162,12 +3230,12 @@ Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfs_v15p2_debug PASS
+Test 058 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_debug_prod
-Checking test 058 fv3_ccpp_gfs_v16_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_debug_prod
+Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3230,12 +3298,12 @@ Checking test 058 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v16_debug PASS
+Test 059 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3298,12 +3366,12 @@ Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3366,23 +3434,23 @@ Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_control_debug_prod
-Checking test 061 fv3_ccpp_regional_control_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_regional_control_debug_prod
+Checking test 062 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
-Test 061 fv3_ccpp_regional_control_debug PASS
+Test 062 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_debug_prod
-Checking test 062 fv3_ccpp_control_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_control_debug_prod
+Checking test 063 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3407,12 +3475,12 @@ Checking test 062 fv3_ccpp_control_debug results ....
  Comparing dynf006.tile4.nc .........OK
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
-Test 062 fv3_ccpp_control_debug PASS
+Test 063 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_nest_debug_prod
-Checking test 063 fv3_ccpp_stretched_nest_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_stretched_nest_debug_prod
+Checking test 064 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
  Comparing fv3_history2d.tile2.nc .........OK
@@ -3427,12 +3495,12 @@ Checking test 063 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history.tile4.nc .........OK
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
-Test 063 fv3_ccpp_stretched_nest_debug PASS
+Test 064 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_debug_prod
-Checking test 064 fv3_ccpp_gsd_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gsd_debug_prod
+Checking test 065 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3495,12 +3563,12 @@ Checking test 064 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gsd_debug PASS
+Test 065 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3563,12 +3631,12 @@ Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gsd_diag3d_debug PASS
+Test 066 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_debug_prod
-Checking test 066 fv3_ccpp_thompson_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_thompson_debug_prod
+Checking test 067 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3631,12 +3699,12 @@ Checking test 066 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_thompson_debug PASS
+Test 067 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3699,12 +3767,12 @@ Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_thompson_no_aero_debug PASS
+Test 068 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3767,12 +3835,12 @@ Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 068 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 069 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3835,12 +3903,12 @@ Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3853,12 +3921,12 @@ Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3915,12 +3983,12 @@ Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 071 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 072 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_prod
-Checking test 072 cpld_control results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_control_prod
+Checking test 073 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3968,12 +4036,12 @@ Checking test 072 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_control PASS
+Test 073 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_prod
-Checking test 073 cpld_restart results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_prod
+Checking test 074 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4021,12 +4089,12 @@ Checking test 073 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_restart PASS
+Test 074 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_prod
-Checking test 074 cpld_controlfrac results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_controlfrac_prod
+Checking test 075 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4074,12 +4142,12 @@ Checking test 074 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_controlfrac PASS
+Test 075 cpld_controlfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_prod
-Checking test 075 cpld_restartfrac results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restartfrac_prod
+Checking test 076 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4127,12 +4195,12 @@ Checking test 075 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_restartfrac PASS
+Test 076 cpld_restartfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_2threads_prod
-Checking test 076 cpld_2threads results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_2threads_prod
+Checking test 077 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4180,12 +4248,12 @@ Checking test 076 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_2threads PASS
+Test 077 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_decomp_prod
-Checking test 077 cpld_decomp results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_decomp_prod
+Checking test 078 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4233,12 +4301,12 @@ Checking test 077 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_decomp PASS
+Test 078 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_satmedmf_prod
-Checking test 078 cpld_satmedmf results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_satmedmf_prod
+Checking test 079 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4286,12 +4354,12 @@ Checking test 078 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_satmedmf PASS
+Test 079 cpld_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_ca_prod
-Checking test 079 cpld_ca results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_ca_prod
+Checking test 080 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4339,12 +4407,12 @@ Checking test 079 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_ca PASS
+Test 080 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_c192_prod
-Checking test 080 cpld_control_c192 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_control_c192_prod
+Checking test 081 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4392,12 +4460,12 @@ Checking test 080 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_control_c192 PASS
+Test 081 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_c192_prod
-Checking test 081 cpld_restart_c192 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_c192_prod
+Checking test 082 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4445,12 +4513,12 @@ Checking test 081 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_restart_c192 PASS
+Test 082 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_c192_prod
-Checking test 082 cpld_controlfrac_c192 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_controlfrac_c192_prod
+Checking test 083 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4498,12 +4566,12 @@ Checking test 082 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_controlfrac_c192 PASS
+Test 083 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_c192_prod
-Checking test 083 cpld_restartfrac_c192 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restartfrac_c192_prod
+Checking test 084 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4551,12 +4619,12 @@ Checking test 083 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 083 cpld_restartfrac_c192 PASS
+Test 084 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_c384_prod
-Checking test 084 cpld_control_c384 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_control_c384_prod
+Checking test 085 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4607,12 +4675,12 @@ Checking test 084 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_control_c384 PASS
+Test 085 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_c384_prod
-Checking test 085 cpld_restart_c384 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_c384_prod
+Checking test 086 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4663,12 +4731,12 @@ Checking test 085 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_restart_c384 PASS
+Test 086 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_c384_prod
-Checking test 086 cpld_controlfrac_c384 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_controlfrac_c384_prod
+Checking test 087 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4719,12 +4787,12 @@ Checking test 086 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_controlfrac_c384 PASS
+Test 087 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_c384_prod
-Checking test 087 cpld_restartfrac_c384 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restartfrac_c384_prod
+Checking test 088 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4775,12 +4843,12 @@ Checking test 087 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 087 cpld_restartfrac_c384 PASS
+Test 088 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmark_prod
-Checking test 088 cpld_bmark results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmark_prod
+Checking test 089 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4831,12 +4899,12 @@ Checking test 088 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmark PASS
+Test 089 cpld_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmark_prod
-Checking test 089 cpld_restart_bmark results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_bmark_prod
+Checking test 090 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4887,12 +4955,12 @@ Checking test 089 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_restart_bmark PASS
+Test 090 cpld_restart_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_prod
-Checking test 090 cpld_bmarkfrac results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmarkfrac_prod
+Checking test 091 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4943,12 +5011,12 @@ Checking test 090 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_bmarkfrac PASS
+Test 091 cpld_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmarkfrac_prod
-Checking test 091 cpld_restart_bmarkfrac results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_bmarkfrac_prod
+Checking test 092 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4999,12 +5067,12 @@ Checking test 091 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 091 cpld_restart_bmarkfrac PASS
+Test 092 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_v16_prod
-Checking test 092 cpld_bmarkfrac_v16 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmarkfrac_v16_prod
+Checking test 093 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5055,12 +5123,12 @@ Checking test 092 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 092 cpld_bmarkfrac_v16 PASS
+Test 093 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmarkfrac_v16_prod
-Checking test 093 cpld_restart_bmarkfrac_v16 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_restart_bmarkfrac_v16_prod
+Checking test 094 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5111,12 +5179,12 @@ Checking test 093 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 093 cpld_restart_bmarkfrac_v16 PASS
+Test 094 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmark_wave_prod
-Checking test 094 cpld_bmark_wave results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmark_wave_prod
+Checking test 095 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5170,12 +5238,12 @@ Checking test 094 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 094 cpld_bmark_wave PASS
+Test 095 cpld_bmark_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_wave_prod
-Checking test 095 cpld_bmarkfrac_wave results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmarkfrac_wave_prod
+Checking test 096 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5229,12 +5297,12 @@ Checking test 095 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 095 cpld_bmarkfrac_wave PASS
+Test 096 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_wave_v16_prod
-Checking test 096 cpld_bmarkfrac_wave_v16 results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_bmarkfrac_wave_v16_prod
+Checking test 097 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5288,12 +5356,12 @@ Checking test 096 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 096 cpld_bmarkfrac_wave_v16 PASS
+Test 097 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_wave_prod
-Checking test 097 cpld_control_wave results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_control_wave_prod
+Checking test 098 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5344,12 +5412,12 @@ Checking test 097 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 097 cpld_control_wave PASS
+Test 098 cpld_control_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_debug_prod
-Checking test 098 cpld_debug results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_debug_prod
+Checking test 099 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5397,12 +5465,12 @@ Checking test 098 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 098 cpld_debug PASS
+Test 099 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_debugfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_debugfrac_prod
-Checking test 099 cpld_debugfrac results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/cpld_debugfrac_prod
+Checking test 100 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5450,87 +5518,87 @@ Checking test 099 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 099 cpld_debugfrac PASS
+Test 100 cpld_debugfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_control_cfsr
-Checking test 100 datm_control_cfsr results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_control_cfsr
+Checking test 101 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 100 datm_control_cfsr PASS
+Test 101 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_restart_cfsr
-Checking test 101 datm_restart_cfsr results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_restart_cfsr
+Checking test 102 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_restart_cfsr PASS
+Test 102 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_control_gefs
-Checking test 102 datm_control_gefs results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_control_gefs
+Checking test 103 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_control_gefs PASS
+Test 103 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_bulk_cfsr
-Checking test 103 datm_bulk_cfsr results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_bulk_cfsr
+Checking test 104 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_bulk_cfsr PASS
+Test 104 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_bulk_gefs
-Checking test 104 datm_bulk_gefs results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_bulk_gefs
+Checking test 105 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_bulk_gefs PASS
+Test 105 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_mx025_cfsr
-Checking test 105 datm_mx025_cfsr results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_mx025_cfsr
+Checking test 106 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_mx025_cfsr PASS
+Test 106 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_mx025_gefs
-Checking test 106 datm_mx025_gefs results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_mx025_gefs
+Checking test 107 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 106 datm_mx025_gefs PASS
+Test 107 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_debug_cfsr
-Checking test 107 datm_debug_cfsr results ....
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_6798/datm_debug_cfsr
+Checking test 108 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 107 datm_debug_cfsr PASS
+Test 108 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Feb 19 05:44:09 UTC 2021
-Elapsed time: 08h:19m:22s. Have a nice day!
+Wed Feb 24 03:37:34 UTC 2021
+Elapsed time: 03h:26m:08s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -81,7 +81,7 @@ RUN     | fv3_ccpp_gfs_v16_stochy                                               
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP                                                                                               |  - cheyenne.intel                       | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP                                                                                                 |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP_c192L127                                                                                        |                                         | fv3 |
-RUN     | fv3_ccpp_gfs_v16_RRTMGP_2thrd                                                                                           |                                         | fv3 |
+RUN     | fv3_ccpp_gfs_v16_RRTMGP_2thrd                                                                                           |  - wcoss_cray                           | fv3 |
 
 COMPILE | SUITES=FV3_GFS_v16_csawmg                                                                                               |                                         | fv3 |
 # fv3_ccpp_gfsv16_csawmg crashes with a "bus error" on cheyenne.intel, turn off both tests

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -85,6 +85,7 @@ RUN     | fv3_ccpp_gfs_v16_stochy                                               
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP                                                                                               |  - cheyenne.intel                       | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP                                                                                                 |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP_c192L127                                                                                        |                                         | fv3 |
+RUN     | fv3_ccpp_gfs_v16_RRTMGP_2thrd                                                                                           |                                         | fv3 |
 
 COMPILE | SUITES=FV3_GFS_v16_csawmg                                                                                               |                                         | fv3 |
 # fv3_ccpp_gfsv16_csawmg crashes with a "bus error" on cheyenne.intel, turn off both tests

--- a/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
+++ b/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
@@ -73,10 +73,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 
 
 export_fv3
-export TASKS=$TASKS_thrd
+export THRD=2
 export TPN=$TPN_thrd
-export INPES=$INPES_thrd
-export JNPES=$JNPES_thrd
 DT_ATMOS="1200"
 export DO_RRTMGP=.T.
 

--- a/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
+++ b/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
@@ -6,7 +6,7 @@
 
 export TEST_DESCR="Compare FV3 CCPP GFS v16 w/ RRTMGP using two threads results with previous trunk version"
 
-export CNTL_DIR=fv3_gfs_v16_RRTMGP_2thrd
+export CNTL_DIR=fv3_gfs_v16_RRTMGP
 
 export LIST_FILES="atmos_4xdaily.tile1.nc \
                    atmos_4xdaily.tile2.nc \
@@ -73,8 +73,10 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 
 
 export_fv3
-export THRD=2
-export TPN=20
+export TASKS=$TASKS_thrd
+export TPN=$TPN_thrd
+export INPES=$INPES_thrd
+export JNPES=$JNPES_thrd
 DT_ATMOS="1200"
 export DO_RRTMGP=.T.
 

--- a/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
+++ b/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_2thrd
@@ -1,0 +1,84 @@
+###############################################################################
+#
+#  FV3 CCPP GFS v16 w/ RRTMGP test using two openMP threads
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP GFS v16 w/ RRTMGP using two threads results with previous trunk version"
+
+export CNTL_DIR=fv3_gfs_v16_RRTMGP_2thrd
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc"
+
+
+export_fv3
+export THRD=2
+export TPN=20
+DT_ATMOS="1200"
+export DO_RRTMGP=.T.
+
+export FV3_RUN=ccpp_gfs_v16_run.IN
+export CCPP_SUITE=FV3_GFS_v16_RRTMGP
+export INPUT_NML=ccpp_v16_c96_rrtmgp.nml.IN
+


### PR DESCRIPTION
This PR contains several changes to the initialization and setup of the RRTMGP radiation scheme to allow for use across multiple openMP threads.
*) Moved Interstitial RRTMGP DDTs (ty_rrtmgp_gas_optics, ty_cloud_optics) to static fields defined during initialization in module memory.
*) Add "$omp critical" statements around the calling type-bound procedures during initialization.
*) Move allocation of ty_gas_conc from Interstitial to GFS_typedefs. Initialize ty_gas_concs for all blocks during initialization.

This issue was brought to our attention by @yangfanglin and Qingfu Liu at EMC while testing RRTMGP in high-resolution cases, which require multiple threads.

The GP regression tests on hera using Intel were successful.
There are no changes to the baselines

Waiting on
https://github.com/NCAR/ccpp-physics/pull/568
https://github.com/NOAA-EMC/fv3atm/pull/247