### PR TITLE
Add one regional regression test in DEBUG mode.

### DIFF
--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -47,6 +47,9 @@ RUN     | fv3_ccpp_regional_quilt_netcdf_parallel                               
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | jet.intel                               | fv3 |
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | orion.intel                             | fv3 |
 
+COMPILE | SUITES=FV3_GFS_v15_thompson_mynn 32BIT=Y DEBUG=Y                                                                        |                                         | fv3 |
+RUN     | fv3_ccpp_regional_control_debug                                                                                         |                                         | fv3 |
+
 COMPILE | SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                              |                                         | fv3 |
 RUN     | fv3_ccpp_control_debug                                                                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_stretched_nest_debug                                                                                           |                                         | fv3 |

--- a/tests/tests/fv3_ccpp_regional_control_debug
+++ b/tests/tests/fv3_ccpp_regional_control_debug
@@ -1,0 +1,35 @@
+###############################################################################
+#
+#  FV3 CCPP regional control test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP regional control results with previous trunk version"
+
+export CNTL_DIR=fv3_regional_control_debug
+
+export LIST_FILES="  atmos_4xdaily.nc \
+                     fv3_history2d.nc \
+                       fv3_history.nc \
+     RESTART/fv_core.res.tile1_new.nc \
+   RESTART/fv_tracer.res.tile1_new.nc"
+
+export_fv3
+
+export TASKS=40
+export FHMAX="01"
+
+export FV3_RUN=ccpp_regional_run.IN
+
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+export HYBEDMF=.F.
+
+export CCPP_SUITE=FV3_GFS_v15_thompson_mynn
+export INPUT_NML=ccpp_regional.nml.IN
+
+export FDIAG=1
+export INPES=5
+export JNPES=8
+export WRITE_RESTART_WITH_BCS=.true.


### PR DESCRIPTION
## Description

Add one regional regression test in DEBUG mode.
Add two lines in tests/rt.conf and one file tests/tests/fv3_ccpp_regional_control_debug
Does not change other results.

### Issue(s) addressed

fixes #361

## Testing

Tested on WCOS's and Hera
What compilers / HPCs was it tested with? - INTEL

## Dependencies

