### PR TITLE
Update regression tests from GFSv15+Thompson to GFSv16+Thompson, include "Add one regional regression test in DEBUG mode. (#419)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/XiaSun-NOAA/fv3atm
-  branch = gfsv16thomp
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/XiaSun-NOAA/fv3atm
+  branch = gfsv16thomp
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Mon Feb 15 08:20:59 MST 2021
+Wed Feb 17 13:05:22 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -198,8 +198,8 @@ Checking test 003 fv3_ccpp_gfs_v16 results ....
 Test 003 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -248,8 +248,8 @@ Checking test 004 fv3_ccpp_gfs_v16_restart results ....
 Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_stochy_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_stochy_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -316,8 +316,8 @@ Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
 Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_flake_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -384,8 +384,8 @@ Checking test 006 fv3_ccpp_gfs_v16_flake results ....
 Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -452,8 +452,8 @@ Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
 Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_RRTMGP_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -520,8 +520,8 @@ Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
 Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gsd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 009 fv3_ccpp_gsd results ....
 Test 009 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 010 fv3_ccpp_thompson results ....
 Test 010 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 011 fv3_ccpp_thompson_no_aero results ....
 Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 012 fv3_ccpp_rrfs_v1beta results ....
 Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -902,8 +902,8 @@ Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfsv16_ugwpv1_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_prod
 Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -964,8 +964,8 @@ Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
 Test 015 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
 Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1026,8 +1026,8 @@ Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
 Test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_control_debug_prod
 Checking test 017 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1056,8 +1056,8 @@ Checking test 017 fv3_ccpp_control_debug results ....
 Test 017 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1124,8 +1124,8 @@ Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
 Test 018 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1192,8 +1192,8 @@ Checking test 019 fv3_ccpp_gfs_v16_debug results ....
 Test 019 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1260,8 +1260,8 @@ Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
 Test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1328,8 +1328,8 @@ Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
 Test 021 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_multigases_prod
 Checking test 022 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1402,9 +1402,292 @@ Checking test 022 fv3_ccpp_multigases results ....
 Test 022 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_regional_control_debug_prod
+Checking test 023 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 023 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 024 fv3_ccpp_rrfs_v1beta_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 024 fv3_ccpp_rrfs_v1beta_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gsd_debug_prod
+Checking test 025 fv3_ccpp_gsd_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 025 fv3_ccpp_gsd_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_debug_prod
+Checking test 026 fv3_ccpp_thompson_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 026 fv3_ccpp_thompson_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 027 fv3_ccpp_thompson_no_aero_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 027 fv3_ccpp_thompson_no_aero_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1467,12 +1750,12 @@ Checking test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1485,12 +1768,12 @@ Checking test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_14558/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 025 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_31552/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 030 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1547,9 +1830,9 @@ Checking test 025 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 025 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 030 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 15 08:39:02 MST 2021
-Elapsed time: 00h:18m:03s. Have a nice day!
+Wed Feb 17 13:22:49 MST 2021
+Elapsed time: 00h:17m:28s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Mon Feb 15 08:21:05 MST 2021
+Wed Feb 17 13:30:04 MST 2021
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_read_inc_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -431,7 +431,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_stochy_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_ca_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lndp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_lndp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_iau_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_lheatstrg_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 017 fv3_ccpp_multigases results ....
 Test 017 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_control_32bit_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1074,8 +1074,8 @@ Checking test 018 fv3_ccpp_control_32bit results ....
 Test 018 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_stretched_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1130,8 +1130,8 @@ Checking test 019 fv3_ccpp_stretched results ....
 Test 019 fv3_ccpp_stretched PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_stretched_nest_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1197,8 +1197,8 @@ Checking test 020 fv3_ccpp_stretched_nest results ....
 Test 020 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1208,8 +1208,8 @@ Checking test 021 fv3_ccpp_regional_control results ....
 Test 021 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_regional_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1217,8 +1217,8 @@ Checking test 022 fv3_ccpp_regional_restart results ....
 Test 022 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_regional_quilt_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1228,70 +1228,20 @@ Checking test 023 fv3_ccpp_regional_quilt results ....
 Test 023 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_control_debug_prod
-Checking test 025 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 025 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_stretched_nest_debug_prod
-Checking test 026 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 026 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfdlmp_prod
-Checking test 027 fv3_ccpp_gfdlmp results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmp_prod
+Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1334,12 +1284,12 @@ Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 027 fv3_ccpp_gfdlmp PASS
+Test 025 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1382,12 +1332,12 @@ Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 028 fv3_ccpp_gfdlmprad_gwd PASS
+Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1430,12 +1380,12 @@ Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_csawmg_prod
-Checking test 030 fv3_ccpp_csawmg results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_csawmg_prod
+Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1478,12 +1428,12 @@ Checking test 030 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 030 fv3_ccpp_csawmg PASS
+Test 028 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_satmedmf_prod
-Checking test 031 fv3_ccpp_satmedmf results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_satmedmf_prod
+Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1526,12 +1476,12 @@ Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 031 fv3_ccpp_satmedmf PASS
+Test 029 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_satmedmfq_prod
-Checking test 032 fv3_ccpp_satmedmfq results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_satmedmfq_prod
+Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1574,12 +1524,12 @@ Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 032 fv3_ccpp_satmedmfq PASS
+Test 030 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1622,12 +1572,12 @@ Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 033 fv3_ccpp_gfdlmp_32bit PASS
+Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1674,12 +1624,12 @@ Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_cpt_prod
-Checking test 035 fv3_ccpp_cpt results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_cpt_prod
+Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1728,12 +1678,12 @@ Checking test 035 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 035 fv3_ccpp_cpt PASS
+Test 033 fv3_ccpp_cpt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gsd_prod
-Checking test 036 fv3_ccpp_gsd results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_prod
+Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1820,12 +1770,12 @@ Checking test 036 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gsd PASS
+Test 034 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rap_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_rap_prod
-Checking test 037 fv3_ccpp_rap results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rap_prod
+Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1888,12 +1838,12 @@ Checking test 037 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 037 fv3_ccpp_rap PASS
+Test 035 fv3_ccpp_rap PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_hrrr_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_hrrr_prod
-Checking test 038 fv3_ccpp_hrrr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_hrrr_prod
+Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1956,12 +1906,12 @@ Checking test 038 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 038 fv3_ccpp_hrrr PASS
+Test 036 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_thompson_prod
-Checking test 039 fv3_ccpp_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_prod
+Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2024,12 +1974,12 @@ Checking test 039 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_thompson PASS
+Test 037 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_thompson_no_aero_prod
-Checking test 040 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_no_aero_prod
+Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2092,12 +2042,12 @@ Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_thompson_no_aero PASS
+Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_rrfs_v1beta_prod
-Checking test 041 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rrfs_v1beta_prod
+Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2160,12 +2110,12 @@ Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_rrfs_v1beta PASS
+Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_prod
-Checking test 042 fv3_ccpp_gfs_v16 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_prod
+Checking test 040 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2240,12 +2190,12 @@ Checking test 042 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 042 fv3_ccpp_gfs_v16 PASS
+Test 040 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_restart_prod
-Checking test 043 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_restart_prod
+Checking test 041 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2290,12 +2240,12 @@ Checking test 043 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfs_v16_restart PASS
+Test 041 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 044 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 042 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2358,12 +2308,12 @@ Checking test 044 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfs_v16_stochy PASS
+Test 042 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 043 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2426,12 +2376,12 @@ Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 043 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2488,12 +2438,12 @@ Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gocart_clm_prod
-Checking test 047 fv3_ccpp_gocart_clm results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gocart_clm_prod
+Checking test 045 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2536,12 +2486,12 @@ Checking test 047 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gocart_clm PASS
+Test 045 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_flake_prod
-Checking test 048 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_flake_prod
+Checking test 046 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2604,12 +2554,12 @@ Checking test 048 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_flake PASS
+Test 046 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2672,12 +2622,12 @@ Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2690,12 +2640,12 @@ Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 051 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2752,12 +2702,12 @@ Checking test 051 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 049 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2814,12 +2764,12 @@ Checking test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 053 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2882,12 +2832,12 @@ Checking test 053 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v15p2_debug PASS
+Test 051 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_debug_prod
-Checking test 054 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_debug_prod
+Checking test 052 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2950,12 +2900,12 @@ Checking test 054 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfs_v16_debug PASS
+Test 052 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3018,12 +2968,12 @@ Checking test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 056 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3086,12 +3036,73 @@ Checking test 056 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 054 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gsd_debug_prod
-Checking test 057 fv3_ccpp_gsd_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_regional_control_debug_prod
+Checking test 055 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 055 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_control_debug_prod
+Checking test 056 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 056 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_stretched_nest_debug_prod
+Checking test 057 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 057 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_debug_prod
+Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3154,12 +3165,12 @@ Checking test 057 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gsd_debug PASS
+Test 058 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 058 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3222,12 +3233,12 @@ Checking test 058 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gsd_diag3d_debug PASS
+Test 059 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_thompson_debug_prod
-Checking test 059 fv3_ccpp_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_debug_prod
+Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3290,12 +3301,12 @@ Checking test 059 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_thompson_debug PASS
+Test 060 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 060 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3358,12 +3369,12 @@ Checking test 060 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_thompson_no_aero_debug PASS
+Test 061 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 061 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3426,12 +3437,12 @@ Checking test 061 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3494,12 +3505,12 @@ Checking test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3512,12 +3523,12 @@ Checking test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 064 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3574,12 +3585,12 @@ Checking test 064 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 065 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_control_prod
-Checking test 065 cpld_control results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_prod
+Checking test 066 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3627,12 +3638,12 @@ Checking test 065 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 065 cpld_control PASS
+Test 066 cpld_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_prod
-Checking test 066 cpld_restart results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_prod
+Checking test 067 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3680,12 +3691,12 @@ Checking test 066 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 066 cpld_restart PASS
+Test 067 cpld_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_controlfrac_prod
-Checking test 067 cpld_controlfrac results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_prod
+Checking test 068 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3733,12 +3744,12 @@ Checking test 067 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 067 cpld_controlfrac PASS
+Test 068 cpld_controlfrac PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restartfrac_prod
-Checking test 068 cpld_restartfrac results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_prod
+Checking test 069 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3786,12 +3797,12 @@ Checking test 068 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 068 cpld_restartfrac PASS
+Test 069 cpld_restartfrac PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_2threads_prod
-Checking test 069 cpld_2threads results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_2threads_prod
+Checking test 070 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3839,12 +3850,12 @@ Checking test 069 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 069 cpld_2threads PASS
+Test 070 cpld_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_decomp_prod
-Checking test 070 cpld_decomp results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_decomp_prod
+Checking test 071 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3892,12 +3903,12 @@ Checking test 070 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 070 cpld_decomp PASS
+Test 071 cpld_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_satmedmf_prod
-Checking test 071 cpld_satmedmf results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_satmedmf_prod
+Checking test 072 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3945,12 +3956,12 @@ Checking test 071 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 071 cpld_satmedmf PASS
+Test 072 cpld_satmedmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_ca_prod
-Checking test 072 cpld_ca results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_ca_prod
+Checking test 073 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3998,12 +4009,12 @@ Checking test 072 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_ca PASS
+Test 073 cpld_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_control_c192_prod
-Checking test 073 cpld_control_c192 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_c192_prod
+Checking test 074 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4051,12 +4062,12 @@ Checking test 073 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 073 cpld_control_c192 PASS
+Test 074 cpld_control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_c192_prod
-Checking test 074 cpld_restart_c192 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_c192_prod
+Checking test 075 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4104,12 +4115,12 @@ Checking test 074 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 074 cpld_restart_c192 PASS
+Test 075 cpld_restart_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_controlfrac_c192_prod
-Checking test 075 cpld_controlfrac_c192 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_c192_prod
+Checking test 076 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4157,12 +4168,12 @@ Checking test 075 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 075 cpld_controlfrac_c192 PASS
+Test 076 cpld_controlfrac_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restartfrac_c192_prod
-Checking test 076 cpld_restartfrac_c192 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_c192_prod
+Checking test 077 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4210,12 +4221,12 @@ Checking test 076 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 076 cpld_restartfrac_c192 PASS
+Test 077 cpld_restartfrac_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_control_c384_prod
-Checking test 077 cpld_control_c384 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_c384_prod
+Checking test 078 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4266,12 +4277,12 @@ Checking test 077 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_control_c384 PASS
+Test 078 cpld_control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_c384_prod
-Checking test 078 cpld_restart_c384 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_c384_prod
+Checking test 079 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4322,12 +4333,12 @@ Checking test 078 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_restart_c384 PASS
+Test 079 cpld_restart_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_controlfrac_c384_prod
-Checking test 079 cpld_controlfrac_c384 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_controlfrac_c384_prod
+Checking test 080 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4378,12 +4389,12 @@ Checking test 079 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_controlfrac_c384 PASS
+Test 080 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restartfrac_c384_prod
-Checking test 080 cpld_restartfrac_c384 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restartfrac_c384_prod
+Checking test 081 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4434,12 +4445,12 @@ Checking test 080 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 080 cpld_restartfrac_c384 PASS
+Test 081 cpld_restartfrac_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmark_prod
-Checking test 081 cpld_bmark results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmark_prod
+Checking test 082 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4490,12 +4501,12 @@ Checking test 081 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 081 cpld_bmark PASS
+Test 082 cpld_bmark PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_bmark_prod
-Checking test 082 cpld_restart_bmark results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmark_prod
+Checking test 083 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4546,12 +4557,12 @@ Checking test 082 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 082 cpld_restart_bmark PASS
+Test 083 cpld_restart_bmark PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmarkfrac_prod
-Checking test 083 cpld_bmarkfrac results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_prod
+Checking test 084 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4602,12 +4613,12 @@ Checking test 083 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 083 cpld_bmarkfrac PASS
+Test 084 cpld_bmarkfrac PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_bmarkfrac_prod
-Checking test 084 cpld_restart_bmarkfrac results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmarkfrac_prod
+Checking test 085 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4658,12 +4669,12 @@ Checking test 084 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 084 cpld_restart_bmarkfrac PASS
+Test 085 cpld_restart_bmarkfrac PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmarkfrac_v16_prod
-Checking test 085 cpld_bmarkfrac_v16 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_v16_prod
+Checking test 086 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4714,12 +4725,12 @@ Checking test 085 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 085 cpld_bmarkfrac_v16 PASS
+Test 086 cpld_bmarkfrac_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_restart_bmarkfrac_v16_prod
-Checking test 086 cpld_restart_bmarkfrac_v16 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_restart_bmarkfrac_v16_prod
+Checking test 087 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4770,12 +4781,12 @@ Checking test 086 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 086 cpld_restart_bmarkfrac_v16 PASS
+Test 087 cpld_restart_bmarkfrac_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmark_wave_prod
-Checking test 087 cpld_bmark_wave results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmark_wave_prod
+Checking test 088 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4829,12 +4840,12 @@ Checking test 087 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 087 cpld_bmark_wave PASS
+Test 088 cpld_bmark_wave PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmarkfrac_wave_prod
-Checking test 088 cpld_bmarkfrac_wave results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_wave_prod
+Checking test 089 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4888,12 +4899,12 @@ Checking test 088 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmarkfrac_wave PASS
+Test 089 cpld_bmarkfrac_wave PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_bmarkfrac_wave_v16_prod
-Checking test 089 cpld_bmarkfrac_wave_v16 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_bmarkfrac_wave_v16_prod
+Checking test 090 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -4947,12 +4958,12 @@ Checking test 089 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 089 cpld_bmarkfrac_wave_v16 PASS
+Test 090 cpld_bmarkfrac_wave_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_control_wave_prod
-Checking test 090 cpld_control_wave results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_control_wave_prod
+Checking test 091 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5003,12 +5014,12 @@ Checking test 090 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 090 cpld_control_wave PASS
+Test 091 cpld_control_wave PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_debug_prod
-Checking test 091 cpld_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_debug_prod
+Checking test 092 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5056,12 +5067,12 @@ Checking test 091 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 091 cpld_debug PASS
+Test 092 cpld_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debugfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/cpld_debugfrac_prod
-Checking test 092 cpld_debugfrac results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/cpld_debugfrac_prod
+Checking test 093 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5109,87 +5120,87 @@ Checking test 092 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 092 cpld_debugfrac PASS
+Test 093 cpld_debugfrac PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_control_cfsr
-Checking test 093 datm_control_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_control_cfsr
+Checking test 094 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 093 datm_control_cfsr PASS
+Test 094 datm_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_restart_cfsr
-Checking test 094 datm_restart_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_restart_cfsr
+Checking test 095 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 094 datm_restart_cfsr PASS
+Test 095 datm_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_control_gefs
-Checking test 095 datm_control_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_control_gefs
+Checking test 096 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 095 datm_control_gefs PASS
+Test 096 datm_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_bulk_cfsr
-Checking test 096 datm_bulk_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_bulk_cfsr
+Checking test 097 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 096 datm_bulk_cfsr PASS
+Test 097 datm_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_bulk_gefs
-Checking test 097 datm_bulk_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_bulk_gefs
+Checking test 098 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 097 datm_bulk_gefs PASS
+Test 098 datm_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_mx025_cfsr
-Checking test 098 datm_mx025_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_mx025_cfsr
+Checking test 099 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 098 datm_mx025_cfsr PASS
+Test 099 datm_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_mx025_gefs
-Checking test 099 datm_mx025_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_mx025_gefs
+Checking test 100 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 099 datm_mx025_gefs PASS
+Test 100 datm_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_2233/datm_debug_cfsr
-Checking test 100 datm_debug_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_20008/datm_debug_cfsr
+Checking test 101 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 100 datm_debug_cfsr PASS
+Test 101 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 15 09:40:43 MST 2021
-Elapsed time: 01h:19m:38s. Have a nice day!
+Wed Feb 17 14:49:52 MST 2021
+Elapsed time: 01h:19m:48s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Mon Feb 15 10:22:34 EST 2021
+Wed Feb 17 18:30:56 EST 2021
 Start Regression test
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_decomp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_2threads_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_restart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_read_inc_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_read_inc_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_stochy_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ca_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_ca_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lndp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_lndp_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_iau_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_iau_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_lheatstrg_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_multigases_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_multigases_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 017 fv3_ccpp_multigases results ....
 Test 017 fv3_ccpp_multigases PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_control_32bit_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1074,8 +1074,8 @@ Checking test 018 fv3_ccpp_control_32bit results ....
 Test 018 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_stretched_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1130,8 +1130,8 @@ Checking test 019 fv3_ccpp_stretched results ....
 Test 019 fv3_ccpp_stretched PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_stretched_nest_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1197,8 +1197,8 @@ Checking test 020 fv3_ccpp_stretched_nest results ....
 Test 020 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_regional_control_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1208,8 +1208,8 @@ Checking test 021 fv3_ccpp_regional_control results ....
 Test 021 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_regional_restart_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1217,8 +1217,8 @@ Checking test 022 fv3_ccpp_regional_restart results ....
 Test 022 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_regional_quilt_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1228,8 +1228,8 @@ Checking test 023 fv3_ccpp_regional_quilt results ....
 Test 023 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1239,59 +1239,9 @@ Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_control_debug_prod
-Checking test 025 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 025 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_stretched_nest_debug_prod
-Checking test 026 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 026 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfdlmp_prod
-Checking test 027 fv3_ccpp_gfdlmp results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmp_prod
+Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1334,12 +1284,12 @@ Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 027 fv3_ccpp_gfdlmp PASS
+Test 025 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1382,12 +1332,12 @@ Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 028 fv3_ccpp_gfdlmprad_gwd PASS
+Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1430,12 +1380,12 @@ Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_csawmg_prod
-Checking test 030 fv3_ccpp_csawmg results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_csawmg_prod
+Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1478,12 +1428,12 @@ Checking test 030 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 030 fv3_ccpp_csawmg PASS
+Test 028 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_satmedmf_prod
-Checking test 031 fv3_ccpp_satmedmf results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_satmedmf_prod
+Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1526,12 +1476,12 @@ Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 031 fv3_ccpp_satmedmf PASS
+Test 029 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_satmedmfq_prod
-Checking test 032 fv3_ccpp_satmedmfq results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_satmedmfq_prod
+Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1574,12 +1524,12 @@ Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 032 fv3_ccpp_satmedmfq PASS
+Test 030 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1622,12 +1572,12 @@ Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 033 fv3_ccpp_gfdlmp_32bit PASS
+Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1674,12 +1624,12 @@ Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_cpt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_cpt_prod
-Checking test 035 fv3_ccpp_cpt results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_cpt_prod
+Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1728,12 +1678,12 @@ Checking test 035 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 035 fv3_ccpp_cpt PASS
+Test 033 fv3_ccpp_cpt PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gsd_prod
-Checking test 036 fv3_ccpp_gsd results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_prod
+Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1820,12 +1770,12 @@ Checking test 036 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gsd PASS
+Test 034 fv3_ccpp_gsd PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rap_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_rap_prod
-Checking test 037 fv3_ccpp_rap results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rap_prod
+Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1888,12 +1838,12 @@ Checking test 037 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 037 fv3_ccpp_rap PASS
+Test 035 fv3_ccpp_rap PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_hrrr_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_hrrr_prod
-Checking test 038 fv3_ccpp_hrrr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_hrrr_prod
+Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1956,12 +1906,12 @@ Checking test 038 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 038 fv3_ccpp_hrrr PASS
+Test 036 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_thompson_prod
-Checking test 039 fv3_ccpp_thompson results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_prod
+Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2024,12 +1974,12 @@ Checking test 039 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_thompson PASS
+Test 037 fv3_ccpp_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_thompson_no_aero_prod
-Checking test 040 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_no_aero_prod
+Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2092,12 +2042,12 @@ Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_thompson_no_aero PASS
+Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_rrfs_v1beta_prod
-Checking test 041 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rrfs_v1beta_prod
+Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2160,12 +2110,12 @@ Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_rrfs_v1beta PASS
+Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v15p2_prod
-Checking test 042 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_prod
+Checking test 040 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2228,12 +2178,12 @@ Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 042 fv3_ccpp_gfs_v15p2 PASS
+Test 040 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_prod
-Checking test 043 fv3_ccpp_gfs_v16 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_prod
+Checking test 041 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2308,12 +2258,12 @@ Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfs_v16 PASS
+Test 041 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_restart_prod
-Checking test 044 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_restart_prod
+Checking test 042 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2358,12 +2308,12 @@ Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfs_v16_restart PASS
+Test 042 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 043 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2426,12 +2376,12 @@ Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v16_stochy PASS
+Test 043 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 044 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2494,12 +2444,12 @@ Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 044 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2562,12 +2512,12 @@ Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2624,12 +2574,12 @@ Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 047 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2672,12 +2622,12 @@ Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfsv16_csawmg PASS
+Test 047 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 048 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2720,12 +2670,12 @@ Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_csawmgt PASS
+Test 048 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gocart_clm_prod
-Checking test 051 fv3_ccpp_gocart_clm results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gocart_clm_prod
+Checking test 049 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2768,12 +2718,12 @@ Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gocart_clm PASS
+Test 049 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_flake_prod
-Checking test 052 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_flake_prod
+Checking test 050 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2836,12 +2786,12 @@ Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v16_flake PASS
+Test 050 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 051 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2904,12 +2854,12 @@ Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 051 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2922,12 +2872,12 @@ Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 053 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2984,12 +2934,12 @@ Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 053 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3046,12 +2996,12 @@ Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3114,12 +3064,12 @@ Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfs_v15p2_debug PASS
+Test 055 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_debug_prod
-Checking test 058 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_debug_prod
+Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3182,12 +3132,12 @@ Checking test 058 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v16_debug PASS
+Test 056 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3250,12 +3200,12 @@ Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3318,12 +3268,73 @@ Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gsd_debug_prod
-Checking test 061 fv3_ccpp_gsd_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_regional_control_debug_prod
+Checking test 059 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 059 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_control_debug_prod
+Checking test 060 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 060 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_stretched_nest_debug_prod
+Checking test 061 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 061 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_debug_prod
+Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3386,12 +3397,12 @@ Checking test 061 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gsd_debug PASS
+Test 062 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3454,12 +3465,12 @@ Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gsd_diag3d_debug PASS
+Test 063 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_thompson_debug_prod
-Checking test 063 fv3_ccpp_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_debug_prod
+Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3522,12 +3533,12 @@ Checking test 063 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_thompson_debug PASS
+Test 064 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3590,12 +3601,12 @@ Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_thompson_no_aero_debug PASS
+Test 065 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3658,12 +3669,12 @@ Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3726,12 +3737,12 @@ Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3744,12 +3755,12 @@ Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 068 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 069 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3806,12 +3817,12 @@ Checking test 068 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 068 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 069 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_control_prod
-Checking test 069 cpld_control results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_prod
+Checking test 070 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3859,12 +3870,12 @@ Checking test 069 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 069 cpld_control PASS
+Test 070 cpld_control PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restart_prod
-Checking test 070 cpld_restart results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_prod
+Checking test 071 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3912,12 +3923,12 @@ Checking test 070 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 070 cpld_restart PASS
+Test 071 cpld_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_controlfrac_prod
-Checking test 071 cpld_controlfrac results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_prod
+Checking test 072 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3965,12 +3976,12 @@ Checking test 071 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 071 cpld_controlfrac PASS
+Test 072 cpld_controlfrac PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restartfrac_prod
-Checking test 072 cpld_restartfrac results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_prod
+Checking test 073 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4018,12 +4029,12 @@ Checking test 072 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_restartfrac PASS
+Test 073 cpld_restartfrac PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_2threads_prod
-Checking test 073 cpld_2threads results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_2threads_prod
+Checking test 074 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4071,12 +4082,12 @@ Checking test 073 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_2threads PASS
+Test 074 cpld_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_decomp_prod
-Checking test 074 cpld_decomp results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_decomp_prod
+Checking test 075 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4124,12 +4135,12 @@ Checking test 074 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_decomp PASS
+Test 075 cpld_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_satmedmf_prod
-Checking test 075 cpld_satmedmf results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_satmedmf_prod
+Checking test 076 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4177,12 +4188,12 @@ Checking test 075 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_satmedmf PASS
+Test 076 cpld_satmedmf PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_ca_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_ca_prod
-Checking test 076 cpld_ca results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_ca_prod
+Checking test 077 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4230,12 +4241,12 @@ Checking test 076 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_ca PASS
+Test 077 cpld_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_control_c192_prod
-Checking test 077 cpld_control_c192 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_c192_prod
+Checking test 078 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4283,12 +4294,12 @@ Checking test 077 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 077 cpld_control_c192 PASS
+Test 078 cpld_control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restart_c192_prod
-Checking test 078 cpld_restart_c192 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_c192_prod
+Checking test 079 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4336,12 +4347,12 @@ Checking test 078 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 078 cpld_restart_c192 PASS
+Test 079 cpld_restart_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_controlfrac_c192_prod
-Checking test 079 cpld_controlfrac_c192 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_c192_prod
+Checking test 080 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4389,12 +4400,12 @@ Checking test 079 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 079 cpld_controlfrac_c192 PASS
+Test 080 cpld_controlfrac_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restartfrac_c192_prod
-Checking test 080 cpld_restartfrac_c192 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_c192_prod
+Checking test 081 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4442,12 +4453,12 @@ Checking test 080 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_restartfrac_c192 PASS
+Test 081 cpld_restartfrac_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_control_c384_prod
-Checking test 081 cpld_control_c384 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_control_c384_prod
+Checking test 082 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4498,12 +4509,12 @@ Checking test 081 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 081 cpld_control_c384 PASS
+Test 082 cpld_control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restart_c384_prod
-Checking test 082 cpld_restart_c384 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_c384_prod
+Checking test 083 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4554,12 +4565,12 @@ Checking test 082 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 082 cpld_restart_c384 PASS
+Test 083 cpld_restart_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_controlfrac_c384_prod
-Checking test 083 cpld_controlfrac_c384 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_controlfrac_c384_prod
+Checking test 084 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4610,12 +4621,12 @@ Checking test 083 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 083 cpld_controlfrac_c384 PASS
+Test 084 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restartfrac_c384_prod
-Checking test 084 cpld_restartfrac_c384 results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restartfrac_c384_prod
+Checking test 085 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4666,12 +4677,12 @@ Checking test 084 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_restartfrac_c384 PASS
+Test 085 cpld_restartfrac_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_bmark_prod
-Checking test 085 cpld_bmark results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_bmark_prod
+Checking test 086 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4722,12 +4733,12 @@ Checking test 085 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 085 cpld_bmark PASS
+Test 086 cpld_bmark PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restart_bmark_prod
-Checking test 086 cpld_restart_bmark results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_bmark_prod
+Checking test 087 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4778,12 +4789,12 @@ Checking test 086 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 086 cpld_restart_bmark PASS
+Test 087 cpld_restart_bmark PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_bmarkfrac_prod
-Checking test 087 cpld_bmarkfrac results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_bmarkfrac_prod
+Checking test 088 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4834,12 +4845,12 @@ Checking test 087 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 087 cpld_bmarkfrac PASS
+Test 088 cpld_bmarkfrac PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_restart_bmarkfrac_prod
-Checking test 088 cpld_restart_bmarkfrac results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_restart_bmarkfrac_prod
+Checking test 089 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4890,12 +4901,12 @@ Checking test 088 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_restart_bmarkfrac PASS
+Test 089 cpld_restart_bmarkfrac PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_debug_prod
-Checking test 089 cpld_debug results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_debug_prod
+Checking test 090 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -4943,12 +4954,12 @@ Checking test 089 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 089 cpld_debug PASS
+Test 090 cpld_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debugfrac_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/cpld_debugfrac_prod
-Checking test 090 cpld_debugfrac results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/cpld_debugfrac_prod
+Checking test 091 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -4996,87 +5007,87 @@ Checking test 090 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 090 cpld_debugfrac PASS
+Test 091 cpld_debugfrac PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_control_cfsr
-Checking test 091 datm_control_cfsr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_control_cfsr
+Checking test 092 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 091 datm_control_cfsr PASS
+Test 092 datm_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_restart_cfsr
-Checking test 092 datm_restart_cfsr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_restart_cfsr
+Checking test 093 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 092 datm_restart_cfsr PASS
+Test 093 datm_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_control_gefs
-Checking test 093 datm_control_gefs results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_control_gefs
+Checking test 094 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 093 datm_control_gefs PASS
+Test 094 datm_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_bulk_cfsr
-Checking test 094 datm_bulk_cfsr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_bulk_cfsr
+Checking test 095 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 094 datm_bulk_cfsr PASS
+Test 095 datm_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_bulk_gefs
-Checking test 095 datm_bulk_gefs results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_bulk_gefs
+Checking test 096 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 095 datm_bulk_gefs PASS
+Test 096 datm_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_mx025_cfsr
-Checking test 096 datm_mx025_cfsr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_mx025_cfsr
+Checking test 097 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 096 datm_mx025_cfsr PASS
+Test 097 datm_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_mx025_gefs
-Checking test 097 datm_mx025_gefs results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_mx025_gefs
+Checking test 098 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 097 datm_mx025_gefs PASS
+Test 098 datm_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_21897/datm_debug_cfsr
-Checking test 098 datm_debug_cfsr results ....
+baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_12314/datm_debug_cfsr
+Checking test 099 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 098 datm_debug_cfsr PASS
+Test 099 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 15 12:31:33 EST 2021
-Elapsed time: 02h:08m:59s. Have a nice day!
+Wed Feb 17 20:13:13 EST 2021
+Elapsed time: 01h:42m:18s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Sat Feb 13 03:32:15 UTC 2021
+Wed Feb 17 20:45:37 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfdlmp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfdlmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -198,8 +198,8 @@ Checking test 003 fv3_ccpp_gfs_v16 results ....
 Test 003 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_restart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -248,8 +248,8 @@ Checking test 004 fv3_ccpp_gfs_v16_restart results ....
 Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_stochy_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_stochy_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -316,8 +316,8 @@ Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
 Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_flake_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_flake_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -384,8 +384,8 @@ Checking test 006 fv3_ccpp_gfs_v16_flake results ....
 Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -452,8 +452,8 @@ Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
 Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_RRTMGP_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -520,8 +520,8 @@ Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
 Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gsd_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 009 fv3_ccpp_gsd results ....
 Test 009 fv3_ccpp_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_thompson_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 010 fv3_ccpp_thompson results ....
 Test 010 fv3_ccpp_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 011 fv3_ccpp_thompson_no_aero results ....
 Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 012 fv3_ccpp_rrfs_v1beta results ....
 Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
 Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -902,8 +902,8 @@ Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
 Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfsv16_ugwpv1_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_prod
 Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -964,8 +964,8 @@ Checking test 015 fv3_ccpp_gfsv16_ugwpv1 results ....
 Test 015 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
 Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1026,8 +1026,8 @@ Checking test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
 Test 016 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_control_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_control_debug_prod
 Checking test 017 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1056,8 +1056,8 @@ Checking test 017 fv3_ccpp_control_debug results ....
 Test 017 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1124,8 +1124,8 @@ Checking test 018 fv3_ccpp_gfs_v15p2_debug results ....
 Test 018 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1192,8 +1192,8 @@ Checking test 019 fv3_ccpp_gfs_v16_debug results ....
 Test 019 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1260,8 +1260,8 @@ Checking test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
 Test 020 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1328,8 +1328,8 @@ Checking test 021 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
 Test 021 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_multigases_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_multigases_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_multigases_prod
 Checking test 022 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1402,9 +1402,292 @@ Checking test 022 fv3_ccpp_multigases results ....
 Test 022 fv3_ccpp_multigases PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_regional_control_debug_prod
+Checking test 023 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 023 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 024 fv3_ccpp_rrfs_v1beta_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 024 fv3_ccpp_rrfs_v1beta_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_gsd_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gsd_debug_prod
+Checking test 025 fv3_ccpp_gsd_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf003.tile1.nc .........OK
+ Comparing phyf003.tile2.nc .........OK
+ Comparing phyf003.tile3.nc .........OK
+ Comparing phyf003.tile4.nc .........OK
+ Comparing phyf003.tile5.nc .........OK
+ Comparing phyf003.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf003.tile1.nc .........OK
+ Comparing dynf003.tile2.nc .........OK
+ Comparing dynf003.tile3.nc .........OK
+ Comparing dynf003.tile4.nc .........OK
+ Comparing dynf003.tile5.nc .........OK
+ Comparing dynf003.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 025 fv3_ccpp_gsd_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_debug_prod
+Checking test 026 fv3_ccpp_thompson_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 026 fv3_ccpp_thompson_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_thompson_no_aero_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 027 fv3_ccpp_thompson_no_aero_debug results ....
+ Comparing atmos_4xdaily.tile1.nc .........OK
+ Comparing atmos_4xdaily.tile2.nc .........OK
+ Comparing atmos_4xdaily.tile3.nc .........OK
+ Comparing atmos_4xdaily.tile4.nc .........OK
+ Comparing atmos_4xdaily.tile5.nc .........OK
+ Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+Test 027 fv3_ccpp_thompson_no_aero_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1467,12 +1750,12 @@ Checking test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 023 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 028 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1485,12 +1768,12 @@ Checking test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 024 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 029 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191545/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 025 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/GNU/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_236046/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 030 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1547,9 +1830,9 @@ Checking test 025 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 025 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 030 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Feb 13 04:02:26 UTC 2021
-Elapsed time: 00h:30m:12s. Have a nice day!
+Wed Feb 17 21:14:47 UTC 2021
+Elapsed time: 00h:29m:11s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Sat Feb 13 04:42:55 UTC 2021
+Thu Feb 18 02:57:16 UTC 2021
 Start Regression test
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_control_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_decomp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_2threads_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_restart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_read_inc_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -429,7 +429,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_stochy_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_ca_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lndp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_lndp_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_iau_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_lheatstrg_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmprad_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -981,8 +981,8 @@ Checking test 017 fv3_ccpp_gfdlmprad results ....
 Test 017 fv3_ccpp_gfdlmprad PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmprad_atmwav_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_atmwav_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1030,8 +1030,8 @@ Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
 Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_wrtGauss_nemsio_c768_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1079,8 +1079,8 @@ Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
 Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_multigases_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1153,8 +1153,8 @@ Checking test 020 fv3_ccpp_multigases results ....
 Test 020 fv3_ccpp_multigases PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_control_32bit_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1221,8 +1221,8 @@ Checking test 021 fv3_ccpp_control_32bit results ....
 Test 021 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_stretched_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1277,8 +1277,8 @@ Checking test 022 fv3_ccpp_stretched results ....
 Test 022 fv3_ccpp_stretched PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_stretched_nest_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1344,8 +1344,8 @@ Checking test 023 fv3_ccpp_stretched_nest results ....
 Test 023 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_regional_control_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1355,8 +1355,8 @@ Checking test 024 fv3_ccpp_regional_control results ....
 Test 024 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_regional_restart_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1364,8 +1364,8 @@ Checking test 025 fv3_ccpp_regional_restart results ....
 Test 025 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_regional_quilt_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1375,8 +1375,8 @@ Checking test 026 fv3_ccpp_regional_quilt results ....
 Test 026 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1386,59 +1386,9 @@ Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_control_debug_prod
-Checking test 028 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 028 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_stretched_nest_debug_prod
-Checking test 029 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 029 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmp_prod
-Checking test 030 fv3_ccpp_gfdlmp results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmp_prod
+Checking test 028 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1481,12 +1431,12 @@ Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 030 fv3_ccpp_gfdlmp PASS
+Test 028 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 029 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1529,12 +1479,12 @@ Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 031 fv3_ccpp_gfdlmprad_gwd PASS
+Test 029 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 030 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1577,12 +1527,12 @@ Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 030 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_csawmg_prod
-Checking test 033 fv3_ccpp_csawmg results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_csawmg_prod
+Checking test 031 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1625,12 +1575,12 @@ Checking test 033 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 033 fv3_ccpp_csawmg PASS
+Test 031 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_satmedmf_prod
-Checking test 034 fv3_ccpp_satmedmf results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_satmedmf_prod
+Checking test 032 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1673,12 +1623,12 @@ Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 034 fv3_ccpp_satmedmf PASS
+Test 032 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_satmedmfq_prod
-Checking test 035 fv3_ccpp_satmedmfq results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_satmedmfq_prod
+Checking test 033 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1721,12 +1671,12 @@ Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 035 fv3_ccpp_satmedmfq PASS
+Test 033 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 034 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1769,12 +1719,12 @@ Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gfdlmp_32bit PASS
+Test 034 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 035 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1821,12 +1771,12 @@ Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 035 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_cpt_prod
-Checking test 038 fv3_ccpp_cpt results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_cpt_prod
+Checking test 036 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1875,12 +1825,12 @@ Checking test 038 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 038 fv3_ccpp_cpt PASS
+Test 036 fv3_ccpp_cpt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gsd_prod
-Checking test 039 fv3_ccpp_gsd results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_prod
+Checking test 037 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1967,12 +1917,12 @@ Checking test 039 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_gsd PASS
+Test 037 fv3_ccpp_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rap_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_rap_prod
-Checking test 040 fv3_ccpp_rap results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rap_prod
+Checking test 038 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2035,12 +1985,12 @@ Checking test 040 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_rap PASS
+Test 038 fv3_ccpp_rap PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_hrrr_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_hrrr_prod
-Checking test 041 fv3_ccpp_hrrr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_hrrr_prod
+Checking test 039 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2103,12 +2053,12 @@ Checking test 041 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_hrrr PASS
+Test 039 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_thompson_prod
-Checking test 042 fv3_ccpp_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_prod
+Checking test 040 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2171,12 +2121,12 @@ Checking test 042 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 042 fv3_ccpp_thompson PASS
+Test 040 fv3_ccpp_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_thompson_no_aero_prod
-Checking test 043 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_no_aero_prod
+Checking test 041 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2239,12 +2189,12 @@ Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 043 fv3_ccpp_thompson_no_aero PASS
+Test 041 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_rrfs_v1beta_prod
-Checking test 044 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rrfs_v1beta_prod
+Checking test 042 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2307,12 +2257,12 @@ Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 044 fv3_ccpp_rrfs_v1beta PASS
+Test 042 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v15p2_prod
-Checking test 045 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_prod
+Checking test 043 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2375,12 +2325,12 @@ Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v15p2 PASS
+Test 043 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_prod
-Checking test 046 fv3_ccpp_gfs_v16 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_prod
+Checking test 044 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2455,12 +2405,12 @@ Checking test 046 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16 PASS
+Test 044 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_restart_prod
-Checking test 047 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_restart_prod
+Checking test 045 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2505,12 +2455,12 @@ Checking test 047 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfs_v16_restart PASS
+Test 045 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 046 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2573,12 +2523,12 @@ Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_stochy PASS
+Test 046 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 047 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2641,12 +2591,12 @@ Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 047 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 048 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2709,12 +2659,12 @@ Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 048 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2771,12 +2721,12 @@ Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2819,12 +2769,12 @@ Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfsv16_csawmg PASS
+Test 050 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2867,12 +2817,12 @@ Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfsv16_csawmgt PASS
+Test 051 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gocart_clm_prod
-Checking test 054 fv3_ccpp_gocart_clm results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gocart_clm_prod
+Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2915,12 +2865,12 @@ Checking test 054 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gocart_clm PASS
+Test 052 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_flake_prod
-Checking test 055 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_flake_prod
+Checking test 053 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2983,12 +2933,12 @@ Checking test 055 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfs_v16_flake PASS
+Test 053 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3051,12 +3001,12 @@ Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -3069,12 +3019,12 @@ Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 058 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3131,12 +3081,12 @@ Checking test 058 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 056 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3193,12 +3143,12 @@ Checking test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 060 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3261,12 +3211,12 @@ Checking test 060 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v15p2_debug PASS
+Test 058 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_debug_prod
-Checking test 061 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_debug_prod
+Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3329,12 +3279,12 @@ Checking test 061 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gfs_v16_debug PASS
+Test 059 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3397,12 +3347,12 @@ Checking test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 063 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3465,12 +3415,73 @@ Checking test 063 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gsd_debug_prod
-Checking test 064 fv3_ccpp_gsd_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_regional_control_debug_prod
+Checking test 062 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 062 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_control_debug_prod
+Checking test 063 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 063 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_stretched_nest_debug_prod
+Checking test 064 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 064 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_debug_prod
+Checking test 065 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3533,12 +3544,12 @@ Checking test 064 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gsd_debug PASS
+Test 065 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3601,12 +3612,12 @@ Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gsd_diag3d_debug PASS
+Test 066 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_thompson_debug_prod
-Checking test 066 fv3_ccpp_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_debug_prod
+Checking test 067 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3669,12 +3680,12 @@ Checking test 066 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_thompson_debug PASS
+Test 067 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3737,12 +3748,12 @@ Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_thompson_no_aero_debug PASS
+Test 068 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3805,12 +3816,12 @@ Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 068 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 069 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3873,12 +3884,12 @@ Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3891,12 +3902,12 @@ Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3953,12 +3964,12 @@ Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 071 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 072 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_control_prod
-Checking test 072 cpld_control results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_prod
+Checking test 073 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4006,12 +4017,12 @@ Checking test 072 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_control PASS
+Test 073 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_prod
-Checking test 073 cpld_restart results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_prod
+Checking test 074 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4059,12 +4070,12 @@ Checking test 073 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_restart PASS
+Test 074 cpld_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_controlfrac_prod
-Checking test 074 cpld_controlfrac results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_prod
+Checking test 075 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4112,12 +4123,12 @@ Checking test 074 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_controlfrac PASS
+Test 075 cpld_controlfrac PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restartfrac_prod
-Checking test 075 cpld_restartfrac results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_prod
+Checking test 076 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4165,12 +4176,12 @@ Checking test 075 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_restartfrac PASS
+Test 076 cpld_restartfrac PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_2threads_prod
-Checking test 076 cpld_2threads results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_2threads_prod
+Checking test 077 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4218,12 +4229,12 @@ Checking test 076 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_2threads PASS
+Test 077 cpld_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_decomp_prod
-Checking test 077 cpld_decomp results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_decomp_prod
+Checking test 078 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4271,12 +4282,12 @@ Checking test 077 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_decomp PASS
+Test 078 cpld_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_satmedmf_prod
-Checking test 078 cpld_satmedmf results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_satmedmf_prod
+Checking test 079 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4324,12 +4335,12 @@ Checking test 078 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_satmedmf PASS
+Test 079 cpld_satmedmf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_ca_prod
-Checking test 079 cpld_ca results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_ca_prod
+Checking test 080 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4377,12 +4388,12 @@ Checking test 079 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_ca PASS
+Test 080 cpld_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_control_c192_prod
-Checking test 080 cpld_control_c192 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_c192_prod
+Checking test 081 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4430,12 +4441,12 @@ Checking test 080 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_control_c192 PASS
+Test 081 cpld_control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_c192_prod
-Checking test 081 cpld_restart_c192 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_c192_prod
+Checking test 082 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4483,12 +4494,12 @@ Checking test 081 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_restart_c192 PASS
+Test 082 cpld_restart_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_controlfrac_c192_prod
-Checking test 082 cpld_controlfrac_c192 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_c192_prod
+Checking test 083 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4536,12 +4547,12 @@ Checking test 082 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_controlfrac_c192 PASS
+Test 083 cpld_controlfrac_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restartfrac_c192_prod
-Checking test 083 cpld_restartfrac_c192 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_c192_prod
+Checking test 084 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4589,12 +4600,12 @@ Checking test 083 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 083 cpld_restartfrac_c192 PASS
+Test 084 cpld_restartfrac_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_control_c384_prod
-Checking test 084 cpld_control_c384 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_c384_prod
+Checking test 085 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4645,12 +4656,12 @@ Checking test 084 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_control_c384 PASS
+Test 085 cpld_control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_c384_prod
-Checking test 085 cpld_restart_c384 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_c384_prod
+Checking test 086 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4701,12 +4712,12 @@ Checking test 085 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_restart_c384 PASS
+Test 086 cpld_restart_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_controlfrac_c384_prod
-Checking test 086 cpld_controlfrac_c384 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_controlfrac_c384_prod
+Checking test 087 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4757,12 +4768,12 @@ Checking test 086 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_controlfrac_c384 PASS
+Test 087 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restartfrac_c384_prod
-Checking test 087 cpld_restartfrac_c384 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restartfrac_c384_prod
+Checking test 088 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4813,12 +4824,12 @@ Checking test 087 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 087 cpld_restartfrac_c384 PASS
+Test 088 cpld_restartfrac_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmark_prod
-Checking test 088 cpld_bmark results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmark_prod
+Checking test 089 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4869,12 +4880,12 @@ Checking test 088 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmark PASS
+Test 089 cpld_bmark PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_bmark_prod
-Checking test 089 cpld_restart_bmark results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmark_prod
+Checking test 090 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4925,12 +4936,12 @@ Checking test 089 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_restart_bmark PASS
+Test 090 cpld_restart_bmark PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmarkfrac_prod
-Checking test 090 cpld_bmarkfrac results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_prod
+Checking test 091 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4981,12 +4992,12 @@ Checking test 090 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_bmarkfrac PASS
+Test 091 cpld_bmarkfrac PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_bmarkfrac_prod
-Checking test 091 cpld_restart_bmarkfrac results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmarkfrac_prod
+Checking test 092 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5037,12 +5048,12 @@ Checking test 091 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 091 cpld_restart_bmarkfrac PASS
+Test 092 cpld_restart_bmarkfrac PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmarkfrac_v16_prod
-Checking test 092 cpld_bmarkfrac_v16 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_v16_prod
+Checking test 093 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5093,12 +5104,12 @@ Checking test 092 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 092 cpld_bmarkfrac_v16 PASS
+Test 093 cpld_bmarkfrac_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_restart_bmarkfrac_v16_prod
-Checking test 093 cpld_restart_bmarkfrac_v16 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_restart_bmarkfrac_v16_prod
+Checking test 094 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5149,12 +5160,12 @@ Checking test 093 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 093 cpld_restart_bmarkfrac_v16 PASS
+Test 094 cpld_restart_bmarkfrac_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmark_wave_prod
-Checking test 094 cpld_bmark_wave results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmark_wave_prod
+Checking test 095 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5208,12 +5219,12 @@ Checking test 094 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 094 cpld_bmark_wave PASS
+Test 095 cpld_bmark_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmarkfrac_wave_prod
-Checking test 095 cpld_bmarkfrac_wave results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_wave_prod
+Checking test 096 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5267,12 +5278,12 @@ Checking test 095 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 095 cpld_bmarkfrac_wave PASS
+Test 096 cpld_bmarkfrac_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_bmarkfrac_wave_v16_prod
-Checking test 096 cpld_bmarkfrac_wave_v16 results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_bmarkfrac_wave_v16_prod
+Checking test 097 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5326,12 +5337,12 @@ Checking test 096 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 096 cpld_bmarkfrac_wave_v16 PASS
+Test 097 cpld_bmarkfrac_wave_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_control_wave_prod
-Checking test 097 cpld_control_wave results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_control_wave_prod
+Checking test 098 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5382,12 +5393,12 @@ Checking test 097 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 097 cpld_control_wave PASS
+Test 098 cpld_control_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_debug_prod
-Checking test 098 cpld_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_debug_prod
+Checking test 099 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5435,12 +5446,12 @@ Checking test 098 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 098 cpld_debug PASS
+Test 099 cpld_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debugfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/cpld_debugfrac_prod
-Checking test 099 cpld_debugfrac results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/cpld_debugfrac_prod
+Checking test 100 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5488,87 +5499,87 @@ Checking test 099 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 099 cpld_debugfrac PASS
+Test 100 cpld_debugfrac PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_control_cfsr
-Checking test 100 datm_control_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_control_cfsr
+Checking test 101 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 100 datm_control_cfsr PASS
+Test 101 datm_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_restart_cfsr
-Checking test 101 datm_restart_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_restart_cfsr
+Checking test 102 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_restart_cfsr PASS
+Test 102 datm_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_control_gefs
-Checking test 102 datm_control_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_control_gefs
+Checking test 103 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_control_gefs PASS
+Test 103 datm_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_bulk_cfsr
-Checking test 103 datm_bulk_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_bulk_cfsr
+Checking test 104 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_bulk_cfsr PASS
+Test 104 datm_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_bulk_gefs
-Checking test 104 datm_bulk_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_bulk_gefs
+Checking test 105 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_bulk_gefs PASS
+Test 105 datm_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_mx025_cfsr
-Checking test 105 datm_mx025_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_mx025_cfsr
+Checking test 106 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_mx025_cfsr PASS
+Test 106 datm_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_mx025_gefs
-Checking test 106 datm_mx025_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_mx025_gefs
+Checking test 107 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 106 datm_mx025_gefs PASS
+Test 107 datm_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_243096/datm_debug_cfsr
-Checking test 107 datm_debug_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_71644/datm_debug_cfsr
+Checking test 108 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 107 datm_debug_cfsr PASS
+Test 108 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Feb 13 06:10:19 UTC 2021
-Elapsed time: 01h:27m:25s. Have a nice day!
+Thu Feb 18 04:38:47 UTC 2021
+Elapsed time: 01h:41m:32s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Tue Feb 16 02:56:45 GMT 2021
+Wed Feb 17 22:55:09 GMT 2021
 Start Regression test
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_control_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_2threads_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_2threads_prod
 Checking test 002 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_2threads results ....
 Test 002 fv3_ccpp_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_restart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_restart_prod
 Checking test 003 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -188,8 +188,8 @@ Checking test 003 fv3_ccpp_restart results ....
 Test 003 fv3_ccpp_restart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_read_inc_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_read_inc_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_read_inc_prod
 Checking test 004 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_read_inc results ....
 Test 004 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 005 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -304,8 +304,8 @@ Checking test 005 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 005 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -352,8 +352,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -400,8 +400,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -448,8 +448,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -496,8 +496,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -544,8 +544,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_stochy_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ca_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_ca_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_ca_prod
 Checking test 012 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_ca results ....
 Test 012 fv3_ccpp_ca PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lndp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_lndp_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_lndp_prod
 Checking test 013 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_lndp results ....
 Test 013 fv3_ccpp_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_iau_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_iau_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_iau_prod
 Checking test 014 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_iau results ....
 Test 014 fv3_ccpp_iau PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_lheatstrg_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_lheatstrg_prod
 Checking test 015 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -864,8 +864,8 @@ Checking test 015 fv3_ccpp_lheatstrg results ....
 Test 015 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_multigases_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_multigases_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_multigases_prod
 Checking test 016 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -938,8 +938,8 @@ Checking test 016 fv3_ccpp_multigases results ....
 Test 016 fv3_ccpp_multigases PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_control_32bit_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_32bit_prod
 Checking test 017 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 017 fv3_ccpp_control_32bit results ....
 Test 017 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_stretched_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_prod
 Checking test 018 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1062,8 +1062,8 @@ Checking test 018 fv3_ccpp_stretched results ....
 Test 018 fv3_ccpp_stretched PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_stretched_nest_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_nest_prod
 Checking test 019 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1129,8 +1129,8 @@ Checking test 019 fv3_ccpp_stretched_nest results ....
 Test 019 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_regional_control_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_control_prod
 Checking test 020 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1140,8 +1140,8 @@ Checking test 020 fv3_ccpp_regional_control results ....
 Test 020 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_restart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_regional_restart_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_restart_prod
 Checking test 021 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1149,8 +1149,8 @@ Checking test 021 fv3_ccpp_regional_restart results ....
 Test 021 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_regional_quilt_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_quilt_prod
 Checking test 022 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1160,8 +1160,8 @@ Checking test 022 fv3_ccpp_regional_quilt results ....
 Test 022 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 023 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1171,59 +1171,9 @@ Checking test 023 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 023 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_control_debug_prod
-Checking test 024 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 024 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_stretched_nest_debug_prod
-Checking test 025 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 025 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfdlmp_prod
-Checking test 026 fv3_ccpp_gfdlmp results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmp_prod
+Checking test 024 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1266,12 +1216,12 @@ Checking test 026 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 026 fv3_ccpp_gfdlmp PASS
+Test 024 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 027 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1314,12 +1264,12 @@ Checking test 027 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 027 fv3_ccpp_gfdlmprad_gwd PASS
+Test 025 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 028 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1362,12 +1312,12 @@ Checking test 028 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 028 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 026 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_csawmg_prod
-Checking test 029 fv3_ccpp_csawmg results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_csawmg_prod
+Checking test 027 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1410,12 +1360,12 @@ Checking test 029 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 029 fv3_ccpp_csawmg PASS
+Test 027 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_satmedmf_prod
-Checking test 030 fv3_ccpp_satmedmf results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_satmedmf_prod
+Checking test 028 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1458,12 +1408,12 @@ Checking test 030 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 030 fv3_ccpp_satmedmf PASS
+Test 028 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_satmedmfq_prod
-Checking test 031 fv3_ccpp_satmedmfq results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_satmedmfq_prod
+Checking test 029 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1506,12 +1456,12 @@ Checking test 031 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 031 fv3_ccpp_satmedmfq PASS
+Test 029 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 030 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1554,12 +1504,12 @@ Checking test 032 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 032 fv3_ccpp_gfdlmp_32bit PASS
+Test 030 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 031 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1606,12 +1556,12 @@ Checking test 033 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 033 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 031 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_cpt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_cpt_prod
-Checking test 034 fv3_ccpp_cpt results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_cpt_prod
+Checking test 032 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1660,12 +1610,12 @@ Checking test 034 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 034 fv3_ccpp_cpt PASS
+Test 032 fv3_ccpp_cpt PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gsd_prod
-Checking test 035 fv3_ccpp_gsd results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_prod
+Checking test 033 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1752,12 +1702,12 @@ Checking test 035 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 035 fv3_ccpp_gsd PASS
+Test 033 fv3_ccpp_gsd PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_thompson_prod
-Checking test 036 fv3_ccpp_thompson results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_prod
+Checking test 034 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1820,12 +1770,12 @@ Checking test 036 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 036 fv3_ccpp_thompson PASS
+Test 034 fv3_ccpp_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_thompson_no_aero_prod
-Checking test 037 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_no_aero_prod
+Checking test 035 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1888,12 +1838,12 @@ Checking test 037 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 037 fv3_ccpp_thompson_no_aero PASS
+Test 035 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v15p2_prod
-Checking test 038 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_prod
+Checking test 036 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1956,12 +1906,12 @@ Checking test 038 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 038 fv3_ccpp_gfs_v15p2 PASS
+Test 036 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_prod
-Checking test 039 fv3_ccpp_gfs_v16 results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_prod
+Checking test 037 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2036,12 +1986,12 @@ Checking test 039 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 039 fv3_ccpp_gfs_v16 PASS
+Test 037 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_restart_prod
-Checking test 040 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_restart_prod
+Checking test 038 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2086,12 +2036,12 @@ Checking test 040 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 040 fv3_ccpp_gfs_v16_restart PASS
+Test 038 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 041 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 039 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2154,12 +2104,12 @@ Checking test 041 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 041 fv3_ccpp_gfs_v16_stochy PASS
+Test 039 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 042 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 040 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2222,12 +2172,12 @@ Checking test 042 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 042 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 040 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 043 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 041 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2290,12 +2240,12 @@ Checking test 043 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 041 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 042 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2352,12 +2302,12 @@ Checking test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 042 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 045 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 043 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2400,12 +2350,12 @@ Checking test 045 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfsv16_csawmg PASS
+Test 043 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 046 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 044 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2448,12 +2398,12 @@ Checking test 046 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfsv16_csawmgt PASS
+Test 044 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gocart_clm_prod
-Checking test 047 fv3_ccpp_gocart_clm results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gocart_clm_prod
+Checking test 045 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2496,12 +2446,12 @@ Checking test 047 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gocart_clm PASS
+Test 045 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_flake_prod
-Checking test 048 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_flake_prod
+Checking test 046 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2564,12 +2514,12 @@ Checking test 048 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_flake PASS
+Test 046 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 047 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2632,12 +2582,12 @@ Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 047 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2650,12 +2600,12 @@ Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 048 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 051 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 049 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2712,12 +2662,12 @@ Checking test 051 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 049 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2774,12 +2724,12 @@ Checking test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 050 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 053 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2842,12 +2792,12 @@ Checking test 053 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfs_v15p2_debug PASS
+Test 051 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_debug_prod
-Checking test 054 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_debug_prod
+Checking test 052 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2910,12 +2860,12 @@ Checking test 054 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfs_v16_debug PASS
+Test 052 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2978,12 +2928,12 @@ Checking test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 056 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 054 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3046,12 +2996,73 @@ Checking test 056 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 054 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gsd_debug_prod
-Checking test 057 fv3_ccpp_gsd_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_regional_control_debug_prod
+Checking test 055 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 055 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_control_debug_prod
+Checking test 056 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 056 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_stretched_nest_debug_prod
+Checking test 057 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 057 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_debug_prod
+Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3114,12 +3125,12 @@ Checking test 057 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gsd_debug PASS
+Test 058 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 058 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3182,12 +3193,12 @@ Checking test 058 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gsd_diag3d_debug PASS
+Test 059 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_thompson_debug_prod
-Checking test 059 fv3_ccpp_thompson_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_debug_prod
+Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3250,12 +3261,12 @@ Checking test 059 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_thompson_debug PASS
+Test 060 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 060 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3318,12 +3329,12 @@ Checking test 060 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_thompson_no_aero_debug PASS
+Test 061 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 061 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3386,12 +3397,12 @@ Checking test 061 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3454,12 +3465,12 @@ Checking test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 062 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3472,12 +3483,12 @@ Checking test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 063 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_69843/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 064 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_257233/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 065 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3534,9 +3545,9 @@ Checking test 064 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 065 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 16 05:09:35 GMT 2021
-Elapsed time: 02h:12m:50s. Have a nice day!
+Thu Feb 18 00:55:53 GMT 2021
+Elapsed time: 02h:00m:45s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Fri Feb 12 21:49:05 CST 2021
+Thu Feb 18 10:57:36 CST 2021
 Start Regression test
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_control_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_decomp_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_2threads_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_restart_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_read_inc_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_read_inc_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -432,7 +432,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_stochy_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stochy_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_ca_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ca_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lndp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_lndp_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lndp_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_iau_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_iau_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_lheatstrg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_lheatstrg_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_lheatstrg_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmprad_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -981,8 +981,8 @@ Checking test 017 fv3_ccpp_gfdlmprad results ....
 Test 017 fv3_ccpp_gfdlmprad PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmprad_atmwav_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_atmwav_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1030,8 +1030,8 @@ Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
 Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_wrtGauss_nemsio_c768_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1079,8 +1079,8 @@ Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
 Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_multigases_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_multigases_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_multigases_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1153,8 +1153,8 @@ Checking test 020 fv3_ccpp_multigases results ....
 Test 020 fv3_ccpp_multigases PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_control_32bit_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_32bit_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1221,8 +1221,8 @@ Checking test 021 fv3_ccpp_control_32bit results ....
 Test 021 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_stretched_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1277,8 +1277,8 @@ Checking test 022 fv3_ccpp_stretched results ....
 Test 022 fv3_ccpp_stretched PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_stretched_nest_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1344,8 +1344,8 @@ Checking test 023 fv3_ccpp_stretched_nest results ....
 Test 023 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_regional_control_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1355,8 +1355,8 @@ Checking test 024 fv3_ccpp_regional_control results ....
 Test 024 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_regional_restart_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_restart_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1364,8 +1364,8 @@ Checking test 025 fv3_ccpp_regional_restart results ....
 Test 025 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_regional_quilt_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1375,8 +1375,8 @@ Checking test 026 fv3_ccpp_regional_quilt results ....
 Test 026 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1386,59 +1386,9 @@ Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_control_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_control_debug_prod
-Checking test 028 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 028 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_stretched_nest_debug_prod
-Checking test 029 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 029 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmp_prod
-Checking test 030 fv3_ccpp_gfdlmp results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmp_prod
+Checking test 028 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1481,12 +1431,12 @@ Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 030 fv3_ccpp_gfdlmp PASS
+Test 028 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 029 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1529,12 +1479,12 @@ Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 031 fv3_ccpp_gfdlmprad_gwd PASS
+Test 029 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 030 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1577,12 +1527,12 @@ Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 030 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_csawmg_prod
-Checking test 033 fv3_ccpp_csawmg results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_csawmg_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_csawmg_prod
+Checking test 031 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1625,12 +1575,12 @@ Checking test 033 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 033 fv3_ccpp_csawmg PASS
+Test 031 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_satmedmf_prod
-Checking test 034 fv3_ccpp_satmedmf results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmf_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_satmedmf_prod
+Checking test 032 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1673,12 +1623,12 @@ Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 034 fv3_ccpp_satmedmf PASS
+Test 032 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_satmedmfq_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_satmedmfq_prod
-Checking test 035 fv3_ccpp_satmedmfq results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_satmedmfq_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_satmedmfq_prod
+Checking test 033 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1721,12 +1671,12 @@ Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 035 fv3_ccpp_satmedmfq PASS
+Test 033 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 034 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1769,12 +1719,12 @@ Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gfdlmp_32bit PASS
+Test 034 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 035 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1821,12 +1771,12 @@ Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 035 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_cpt_prod
-Checking test 038 fv3_ccpp_cpt results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_cpt_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_cpt_prod
+Checking test 036 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1875,12 +1825,12 @@ Checking test 038 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 038 fv3_ccpp_cpt PASS
+Test 036 fv3_ccpp_cpt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gsd_prod
-Checking test 039 fv3_ccpp_gsd results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_prod
+Checking test 037 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1967,12 +1917,12 @@ Checking test 039 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_gsd PASS
+Test 037 fv3_ccpp_gsd PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rap_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_rap_prod
-Checking test 040 fv3_ccpp_rap results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rap_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rap_prod
+Checking test 038 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2035,12 +1985,12 @@ Checking test 040 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_rap PASS
+Test 038 fv3_ccpp_rap PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_hrrr_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_hrrr_prod
-Checking test 041 fv3_ccpp_hrrr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_hrrr_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_hrrr_prod
+Checking test 039 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2103,12 +2053,12 @@ Checking test 041 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_hrrr PASS
+Test 039 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_thompson_prod
-Checking test 042 fv3_ccpp_thompson results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_prod
+Checking test 040 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2171,12 +2121,12 @@ Checking test 042 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 042 fv3_ccpp_thompson PASS
+Test 040 fv3_ccpp_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_thompson_no_aero_prod
-Checking test 043 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_no_aero_prod
+Checking test 041 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2239,12 +2189,12 @@ Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 043 fv3_ccpp_thompson_no_aero PASS
+Test 041 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_rrfs_v1beta_prod
-Checking test 044 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rrfs_v1beta_prod
+Checking test 042 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2307,12 +2257,12 @@ Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 044 fv3_ccpp_rrfs_v1beta PASS
+Test 042 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v15p2_prod
-Checking test 045 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_prod
+Checking test 043 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2375,12 +2325,12 @@ Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v15p2 PASS
+Test 043 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_prod
-Checking test 046 fv3_ccpp_gfs_v16 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_prod
+Checking test 044 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2455,12 +2405,12 @@ Checking test 046 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16 PASS
+Test 044 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_restart_prod
-Checking test 047 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_restart_prod
+Checking test 045 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2505,12 +2455,12 @@ Checking test 047 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfs_v16_restart PASS
+Test 045 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_stochy_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_stochy_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 046 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2573,12 +2523,12 @@ Checking test 048 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_stochy PASS
+Test 046 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 047 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2641,12 +2591,12 @@ Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 047 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 048 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2709,12 +2659,12 @@ Checking test 050 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 048 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2771,12 +2721,12 @@ Checking test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 049 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmg_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2819,12 +2769,12 @@ Checking test 052 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfsv16_csawmg PASS
+Test 050 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfsv16_csawmgt_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2867,12 +2817,12 @@ Checking test 053 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gfsv16_csawmgt PASS
+Test 051 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gocart_clm_prod
-Checking test 054 fv3_ccpp_gocart_clm results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gocart_clm_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gocart_clm_prod
+Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2915,12 +2865,12 @@ Checking test 054 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gocart_clm PASS
+Test 052 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_flake_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_flake_prod
-Checking test 055 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_flake_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_flake_prod
+Checking test 053 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2983,12 +2933,12 @@ Checking test 055 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfs_v16_flake PASS
+Test 053 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3051,12 +3001,12 @@ Checking test 056 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -3069,12 +3019,12 @@ Checking test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 057 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 058 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 056 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3131,12 +3081,12 @@ Checking test 058 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 056 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3193,12 +3143,12 @@ Checking test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 057 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 060 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 058 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3261,12 +3211,12 @@ Checking test 060 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v15p2_debug PASS
+Test 058 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_debug_prod
-Checking test 061 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_debug_prod
+Checking test 059 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3329,12 +3279,12 @@ Checking test 061 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gfs_v16_debug PASS
+Test 059 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3397,12 +3347,12 @@ Checking test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 060 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 063 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 061 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3465,12 +3415,73 @@ Checking test 063 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 061 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gsd_debug_prod
-Checking test 064 fv3_ccpp_gsd_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_regional_control_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_regional_control_debug_prod
+Checking test 062 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 062 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_control_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_control_debug_prod
+Checking test 063 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 063 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_stretched_nest_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_stretched_nest_debug_prod
+Checking test 064 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 064 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_debug_prod
+Checking test 065 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3533,12 +3544,12 @@ Checking test 064 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gsd_debug PASS
+Test 065 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 066 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3601,12 +3612,12 @@ Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_gsd_diag3d_debug PASS
+Test 066 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_thompson_debug_prod
-Checking test 066 fv3_ccpp_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_debug_prod
+Checking test 067 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3669,12 +3680,12 @@ Checking test 066 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_thompson_debug PASS
+Test 067 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 068 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3737,12 +3748,12 @@ Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_thompson_no_aero_debug PASS
+Test 068 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 069 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3805,12 +3816,12 @@ Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 068 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 069 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3873,12 +3884,12 @@ Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 070 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3891,12 +3902,12 @@ Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 071 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 072 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3953,12 +3964,12 @@ Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 071 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 072 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_control_prod
-Checking test 072 cpld_control results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_prod
+Checking test 073 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4006,12 +4017,12 @@ Checking test 072 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_control PASS
+Test 073 cpld_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_prod
-Checking test 073 cpld_restart results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_prod
+Checking test 074 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4059,12 +4070,12 @@ Checking test 073 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_restart PASS
+Test 074 cpld_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_controlfrac_prod
-Checking test 074 cpld_controlfrac results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_prod
+Checking test 075 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4112,12 +4123,12 @@ Checking test 074 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_controlfrac PASS
+Test 075 cpld_controlfrac PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restartfrac_prod
-Checking test 075 cpld_restartfrac results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_prod
+Checking test 076 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4165,12 +4176,12 @@ Checking test 075 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_restartfrac PASS
+Test 076 cpld_restartfrac PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_2threads_prod
-Checking test 076 cpld_2threads results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_2threads_prod
+Checking test 077 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4218,12 +4229,12 @@ Checking test 076 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_2threads PASS
+Test 077 cpld_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_decomp_prod
-Checking test 077 cpld_decomp results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_decomp_prod
+Checking test 078 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4271,12 +4282,12 @@ Checking test 077 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_decomp PASS
+Test 078 cpld_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_satmedmf_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_satmedmf_prod
-Checking test 078 cpld_satmedmf results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_satmedmf_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_satmedmf_prod
+Checking test 079 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4324,12 +4335,12 @@ Checking test 078 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_satmedmf PASS
+Test 079 cpld_satmedmf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_ca_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_ca_prod
-Checking test 079 cpld_ca results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_ca_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_ca_prod
+Checking test 080 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4377,12 +4388,12 @@ Checking test 079 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 079 cpld_ca PASS
+Test 080 cpld_ca PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_control_c192_prod
-Checking test 080 cpld_control_c192 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_c192_prod
+Checking test 081 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4430,12 +4441,12 @@ Checking test 080 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_control_c192 PASS
+Test 081 cpld_control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_c192_prod
-Checking test 081 cpld_restart_c192 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c192_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_c192_prod
+Checking test 082 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4483,12 +4494,12 @@ Checking test 081 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_restart_c192 PASS
+Test 082 cpld_restart_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_controlfrac_c192_prod
-Checking test 082 cpld_controlfrac_c192 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_c192_prod
+Checking test 083 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4536,12 +4547,12 @@ Checking test 082 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_controlfrac_c192 PASS
+Test 083 cpld_controlfrac_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restartfrac_c192_prod
-Checking test 083 cpld_restartfrac_c192 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c192_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_c192_prod
+Checking test 084 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4589,12 +4600,12 @@ Checking test 083 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 083 cpld_restartfrac_c192 PASS
+Test 084 cpld_restartfrac_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_control_c384_prod
-Checking test 084 cpld_control_c384 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_c384_prod
+Checking test 085 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4645,12 +4656,12 @@ Checking test 084 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_control_c384 PASS
+Test 085 cpld_control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_c384_prod
-Checking test 085 cpld_restart_c384 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_c384_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_c384_prod
+Checking test 086 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4701,12 +4712,12 @@ Checking test 085 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_restart_c384 PASS
+Test 086 cpld_restart_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_controlfrac_c384_prod
-Checking test 086 cpld_controlfrac_c384 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_controlfrac_c384_prod
+Checking test 087 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4757,12 +4768,12 @@ Checking test 086 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_controlfrac_c384 PASS
+Test 087 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restartfrac_c384_prod
-Checking test 087 cpld_restartfrac_c384 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_controlfrac_c384_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restartfrac_c384_prod
+Checking test 088 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4813,12 +4824,12 @@ Checking test 087 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 087 cpld_restartfrac_c384 PASS
+Test 088 cpld_restartfrac_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmark_prod
-Checking test 088 cpld_bmark results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmark_prod
+Checking test 089 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4869,12 +4880,12 @@ Checking test 088 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_bmark PASS
+Test 089 cpld_bmark PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_bmark_prod
-Checking test 089 cpld_restart_bmark results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmark_prod
+Checking test 090 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4925,12 +4936,12 @@ Checking test 089 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_restart_bmark PASS
+Test 090 cpld_restart_bmark PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmarkfrac_prod
-Checking test 090 cpld_bmarkfrac results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_prod
+Checking test 091 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4981,12 +4992,12 @@ Checking test 090 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_bmarkfrac PASS
+Test 091 cpld_bmarkfrac PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_bmarkfrac_prod
-Checking test 091 cpld_restart_bmarkfrac results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmarkfrac_prod
+Checking test 092 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5037,12 +5048,12 @@ Checking test 091 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 091 cpld_restart_bmarkfrac PASS
+Test 092 cpld_restart_bmarkfrac PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmarkfrac_v16_prod
-Checking test 092 cpld_bmarkfrac_v16 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_v16_prod
+Checking test 093 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5093,12 +5104,12 @@ Checking test 092 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 092 cpld_bmarkfrac_v16 PASS
+Test 093 cpld_bmarkfrac_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_restart_bmarkfrac_v16_prod
-Checking test 093 cpld_restart_bmarkfrac_v16 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_v16_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_restart_bmarkfrac_v16_prod
+Checking test 094 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5149,12 +5160,12 @@ Checking test 093 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 093 cpld_restart_bmarkfrac_v16 PASS
+Test 094 cpld_restart_bmarkfrac_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmark_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmark_wave_prod
-Checking test 094 cpld_bmark_wave results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmark_wave_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmark_wave_prod
+Checking test 095 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5208,12 +5219,12 @@ Checking test 094 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 094 cpld_bmark_wave PASS
+Test 095 cpld_bmark_wave PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmarkfrac_wave_prod
-Checking test 095 cpld_bmarkfrac_wave results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_wave_prod
+Checking test 096 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5267,12 +5278,12 @@ Checking test 095 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 095 cpld_bmarkfrac_wave PASS
+Test 096 cpld_bmarkfrac_wave PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_bmarkfrac_wave_v16_prod
-Checking test 096 cpld_bmarkfrac_wave_v16 results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_bmarkfrac_wave_v16_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_bmarkfrac_wave_v16_prod
+Checking test 097 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5326,12 +5337,12 @@ Checking test 096 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 096 cpld_bmarkfrac_wave_v16 PASS
+Test 097 cpld_bmarkfrac_wave_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_control_wave_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_control_wave_prod
-Checking test 097 cpld_control_wave results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_control_wave_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_control_wave_prod
+Checking test 098 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5382,12 +5393,12 @@ Checking test 097 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 097 cpld_control_wave PASS
+Test 098 cpld_control_wave PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_debug_prod
-Checking test 098 cpld_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debug_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_debug_prod
+Checking test 099 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5435,12 +5446,12 @@ Checking test 098 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 098 cpld_debug PASS
+Test 099 cpld_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/cpld_debugfrac_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/cpld_debugfrac_prod
-Checking test 099 cpld_debugfrac results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/cpld_debugfrac_ccpp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/cpld_debugfrac_prod
+Checking test 100 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5488,87 +5499,87 @@ Checking test 099 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 099 cpld_debugfrac PASS
+Test 100 cpld_debugfrac PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_control_cfsr
-Checking test 100 datm_control_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_control_cfsr
+Checking test 101 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 100 datm_control_cfsr PASS
+Test 101 datm_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_restart_cfsr
-Checking test 101 datm_restart_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_restart_cfsr
+Checking test 102 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_restart_cfsr PASS
+Test 102 datm_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_control_gefs
-Checking test 102 datm_control_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_control_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_control_gefs
+Checking test 103 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_control_gefs PASS
+Test 103 datm_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_bulk_cfsr
-Checking test 103 datm_bulk_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_bulk_cfsr
+Checking test 104 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_bulk_cfsr PASS
+Test 104 datm_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_bulk_gefs
-Checking test 104 datm_bulk_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_bulk_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_bulk_gefs
+Checking test 105 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_bulk_gefs PASS
+Test 105 datm_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_mx025_cfsr
-Checking test 105 datm_mx025_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_mx025_cfsr
+Checking test 106 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_mx025_cfsr PASS
+Test 106 datm_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_mx025_gefs
-Checking test 106 datm_mx025_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_mx025_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_mx025_gefs
+Checking test 107 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 106 datm_mx025_gefs PASS
+Test 107 datm_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_261242/datm_debug_cfsr
-Checking test 107 datm_debug_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/INTEL/datm_debug_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_239111/datm_debug_cfsr
+Checking test 108 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 107 datm_debug_cfsr PASS
+Test 108 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Feb 12 23:13:38 CST 2021
-Elapsed time: 01h:24m:33s. Have a nice day!
+Thu Feb 18 21:22:48 CST 2021
+Elapsed time: 10h:25m:12s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Sat Feb 13 21:26:36 UTC 2021
+Thu Feb 18 16:08:52 UTC 2021
 Start Regression test
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_control_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_decomp_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_2threads_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_restart_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_read_inc_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_read_inc_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_stochy_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stochy_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ca_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_ca_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ca_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_lndp_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_lndp_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lndp_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_iau_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_iau_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_lheatstrg_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lheatstrg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_multigases_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_multigases_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_multigases_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1006,8 +1006,8 @@ Checking test 017 fv3_ccpp_multigases results ....
 Test 017 fv3_ccpp_multigases PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_control_32bit_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_32bit_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1074,8 +1074,8 @@ Checking test 018 fv3_ccpp_control_32bit results ....
 Test 018 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_stretched_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1130,8 +1130,8 @@ Checking test 019 fv3_ccpp_stretched results ....
 Test 019 fv3_ccpp_stretched PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_stretched_nest_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1197,8 +1197,8 @@ Checking test 020 fv3_ccpp_stretched_nest results ....
 Test 020 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_regional_control_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1208,8 +1208,8 @@ Checking test 021 fv3_ccpp_regional_control results ....
 Test 021 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_regional_restart_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_restart_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1217,8 +1217,8 @@ Checking test 022 fv3_ccpp_regional_restart results ....
 Test 022 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_regional_quilt_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1228,8 +1228,8 @@ Checking test 023 fv3_ccpp_regional_quilt results ....
 Test 023 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1239,59 +1239,9 @@ Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_control_debug_prod
-Checking test 025 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 025 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_stretched_nest_debug_prod
-Checking test 026 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 026 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfdlmp_prod
-Checking test 027 fv3_ccpp_gfdlmp results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmp_prod
+Checking test 025 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1334,12 +1284,12 @@ Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 027 fv3_ccpp_gfdlmp PASS
+Test 025 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_gwd_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 026 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1382,12 +1332,12 @@ Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 028 fv3_ccpp_gfdlmprad_gwd PASS
+Test 026 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 027 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1430,12 +1380,12 @@ Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 027 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_csawmg_prod
-Checking test 030 fv3_ccpp_csawmg results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_csawmg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_csawmg_prod
+Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1478,12 +1428,12 @@ Checking test 030 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 030 fv3_ccpp_csawmg PASS
+Test 028 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_satmedmf_prod
-Checking test 031 fv3_ccpp_satmedmf results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmf_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_satmedmf_prod
+Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1526,12 +1476,12 @@ Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 031 fv3_ccpp_satmedmf PASS
+Test 029 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_satmedmfq_prod
-Checking test 032 fv3_ccpp_satmedmfq results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmfq_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_satmedmfq_prod
+Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1574,12 +1524,12 @@ Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 032 fv3_ccpp_satmedmfq PASS
+Test 030 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_32bit_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1622,12 +1572,12 @@ Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 033 fv3_ccpp_gfdlmp_32bit PASS
+Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1674,12 +1624,12 @@ Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_cpt_prod
-Checking test 035 fv3_ccpp_cpt results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_cpt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_cpt_prod
+Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1728,12 +1678,12 @@ Checking test 035 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 035 fv3_ccpp_cpt PASS
+Test 033 fv3_ccpp_cpt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gsd_prod
-Checking test 036 fv3_ccpp_gsd results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_prod
+Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1820,12 +1770,12 @@ Checking test 036 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gsd PASS
+Test 034 fv3_ccpp_gsd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rap_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_rap_prod
-Checking test 037 fv3_ccpp_rap results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rap_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rap_prod
+Checking test 035 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1888,12 +1838,12 @@ Checking test 037 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 037 fv3_ccpp_rap PASS
+Test 035 fv3_ccpp_rap PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_hrrr_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_hrrr_prod
-Checking test 038 fv3_ccpp_hrrr results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_hrrr_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_hrrr_prod
+Checking test 036 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1956,12 +1906,12 @@ Checking test 038 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 038 fv3_ccpp_hrrr PASS
+Test 036 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_thompson_prod
-Checking test 039 fv3_ccpp_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_prod
+Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2024,12 +1974,12 @@ Checking test 039 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_thompson PASS
+Test 037 fv3_ccpp_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_thompson_no_aero_prod
-Checking test 040 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_no_aero_prod
+Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2092,12 +2042,12 @@ Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_thompson_no_aero PASS
+Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_rrfs_v1beta_prod
-Checking test 041 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rrfs_v1beta_prod
+Checking test 039 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2160,12 +2110,12 @@ Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_rrfs_v1beta PASS
+Test 039 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v15p2_prod
-Checking test 042 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_prod
+Checking test 040 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2228,12 +2178,12 @@ Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 042 fv3_ccpp_gfs_v15p2 PASS
+Test 040 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_prod
-Checking test 043 fv3_ccpp_gfs_v16 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_prod
+Checking test 041 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2308,12 +2258,12 @@ Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 043 fv3_ccpp_gfs_v16 PASS
+Test 041 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_restart_prod
-Checking test 044 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_restart_prod
+Checking test 042 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2358,12 +2308,12 @@ Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfs_v16_restart PASS
+Test 042 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_stochy_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 043 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2426,12 +2376,12 @@ Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v16_stochy PASS
+Test 043 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 044 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2494,12 +2444,12 @@ Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 044 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 045 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2562,12 +2512,12 @@ Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 045 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2624,12 +2574,12 @@ Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 046 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmg_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 047 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2672,12 +2622,12 @@ Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfsv16_csawmg PASS
+Test 047 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmgt_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 048 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2720,12 +2670,12 @@ Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfsv16_csawmgt PASS
+Test 048 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gocart_clm_prod
-Checking test 051 fv3_ccpp_gocart_clm results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gocart_clm_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gocart_clm_prod
+Checking test 049 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2768,12 +2718,12 @@ Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gocart_clm PASS
+Test 049 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_flake_prod
-Checking test 052 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_flake_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_flake_prod
+Checking test 050 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2836,12 +2786,12 @@ Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfs_v16_flake PASS
+Test 050 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 051 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2904,12 +2854,12 @@ Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 051 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2922,12 +2872,12 @@ Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 052 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 053 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2984,12 +2934,12 @@ Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 053 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3046,12 +2996,12 @@ Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 054 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 055 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3114,12 +3064,12 @@ Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfs_v15p2_debug PASS
+Test 055 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_debug_prod
-Checking test 058 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_debug_prod
+Checking test 056 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3182,12 +3132,12 @@ Checking test 058 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfs_v16_debug PASS
+Test 056 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3250,12 +3200,12 @@ Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 057 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 058 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3318,12 +3268,73 @@ Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 058 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gsd_debug_prod
-Checking test 061 fv3_ccpp_gsd_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_regional_control_debug_prod
+Checking test 059 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 059 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_control_debug_prod
+Checking test 060 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 060 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_stretched_nest_debug_prod
+Checking test 061 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 061 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_debug_prod
+Checking test 062 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3386,12 +3397,12 @@ Checking test 061 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gsd_debug PASS
+Test 062 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_diag3d_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 063 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3454,12 +3465,12 @@ Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gsd_diag3d_debug PASS
+Test 063 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_thompson_debug_prod
-Checking test 063 fv3_ccpp_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_debug_prod
+Checking test 064 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3522,12 +3533,12 @@ Checking test 063 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_thompson_debug PASS
+Test 064 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 065 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3590,12 +3601,12 @@ Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_thompson_no_aero_debug PASS
+Test 065 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 066 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3658,12 +3669,12 @@ Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 066 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3726,12 +3737,12 @@ Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 067 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3744,12 +3755,12 @@ Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 068 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_35664/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 068 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_7643/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 069 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3806,9 +3817,9 @@ Checking test 068 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 068 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 069 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Feb 13 22:08:09 UTC 2021
-Elapsed time: 00h:41m:34s. Have a nice day!
+Thu Feb 18 16:51:34 UTC 2021
+Elapsed time: 00h:42m:42s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Sun Feb 14 01:18:17 UTC 2021
+Thu Feb 18 21:24:50 UTC 2021
 Start Regression test
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_control_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_decomp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_2threads_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_restart_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -256,8 +256,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_read_inc_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_read_inc_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -324,8 +324,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,8 +372,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -420,8 +420,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_netcdf_parallel_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -430,9 +430,9 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -468,8 +468,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
 Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -516,8 +516,8 @@ Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -564,8 +564,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -612,8 +612,8 @@ Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_stochy_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stochy_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -680,8 +680,8 @@ Checking test 012 fv3_ccpp_stochy results ....
 Test 012 fv3_ccpp_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_ca_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ca_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -748,8 +748,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_lndp_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_lndp_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lndp_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -816,8 +816,8 @@ Checking test 014 fv3_ccpp_lndp results ....
 Test 014 fv3_ccpp_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_iau_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_iau_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -884,8 +884,8 @@ Checking test 015 fv3_ccpp_iau results ....
 Test 015 fv3_ccpp_iau PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_lheatstrg_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_lheatstrg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -932,8 +932,8 @@ Checking test 016 fv3_ccpp_lheatstrg results ....
 Test 016 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmprad_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -981,8 +981,8 @@ Checking test 017 fv3_ccpp_gfdlmprad results ....
 Test 017 fv3_ccpp_gfdlmprad PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmprad_atmwav_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_atmwav_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1030,8 +1030,8 @@ Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
 Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_multigases_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_multigases_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_multigases_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_multigases_prod
 Checking test 019 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1104,8 +1104,8 @@ Checking test 019 fv3_ccpp_multigases results ....
 Test 019 fv3_ccpp_multigases PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_control_32bit_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_32bit_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_32bit_prod
 Checking test 020 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1172,8 +1172,8 @@ Checking test 020 fv3_ccpp_control_32bit results ....
 Test 020 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_stretched_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_prod
 Checking test 021 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1228,8 +1228,8 @@ Checking test 021 fv3_ccpp_stretched results ....
 Test 021 fv3_ccpp_stretched PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_stretched_nest_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_nest_prod
 Checking test 022 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1295,8 +1295,8 @@ Checking test 022 fv3_ccpp_stretched_nest results ....
 Test 022 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_regional_control_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_control_prod
 Checking test 023 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1306,8 +1306,8 @@ Checking test 023 fv3_ccpp_regional_control results ....
 Test 023 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_regional_restart_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_restart_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_restart_prod
 Checking test 024 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1315,8 +1315,8 @@ Checking test 024 fv3_ccpp_regional_restart results ....
 Test 024 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_regional_quilt_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_quilt_prod
 Checking test 025 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1326,8 +1326,8 @@ Checking test 025 fv3_ccpp_regional_quilt results ....
 Test 025 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_quilt_netcdf_parallel_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 026 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1337,59 +1337,9 @@ Checking test 026 fv3_ccpp_regional_quilt_netcdf_parallel results ....
 Test 026 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_control_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_control_debug_prod
-Checking test 027 fv3_ccpp_control_debug results ....
- Comparing phyf000.tile1.nc .........OK
- Comparing phyf000.tile2.nc .........OK
- Comparing phyf000.tile3.nc .........OK
- Comparing phyf000.tile4.nc .........OK
- Comparing phyf000.tile5.nc .........OK
- Comparing phyf000.tile6.nc .........OK
- Comparing dynf000.tile1.nc .........OK
- Comparing dynf000.tile2.nc .........OK
- Comparing dynf000.tile3.nc .........OK
- Comparing dynf000.tile4.nc .........OK
- Comparing dynf000.tile5.nc .........OK
- Comparing dynf000.tile6.nc .........OK
- Comparing phyf006.tile1.nc .........OK
- Comparing phyf006.tile2.nc .........OK
- Comparing phyf006.tile3.nc .........OK
- Comparing phyf006.tile4.nc .........OK
- Comparing phyf006.tile5.nc .........OK
- Comparing phyf006.tile6.nc .........OK
- Comparing dynf006.tile1.nc .........OK
- Comparing dynf006.tile2.nc .........OK
- Comparing dynf006.tile3.nc .........OK
- Comparing dynf006.tile4.nc .........OK
- Comparing dynf006.tile5.nc .........OK
- Comparing dynf006.tile6.nc .........OK
-Test 027 fv3_ccpp_control_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_stretched_nest_debug_prod
-Checking test 028 fv3_ccpp_stretched_nest_debug results ....
- Comparing fv3_history2d.nest02.tile7.nc .........OK
- Comparing fv3_history2d.tile1.nc .........OK
- Comparing fv3_history2d.tile2.nc .........OK
- Comparing fv3_history2d.tile3.nc .........OK
- Comparing fv3_history2d.tile4.nc .........OK
- Comparing fv3_history2d.tile5.nc .........OK
- Comparing fv3_history2d.tile6.nc .........OK
- Comparing fv3_history.nest02.tile7.nc .........OK
- Comparing fv3_history.tile1.nc .........OK
- Comparing fv3_history.tile2.nc .........OK
- Comparing fv3_history.tile3.nc .........OK
- Comparing fv3_history.tile4.nc .........OK
- Comparing fv3_history.tile5.nc .........OK
- Comparing fv3_history.tile6.nc .........OK
-Test 028 fv3_ccpp_stretched_nest_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmp_prod
-Checking test 029 fv3_ccpp_gfdlmp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmp_prod
+Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1432,12 +1382,12 @@ Checking test 029 fv3_ccpp_gfdlmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 029 fv3_ccpp_gfdlmp PASS
+Test 027 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmprad_gwd_prod
-Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_gwd_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_gwd_prod
+Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1480,12 +1430,12 @@ Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 030 fv3_ccpp_gfdlmprad_gwd PASS
+Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmprad_noahmp_prod
-Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_noahmp_prod
+Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1528,12 +1478,12 @@ Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 031 fv3_ccpp_gfdlmprad_noahmp PASS
+Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_csawmg_prod
-Checking test 032 fv3_ccpp_csawmg results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_csawmg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_csawmg_prod
+Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1576,12 +1526,12 @@ Checking test 032 fv3_ccpp_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 032 fv3_ccpp_csawmg PASS
+Test 030 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_satmedmf_prod
-Checking test 033 fv3_ccpp_satmedmf results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_satmedmf_prod
+Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1624,12 +1574,12 @@ Checking test 033 fv3_ccpp_satmedmf results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 033 fv3_ccpp_satmedmf PASS
+Test 031 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_satmedmfq_prod
-Checking test 034 fv3_ccpp_satmedmfq results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_satmedmfq_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_satmedmfq_prod
+Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1672,12 +1622,12 @@ Checking test 034 fv3_ccpp_satmedmfq results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 034 fv3_ccpp_satmedmfq PASS
+Test 032 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmp_32bit_prod
-Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmp_32bit_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmp_32bit_prod
+Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1720,12 +1670,12 @@ Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 035 fv3_ccpp_gfdlmp_32bit PASS
+Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfdlmprad_32bit_post_prod
-Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfdlmprad_32bit_post_prod
+Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1772,12 +1722,12 @@ Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 036 fv3_ccpp_gfdlmprad_32bit_post PASS
+Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_cpt_prod
-Checking test 037 fv3_ccpp_cpt results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_cpt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_cpt_prod
+Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1826,12 +1776,12 @@ Checking test 037 fv3_ccpp_cpt results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 037 fv3_ccpp_cpt PASS
+Test 035 fv3_ccpp_cpt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gsd_prod
-Checking test 038 fv3_ccpp_gsd results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_prod
+Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1918,12 +1868,12 @@ Checking test 038 fv3_ccpp_gsd results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 038 fv3_ccpp_gsd PASS
+Test 036 fv3_ccpp_gsd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rap_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_rap_prod
-Checking test 039 fv3_ccpp_rap results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rap_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rap_prod
+Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1986,12 +1936,12 @@ Checking test 039 fv3_ccpp_rap results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 039 fv3_ccpp_rap PASS
+Test 037 fv3_ccpp_rap PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_hrrr_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_hrrr_prod
-Checking test 040 fv3_ccpp_hrrr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_hrrr_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_hrrr_prod
+Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2054,12 +2004,12 @@ Checking test 040 fv3_ccpp_hrrr results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 040 fv3_ccpp_hrrr PASS
+Test 038 fv3_ccpp_hrrr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_thompson_prod
-Checking test 041 fv3_ccpp_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_prod
+Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2122,12 +2072,12 @@ Checking test 041 fv3_ccpp_thompson results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 041 fv3_ccpp_thompson PASS
+Test 039 fv3_ccpp_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_thompson_no_aero_prod
-Checking test 042 fv3_ccpp_thompson_no_aero results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_no_aero_prod
+Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2190,12 +2140,12 @@ Checking test 042 fv3_ccpp_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 042 fv3_ccpp_thompson_no_aero PASS
+Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_rrfs_v1beta_prod
-Checking test 043 fv3_ccpp_rrfs_v1beta results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rrfs_v1beta_prod
+Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2258,12 +2208,12 @@ Checking test 043 fv3_ccpp_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 043 fv3_ccpp_rrfs_v1beta PASS
+Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v15p2_prod
-Checking test 044 fv3_ccpp_gfs_v15p2 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_prod
+Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2326,12 +2276,12 @@ Checking test 044 fv3_ccpp_gfs_v15p2 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 044 fv3_ccpp_gfs_v15p2 PASS
+Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_prod
-Checking test 045 fv3_ccpp_gfs_v16 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_prod
+Checking test 043 fv3_ccpp_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2406,12 +2356,12 @@ Checking test 045 fv3_ccpp_gfs_v16 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 045 fv3_ccpp_gfs_v16 PASS
+Test 043 fv3_ccpp_gfs_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_restart_prod
-Checking test 046 fv3_ccpp_gfs_v16_restart results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_restart_prod
+Checking test 044 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -2456,12 +2406,12 @@ Checking test 046 fv3_ccpp_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 046 fv3_ccpp_gfs_v16_restart PASS
+Test 044 fv3_ccpp_gfs_v16_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_stochy_prod
-Checking test 047 fv3_ccpp_gfs_v16_stochy results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_stochy_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_stochy_prod
+Checking test 045 fv3_ccpp_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2524,12 +2474,12 @@ Checking test 047 fv3_ccpp_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 047 fv3_ccpp_gfs_v16_stochy PASS
+Test 045 fv3_ccpp_gfs_v16_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v15p2_RRTMGP_prod
-Checking test 048 fv3_ccpp_gfs_v15p2_RRTMGP results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2592,12 +2542,12 @@ Checking test 048 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 048 fv3_ccpp_gfs_v15p2_RRTMGP PASS
+Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_RRTMGP_prod
-Checking test 049 fv3_ccpp_gfs_v16_RRTMGP results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_prod
+Checking test 047 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2660,12 +2610,12 @@ Checking test 049 fv3_ccpp_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 049 fv3_ccpp_gfs_v16_RRTMGP PASS
+Test 047 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_c192L127_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
-Checking test 050 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_c192L127_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_c192L127_prod
+Checking test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -2722,12 +2672,12 @@ Checking test 050 fv3_ccpp_gfs_v16_RRTMGP_c192L127 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 050 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
+Test 048 fv3_ccpp_gfs_v16_RRTMGP_c192L127 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfsv16_csawmg_prod
-Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmg_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_csawmg_prod
+Checking test 049 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2770,12 +2720,12 @@ Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 051 fv3_ccpp_gfsv16_csawmg PASS
+Test 049 fv3_ccpp_gfsv16_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfsv16_csawmgt_prod
-Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfsv16_csawmgt_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_csawmgt_prod
+Checking test 050 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2818,12 +2768,12 @@ Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 052 fv3_ccpp_gfsv16_csawmgt PASS
+Test 050 fv3_ccpp_gfsv16_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gocart_clm_prod
-Checking test 053 fv3_ccpp_gocart_clm results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gocart_clm_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gocart_clm_prod
+Checking test 051 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2866,12 +2816,12 @@ Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 053 fv3_ccpp_gocart_clm PASS
+Test 051 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_flake_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_flake_prod
-Checking test 054 fv3_ccpp_gfs_v16_flake results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_flake_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_flake_prod
+Checking test 052 fv3_ccpp_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2934,12 +2884,12 @@ Checking test 054 fv3_ccpp_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 054 fv3_ccpp_gfs_v16_flake PASS
+Test 052 fv3_ccpp_gfs_v16_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
-Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+Checking test 053 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3002,12 +2952,12 @@ Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
+Test 053 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
-Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+Checking test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -3020,12 +2970,12 @@ Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
+Test 054 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfsv16_ugwpv1_prod
-Checking test 057 fv3_ccpp_gfsv16_ugwpv1 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_prod
+Checking test 055 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3082,12 +3032,12 @@ Checking test 057 fv3_ccpp_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 057 fv3_ccpp_gfsv16_ugwpv1 PASS
+Test 055 fv3_ccpp_gfsv16_ugwpv1 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
-Checking test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_warmstart_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_warmstart_prod
+Checking test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3144,12 +3094,12 @@ Checking test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 058 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
+Test 056 fv3_ccpp_gfsv16_ugwpv1_warmstart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v15p2_debug_prod
-Checking test 059 fv3_ccpp_gfs_v15p2_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_debug_prod
+Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3212,12 +3162,12 @@ Checking test 059 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 059 fv3_ccpp_gfs_v15p2_debug PASS
+Test 057 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_debug_prod
-Checking test 060 fv3_ccpp_gfs_v16_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_debug_prod
+Checking test 058 fv3_ccpp_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3280,12 +3230,12 @@ Checking test 060 fv3_ccpp_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 060 fv3_ccpp_gfs_v16_debug PASS
+Test 058 fv3_ccpp_gfs_v16_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
-Checking test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v15p2_RRTMGP_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3348,12 +3298,12 @@ Checking test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 061 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
+Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
-Checking test 062 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gfs_v16_RRTMGP_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+Checking test 060 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3416,12 +3366,73 @@ Checking test 062 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 062 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
+Test 060 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gsd_debug_prod
-Checking test 063 fv3_ccpp_gsd_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_regional_control_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_regional_control_debug_prod
+Checking test 061 fv3_ccpp_regional_control_debug results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+Test 061 fv3_ccpp_regional_control_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_control_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_control_debug_prod
+Checking test 062 fv3_ccpp_control_debug results ....
+ Comparing phyf000.tile1.nc .........OK
+ Comparing phyf000.tile2.nc .........OK
+ Comparing phyf000.tile3.nc .........OK
+ Comparing phyf000.tile4.nc .........OK
+ Comparing phyf000.tile5.nc .........OK
+ Comparing phyf000.tile6.nc .........OK
+ Comparing dynf000.tile1.nc .........OK
+ Comparing dynf000.tile2.nc .........OK
+ Comparing dynf000.tile3.nc .........OK
+ Comparing dynf000.tile4.nc .........OK
+ Comparing dynf000.tile5.nc .........OK
+ Comparing dynf000.tile6.nc .........OK
+ Comparing phyf006.tile1.nc .........OK
+ Comparing phyf006.tile2.nc .........OK
+ Comparing phyf006.tile3.nc .........OK
+ Comparing phyf006.tile4.nc .........OK
+ Comparing phyf006.tile5.nc .........OK
+ Comparing phyf006.tile6.nc .........OK
+ Comparing dynf006.tile1.nc .........OK
+ Comparing dynf006.tile2.nc .........OK
+ Comparing dynf006.tile3.nc .........OK
+ Comparing dynf006.tile4.nc .........OK
+ Comparing dynf006.tile5.nc .........OK
+ Comparing dynf006.tile6.nc .........OK
+Test 062 fv3_ccpp_control_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_stretched_nest_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_stretched_nest_debug_prod
+Checking test 063 fv3_ccpp_stretched_nest_debug results ....
+ Comparing fv3_history2d.nest02.tile7.nc .........OK
+ Comparing fv3_history2d.tile1.nc .........OK
+ Comparing fv3_history2d.tile2.nc .........OK
+ Comparing fv3_history2d.tile3.nc .........OK
+ Comparing fv3_history2d.tile4.nc .........OK
+ Comparing fv3_history2d.tile5.nc .........OK
+ Comparing fv3_history2d.tile6.nc .........OK
+ Comparing fv3_history.nest02.tile7.nc .........OK
+ Comparing fv3_history.tile1.nc .........OK
+ Comparing fv3_history.tile2.nc .........OK
+ Comparing fv3_history.tile3.nc .........OK
+ Comparing fv3_history.tile4.nc .........OK
+ Comparing fv3_history.tile5.nc .........OK
+ Comparing fv3_history.tile6.nc .........OK
+Test 063 fv3_ccpp_stretched_nest_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_debug_prod
+Checking test 064 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3484,12 +3495,12 @@ Checking test 063 fv3_ccpp_gsd_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 063 fv3_ccpp_gsd_debug PASS
+Test 064 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gsd_diag3d_debug_prod
-Checking test 064 fv3_ccpp_gsd_diag3d_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_gsd_diag3d_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gsd_diag3d_debug_prod
+Checking test 065 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3552,12 +3563,12 @@ Checking test 064 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 064 fv3_ccpp_gsd_diag3d_debug PASS
+Test 065 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_thompson_debug_prod
-Checking test 065 fv3_ccpp_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_debug_prod
+Checking test 066 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3620,12 +3631,12 @@ Checking test 065 fv3_ccpp_thompson_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 065 fv3_ccpp_thompson_debug PASS
+Test 066 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_thompson_no_aero_debug_prod
-Checking test 066 fv3_ccpp_thompson_no_aero_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_thompson_no_aero_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_thompson_no_aero_debug_prod
+Checking test 067 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3688,12 +3699,12 @@ Checking test 066 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 066 fv3_ccpp_thompson_no_aero_debug PASS
+Test 067 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_rrfs_v1beta_debug_prod
-Checking test 067 fv3_ccpp_rrfs_v1beta_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_rrfs_v1beta_debug_prod
+Checking test 068 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3756,12 +3767,12 @@ Checking test 067 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile4.nc .........OK
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
-Test 067 fv3_ccpp_rrfs_v1beta_debug PASS
+Test 068 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 068 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -3824,12 +3835,12 @@ Checking test 068 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 068 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
+Test 069 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
-Checking test 069 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+Checking test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -3842,12 +3853,12 @@ Checking test 069 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/fv_tracer.res.tile1.nc .........OK
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
-Test 069 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 070 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/fv3_ccpp_gfsv16_ugwpv1_debug_prod
-Checking test 070 fv3_ccpp_gfsv16_ugwpv1_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/fv3_ccpp_gfsv16_ugwpv1_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/fv3_ccpp_gfsv16_ugwpv1_debug_prod
+Checking test 071 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -3904,12 +3915,12 @@ Checking test 070 fv3_ccpp_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile4.nc .........OK
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
-Test 070 fv3_ccpp_gfsv16_ugwpv1_debug PASS
+Test 071 fv3_ccpp_gfsv16_ugwpv1_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_control_prod
-Checking test 071 cpld_control results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_prod
+Checking test 072 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -3957,12 +3968,12 @@ Checking test 071 cpld_control results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 071 cpld_control PASS
+Test 072 cpld_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_prod
-Checking test 072 cpld_restart results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_prod
+Checking test 073 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4010,12 +4021,12 @@ Checking test 072 cpld_restart results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 072 cpld_restart PASS
+Test 073 cpld_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_controlfrac_prod
-Checking test 073 cpld_controlfrac results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_prod
+Checking test 074 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4063,12 +4074,12 @@ Checking test 073 cpld_controlfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 073 cpld_controlfrac PASS
+Test 074 cpld_controlfrac PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restartfrac_prod
-Checking test 074 cpld_restartfrac results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_prod
+Checking test 075 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4116,12 +4127,12 @@ Checking test 074 cpld_restartfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 074 cpld_restartfrac PASS
+Test 075 cpld_restartfrac PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_2threads_prod
-Checking test 075 cpld_2threads results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_2threads_prod
+Checking test 076 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4169,12 +4180,12 @@ Checking test 075 cpld_2threads results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 075 cpld_2threads PASS
+Test 076 cpld_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_decomp_prod
-Checking test 076 cpld_decomp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_decomp_prod
+Checking test 077 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4222,12 +4233,12 @@ Checking test 076 cpld_decomp results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 076 cpld_decomp PASS
+Test 077 cpld_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_satmedmf_prod
-Checking test 077 cpld_satmedmf results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_satmedmf_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_satmedmf_prod
+Checking test 078 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4275,12 +4286,12 @@ Checking test 077 cpld_satmedmf results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 077 cpld_satmedmf PASS
+Test 078 cpld_satmedmf PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_ca_prod
-Checking test 078 cpld_ca results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_ca_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_ca_prod
+Checking test 079 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4328,12 +4339,12 @@ Checking test 078 cpld_ca results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 078 cpld_ca PASS
+Test 079 cpld_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_control_c192_prod
-Checking test 079 cpld_control_c192 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_c192_prod
+Checking test 080 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4381,12 +4392,12 @@ Checking test 079 cpld_control_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 079 cpld_control_c192 PASS
+Test 080 cpld_control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_c192_prod
-Checking test 080 cpld_restart_c192 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_c192_prod
+Checking test 081 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4434,12 +4445,12 @@ Checking test 080 cpld_restart_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 080 cpld_restart_c192 PASS
+Test 081 cpld_restart_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_controlfrac_c192_prod
-Checking test 081 cpld_controlfrac_c192 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_c192_prod
+Checking test 082 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4487,12 +4498,12 @@ Checking test 081 cpld_controlfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 081 cpld_controlfrac_c192 PASS
+Test 082 cpld_controlfrac_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restartfrac_c192_prod
-Checking test 082 cpld_restartfrac_c192 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c192_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_c192_prod
+Checking test 083 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
  Comparing phyf048.tile3.nc .........OK
@@ -4540,12 +4551,12 @@ Checking test 082 cpld_restartfrac_c192 results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
-Test 082 cpld_restartfrac_c192 PASS
+Test 083 cpld_restartfrac_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_control_c384_prod
-Checking test 083 cpld_control_c384 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_c384_prod
+Checking test 084 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4596,12 +4607,12 @@ Checking test 083 cpld_control_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 083 cpld_control_c384 PASS
+Test 084 cpld_control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_c384_prod
-Checking test 084 cpld_restart_c384 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_c384_prod
+Checking test 085 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4652,12 +4663,12 @@ Checking test 084 cpld_restart_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 084 cpld_restart_c384 PASS
+Test 085 cpld_restart_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_controlfrac_c384_prod
-Checking test 085 cpld_controlfrac_c384 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_controlfrac_c384_prod
+Checking test 086 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4708,12 +4719,12 @@ Checking test 085 cpld_controlfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 085 cpld_controlfrac_c384 PASS
+Test 086 cpld_controlfrac_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restartfrac_c384_prod
-Checking test 086 cpld_restartfrac_c384 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_controlfrac_c384_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restartfrac_c384_prod
+Checking test 087 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4764,12 +4775,12 @@ Checking test 086 cpld_restartfrac_c384 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
-Test 086 cpld_restartfrac_c384 PASS
+Test 087 cpld_restartfrac_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmark_prod
-Checking test 087 cpld_bmark results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmark_prod
+Checking test 088 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4820,12 +4831,12 @@ Checking test 087 cpld_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 087 cpld_bmark PASS
+Test 088 cpld_bmark PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_bmark_prod
-Checking test 088 cpld_restart_bmark results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmark_prod
+Checking test 089 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4876,12 +4887,12 @@ Checking test 088 cpld_restart_bmark results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 088 cpld_restart_bmark PASS
+Test 089 cpld_restart_bmark PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmarkfrac_prod
-Checking test 089 cpld_bmarkfrac results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_prod
+Checking test 090 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4932,12 +4943,12 @@ Checking test 089 cpld_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 089 cpld_bmarkfrac PASS
+Test 090 cpld_bmarkfrac PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_bmarkfrac_prod
-Checking test 090 cpld_restart_bmarkfrac results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmarkfrac_prod
+Checking test 091 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -4988,12 +4999,12 @@ Checking test 090 cpld_restart_bmarkfrac results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 090 cpld_restart_bmarkfrac PASS
+Test 091 cpld_restart_bmarkfrac PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmarkfrac_v16_prod
-Checking test 091 cpld_bmarkfrac_v16 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_v16_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_v16_prod
+Checking test 092 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5044,12 +5055,12 @@ Checking test 091 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 091 cpld_bmarkfrac_v16 PASS
+Test 092 cpld_bmarkfrac_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_restart_bmarkfrac_v16_prod
-Checking test 092 cpld_restart_bmarkfrac_v16 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_v16_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_restart_bmarkfrac_v16_prod
+Checking test 093 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5100,12 +5111,12 @@ Checking test 092 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 092 cpld_restart_bmarkfrac_v16 PASS
+Test 093 cpld_restart_bmarkfrac_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmark_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmark_wave_prod
-Checking test 093 cpld_bmark_wave results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmark_wave_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmark_wave_prod
+Checking test 094 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5159,12 +5170,12 @@ Checking test 093 cpld_bmark_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 093 cpld_bmark_wave PASS
+Test 094 cpld_bmark_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmarkfrac_wave_prod
-Checking test 094 cpld_bmarkfrac_wave results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_wave_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_wave_prod
+Checking test 095 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5218,12 +5229,12 @@ Checking test 094 cpld_bmarkfrac_wave results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
-Test 094 cpld_bmarkfrac_wave PASS
+Test 095 cpld_bmarkfrac_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_bmarkfrac_wave_v16_prod
-Checking test 095 cpld_bmarkfrac_wave_v16 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_bmarkfrac_wave_v16_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_bmarkfrac_wave_v16_prod
+Checking test 096 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
  Comparing phyf012.tile3.nc .........OK
@@ -5277,12 +5288,12 @@ Checking test 095 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2013-04-01-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-43200.nc .........OK
-Test 095 cpld_bmarkfrac_wave_v16 PASS
+Test 096 cpld_bmarkfrac_wave_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_control_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_control_wave_prod
-Checking test 096 cpld_control_wave results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_control_wave_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_control_wave_prod
+Checking test 097 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
  Comparing phyf024.tile3.nc .........OK
@@ -5333,12 +5344,12 @@ Checking test 096 cpld_control_wave results ....
  Comparing 20161004.000000.out_grd.glo_1deg .........OK
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
-Test 096 cpld_control_wave PASS
+Test 097 cpld_control_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_debug_prod
-Checking test 097 cpld_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_debug_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_debug_prod
+Checking test 098 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5386,12 +5397,12 @@ Checking test 097 cpld_debug results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 097 cpld_debug PASS
+Test 098 cpld_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/cpld_debugfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/cpld_debugfrac_prod
-Checking test 098 cpld_debugfrac results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/cpld_debugfrac_ccpp
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/cpld_debugfrac_prod
+Checking test 099 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
  Comparing phyf006.tile3.nc .........OK
@@ -5439,87 +5450,87 @@ Checking test 098 cpld_debugfrac results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
-Test 098 cpld_debugfrac PASS
+Test 099 cpld_debugfrac PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_control_cfsr
-Checking test 099 datm_control_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_control_cfsr
+Checking test 100 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 099 datm_control_cfsr PASS
+Test 100 datm_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_restart_cfsr
-Checking test 100 datm_restart_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_restart_cfsr
+Checking test 101 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 100 datm_restart_cfsr PASS
+Test 101 datm_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_control_gefs
-Checking test 101 datm_control_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_control_gefs
+Checking test 102 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 101 datm_control_gefs PASS
+Test 102 datm_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_bulk_cfsr
-Checking test 102 datm_bulk_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_bulk_cfsr
+Checking test 103 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 102 datm_bulk_cfsr PASS
+Test 103 datm_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_bulk_gefs
-Checking test 103 datm_bulk_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_bulk_gefs
+Checking test 104 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 103 datm_bulk_gefs PASS
+Test 104 datm_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_mx025_cfsr
-Checking test 104 datm_mx025_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_mx025_cfsr
+Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-Test 104 datm_mx025_cfsr PASS
+Test 105 datm_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_mx025_gefs
-Checking test 105 datm_mx025_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_mx025_gefs
+Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
  Comparing RESTART/MOM.res_3.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-Test 105 datm_mx025_gefs PASS
+Test 106 datm_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210212/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_108921/datm_debug_cfsr
-Checking test 106 datm_debug_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210217/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_133624/datm_debug_cfsr
+Checking test 107 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-Test 106 datm_debug_cfsr PASS
+Test 107 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Feb 14 03:49:20 UTC 2021
-Elapsed time: 02h:31m:05s. Have a nice day!
+Fri Feb 19 05:44:09 UTC 2021
+Elapsed time: 08h:19m:22s. Have a nice day!

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -343,6 +343,8 @@ export NA_INIT=1
 # Radiation
 export DO_RRTMGP=.F.
 export ICLOUD=0
+export IAER=111
+export ICLIQ_SW=1
 export IOVR=1
 
 # Microphysics

--- a/tests/fv3_conf/ccpp_gsd_run.IN
+++ b/tests/fv3_conf/ccpp_gsd_run.IN
@@ -39,8 +39,7 @@ if [ $IMP_PHYSICS = 8 ]; then
     fi
   else
     if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
-      echo "ERROR, no field table configured for Thompson MP without aerosols but with MYNN or SATMEDMF (need TKE)"
-      exit 1
+      cp  @[INPUTDATA_ROOT]/FV3_input_data_gsd/field_table_thompson_noaero_tke field_table
     else
       cp  @[INPUTDATA_ROOT]/FV3_input_data_gsd/field_table_thompson_noaero field_table
     fi

--- a/tests/parm/ccpp_gsd.nml.IN
+++ b/tests/parm/ccpp_gsd.nml.IN
@@ -134,7 +134,9 @@
        fhlwr          = 3600.
        ialb           = 1
        iems           = 1
-       iaer           = 111
+       iaer           = @[IAER]
+       icliq_sw       = @[ICLIQ_SW]
+       iovr           = @[IOVR]
        ico2           = 2
        isubc_sw       = 2
        isubc_lw       = 2
@@ -147,7 +149,8 @@
        redrag         = .true.
        dspheat        = .true.
        hybedmf        = @[HYBEDMF]
-       satmedmf       = .false.
+       satmedmf       = @[SATMEDMF]
+       isatmedmf      = 1
        lheatstrg      = @[LHEATSTRG]
        do_mynnedmf    = @[DO_MYNNEDMF]
        do_mynnsfclay  = @[DO_MYNNSFCLAY]
@@ -194,7 +197,10 @@
        bl_mynn_tkeadvect = .true.
        bl_mynn_edmf      = 1
        bl_mynn_edmf_mom  = 1
-       gwd_opt        = @[GWD_OPT]
+       gwd_opt              = @[GWD_OPT]
+       ldiag_ugwp           = @[LDIAG_UGWP]
+       do_ugwp              = @[DO_UGWP]
+       do_tofd              = @[DO_TOFD]
        do_ugwp_v0           = @[DO_UGWP_V0]
        do_ugwp_v0_orog_only = @[DO_UGWP_V0_OROG_ONLY]
        do_gsl_drag_ls_bl    = @[DO_GSL_DRAG_LS_BL]
@@ -300,27 +306,28 @@
        FSICS    = 99999,
 /
 &nam_stochy
-  lon_s=768,
-  lat_s=384,
-  ntrunc=382,
   SKEBNORM=1,
   SKEB_NPASS=30,
   SKEB_VDOF=5,
   SKEB=@[SKEB],
   SKEB_TAU=2.16E4,
   SKEB_LSCALE=1000.E3,
+  SKEBINT=1800,
   SHUM=@[SHUM],
   SHUM_TAU=21600,
   SHUM_LSCALE=500000,
+  SHUMINT=3600,
   SPPT=@[SPPT],
   SPPT_TAU=21600,
   SPPT_LSCALE=500000,
   SPPT_LOGIT=.TRUE.,
   SPPT_SFCLIMIT=.TRUE.,
+  SPPTINT=1800,
   ISEED_SHUM=1,
   ISEED_SKEB=2,
   ISEED_SPPT=3,
 /
+
 &nam_sfcperts
   lndp_type      = @[LNDP_TYPE]
   LNDP_TAU=21600,
@@ -344,3 +351,4 @@
        knob_ugwp_version = 0
        launch_level      = 25
 /
+

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -47,13 +47,6 @@ RUN     | fv3_ccpp_regional_quilt_netcdf_parallel                               
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | jet.intel                               | fv3 |
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | orion.intel                             | fv3 |
 
-COMPILE | SUITES=FV3_GFS_v15_thompson_mynn 32BIT=Y DEBUG=Y                                                                        |                                         | fv3 |
-RUN     | fv3_ccpp_regional_control_debug                                                                                         |                                         | fv3 |
-
-COMPILE | SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                              |                                         | fv3 |
-RUN     | fv3_ccpp_control_debug                                                                                                  |                                         | fv3 |
-RUN     | fv3_ccpp_stretched_nest_debug                                                                                           |                                         | fv3 |
-
 COMPILE | SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp                                                                   |                                         | fv3 |
 RUN     | fv3_ccpp_gfdlmp                                                                                                         |                                         | fv3 |
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                  |                                         | fv3 |
@@ -66,7 +59,7 @@ RUN     | fv3_ccpp_csawmg                                                       
 RUN     | fv3_ccpp_satmedmf                                                                                                       |                                         | fv3 |
 RUN     | fv3_ccpp_satmedmfq                                                                                                      |                                         | fv3 |
 
-COMPILE | SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta 32BIT=Y          |                                         | fv3 |
+COMPILE | SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta 32BIT=Y          |                                         | fv3 |
 RUN     | fv3_ccpp_gfdlmp_32bit                                                                                                   |                                         | fv3 |
 RUN     | fv3_ccpp_gfdlmprad_32bit_post                                                                                           |                                         | fv3 |
 RUN     | fv3_ccpp_cpt                                                                                                            |                                         | fv3 |
@@ -118,7 +111,14 @@ RUN     | fv3_ccpp_gfs_v16_debug                                                
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP_debug                                                                                         |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP_debug                                                                                           |                                         | fv3 |
 
-COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                                         | fv3 |
+COMPILE | SUITES=FV3_GFS_v15_thompson_mynn 32BIT=Y DEBUG=Y                                                                        |                                         | fv3 |
+RUN     | fv3_ccpp_regional_control_debug                                                                                         |                                         | fv3 |
+
+COMPILE | SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                              |                                         | fv3 |
+RUN     | fv3_ccpp_control_debug                                                                                                  |                                         | fv3 |
+RUN     | fv3_ccpp_stretched_nest_debug                                                                                           |                                         | fv3 |
+
+COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_gsd_debug                                                                                                      |                                         | fv3 |
 RUN     | fv3_ccpp_gsd_diag3d_debug                                                                                               |                                         | fv3 |
 RUN     | fv3_ccpp_thompson_debug                                                                                                 |                                         | fv3 |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -105,20 +105,16 @@ RUN     | fv3_ccpp_gfsv16_ugwpv1_warmstart                                      
 # Exercise compilation without specifying suites (i.e. compile all suites) in DEBUG mode (faster than in PROD mode)
 # Note: weird bug on Cheyenne, compiling without SUITES=... works fine on the login nodes, but crashes on the compute nodes; same issues on wcoss_cray and wcoss_dell_p3
 COMPILE | DEBUG=Y                                                                                                    | - gaea.intel cheyenne.intel wcoss_cray wcoss_dell_p3 | fv3 |
-COMPILE | DEBUG=Y SUITES='FV3_GFS_v15p2,FV3_GFS_v15p2_RRTMGP,FV3_GFS_v16,FV3_GFS_v16_RRTMGP'                         | + gaea.intel cheyenne.intel wcoss_cray wcoss_dell_p3 | fv3 |
+COMPILE | DEBUG=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v15p2_RRTMGP,FV3_GFS_v16,FV3_GFS_v16_RRTMGP                           | + gaea.intel cheyenne.intel wcoss_cray wcoss_dell_p3 | fv3 |
 RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16_debug                                                                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP_debug                                                                                         |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP_debug                                                                                           |                                         | fv3 |
 
-COMPILE | SUITES=FV3_GFS_v15_thompson_mynn 32BIT=Y DEBUG=Y                                                                        |                                         | fv3 |
+COMPILE | SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y |                            | fv3 |
 RUN     | fv3_ccpp_regional_control_debug                                                                                         |                                         | fv3 |
-
-COMPILE | SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                              |                                         | fv3 |
 RUN     | fv3_ccpp_control_debug                                                                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_stretched_nest_debug                                                                                           |                                         | fv3 |
-
-COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_gsd_debug                                                                                                      |                                         | fv3 |
 RUN     | fv3_ccpp_gsd_diag3d_debug                                                                                               |                                         | fv3 |
 RUN     | fv3_ccpp_thompson_debug                                                                                                 |                                         | fv3 |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -47,6 +47,9 @@ RUN     | fv3_ccpp_regional_quilt_netcdf_parallel                               
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | jet.intel                               | fv3 |
 #RUN     | fv3_ccpp_regional_c768                                                                                                 | orion.intel                             | fv3 |
 
+COMPILE | SUITES=FV3_GFS_v15_thompson_mynn 32BIT=Y DEBUG=Y                                                                        |                                         | fv3 |
+RUN     | fv3_ccpp_regional_control_debug                                                                                         |                                         | fv3 |
+
 COMPILE | SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                              |                                         | fv3 |
 RUN     | fv3_ccpp_control_debug                                                                                                  |                                         | fv3 |
 RUN     | fv3_ccpp_stretched_nest_debug                                                                                           |                                         | fv3 |

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -415,9 +415,9 @@ if [[ $TESTS_FILE =~ '35d' ]]; then
 fi
 
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20210212/${RT_COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20210217/${RT_COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20210212}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-20210217}
 fi
 
 INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20210212}

--- a/tests/rt_ccpp_dev.conf
+++ b/tests/rt_ccpp_dev.conf
@@ -20,7 +20,7 @@ COMPILE | REPRO=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                
 RUN     | fv3_ccpp_gsd_mynnsfc                                                                                              |                | fv3         |
 RUN     | fv3_ccpp_gsd_noah_mynnsfc                                                                                         |                | fv3         |
 
-COMPILE | REPRO=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_SAR                                   |                | fv3         |
+COMPILE | REPRO=Y SUITES=FV3_GFS_v16_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_SAR                                   |                | fv3         |
 
 RUN     | fv3_ccpp_thompson                                                                                                 |                | fv3         |
 RUN     | fv3_ccpp_thompson_no_aero                                                                                         |                | fv3         |
@@ -46,7 +46,7 @@ RUN     | fv3_ccpp_ntiedtke                                                     
 # CCPP DEBUG tests                                                                                                                                         #
 ############################################################################################################################################################
 
-COMPILE | DEBUG=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson                            |                | fv3         |
+COMPILE | DEBUG=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v16_thompson                            |                | fv3         |
 
 RUN     | fv3_ccpp_gsd_debug                                                                                                |                | fv3         |
 RUN     | fv3_ccpp_gsd_diag3d_debug                                                                                         |                | fv3         |

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -46,12 +46,12 @@ RUN     | fv3_ccpp_gfs_v16_RRTMGP_debug                                         
 COMPILE | SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y                                                                        |                | fv3         |
 RUN     | fv3_ccpp_multigases                                                                                                     |                | fv3         |
 
-COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                | fv3         |
-# FIX ME - THESE ARE ALL CRASHING ON HERA WITH GNU 9.2.0 / CHEYENNE WITH GNU 9.1.0
-#RUN     | fv3_ccpp_rrfs_v1beta_debug                                                                                              |                | fv3         |
-#RUN     | fv3_ccpp_gsd_debug                                                                                                      |                | fv3         |
-#RUN     | fv3_ccpp_thompson_debug                                                                                                 |                | fv3         |
-#RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                         |                | fv3         |
+COMPILE | SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                        |                | fv3         |
+RUN     | fv3_ccpp_regional_control_debug                                                                                         |                | fv3         |
+RUN     | fv3_ccpp_rrfs_v1beta_debug                                                                                              |                | fv3         |
+RUN     | fv3_ccpp_gsd_debug                                                                                                      |                | fv3         |
+RUN     | fv3_ccpp_thompson_debug                                                                                                 |                | fv3         |
+RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                         |                | fv3         |
 
 COMPILE | SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1 DEBUG=Y                                                   |                | fv3         |
 RUN     | fv3_ccpp_HAFS_v0_hwrf_thompson_debug                                                                                    |                | fv3         |

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -15,7 +15,7 @@ RUN     | fv3_ccpp_gfs_v16_flake                                                
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP                                                                                               |                | fv3         |
 RUN     | fv3_ccpp_gfs_v16_RRTMGP                                                                                                 |                | fv3         |
 
-COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson,FV3_RRFS_v1beta 32BIT=Y                                                          |                | fv3         |
+COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y                                                          |                | fv3         |
 
 RUN     | fv3_ccpp_gsd                                                                                                            |                | fv3         |
 RUN     | fv3_ccpp_thompson                                                                                                       |                | fv3         |
@@ -46,7 +46,7 @@ RUN     | fv3_ccpp_gfs_v16_RRTMGP_debug                                         
 COMPILE | SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y                                                                        |                | fv3         |
 RUN     | fv3_ccpp_multigases                                                                                                     |                | fv3         |
 
-COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                | fv3         |
+COMPILE | SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta 32BIT=Y DEBUG=Y                                                  |                | fv3         |
 # FIX ME - THESE ARE ALL CRASHING ON HERA WITH GNU 9.2.0 / CHEYENNE WITH GNU 9.1.0
 #RUN     | fv3_ccpp_rrfs_v1beta_debug                                                                                              |                | fv3         |
 #RUN     | fv3_ccpp_gsd_debug                                                                                                      |                | fv3         |

--- a/tests/tests/fv3_ccpp_regional_control_debug
+++ b/tests/tests/fv3_ccpp_regional_control_debug
@@ -1,0 +1,35 @@
+###############################################################################
+#
+#  FV3 CCPP regional control test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP regional control results with previous trunk version"
+
+export CNTL_DIR=fv3_regional_control_debug
+
+export LIST_FILES="  atmos_4xdaily.nc \
+                     fv3_history2d.nc \
+                       fv3_history.nc \
+     RESTART/fv_core.res.tile1_new.nc \
+   RESTART/fv_tracer.res.tile1_new.nc"
+
+export_fv3
+
+export TASKS=40
+export FHMAX="01"
+
+export FV3_RUN=ccpp_regional_run.IN
+
+export OZ_PHYS_OLD=.F.
+export OZ_PHYS_NEW=.T.
+export H2O_PHYS=.T.
+export HYBEDMF=.F.
+
+export CCPP_SUITE=FV3_GFS_v15_thompson_mynn
+export INPUT_NML=ccpp_regional.nml.IN
+
+export FDIAG=1
+export INPES=5
+export JNPES=8
+export WRITE_RESTART_WITH_BCS=.true.

--- a/tests/tests/fv3_ccpp_thompson
+++ b/tests/tests/fv3_ccpp_thompson
@@ -81,11 +81,19 @@ export LRADAR=.T.
 export LTAEROSOL=.T.
 
 export FV3_RUN=ccpp_gsd_run.IN
-export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_SUITE=FV3_GFS_v16_thompson
 export INPUT_NML=ccpp_gsd.nml.IN
 
-export HYBEDMF=.T.
+export HYBEDMF=.F.
+export SATMEDMF=.T.
 export DO_MYNNEDMF=.F.
+
 export IMFSHALCNV=2
 export IMFDEEPCNV=2
 
+export IAER=5111
+export ICLIQ_SW=2
+export IOVR=3
+
+export LHEATSTRG=.T.
+export DO_TOFD=.T.

--- a/tests/tests/fv3_ccpp_thompson_debug
+++ b/tests/tests/fv3_ccpp_thompson_debug
@@ -84,11 +84,19 @@ export LRADAR=.T.
 export LTAEROSOL=.T.
 
 export FV3_RUN=ccpp_gsd_run.IN
-export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_SUITE=FV3_GFS_v16_thompson
 export INPUT_NML=ccpp_gsd.nml.IN
 
-export HYBEDMF=.T.
+export HYBEDMF=.F.
+export SATMEDMF=.T.
 export DO_MYNNEDMF=.F.
+
 export IMFSHALCNV=2
 export IMFDEEPCNV=2
 
+export IAER=5111
+export ICLIQ_SW=2
+export IOVR=3
+
+export LHEATSTRG=.T.
+export DO_TOFD=.T.

--- a/tests/tests/fv3_ccpp_thompson_no_aero
+++ b/tests/tests/fv3_ccpp_thompson_no_aero
@@ -82,11 +82,19 @@ export NSRADAR_RESET=3600.0
 export LTAEROSOL=.F.
 
 export FV3_RUN=ccpp_gsd_run.IN
-export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_SUITE=FV3_GFS_v16_thompson
 export INPUT_NML=ccpp_gsd.nml.IN
 
-export HYBEDMF=.T.
+export HYBEDMF=.F.
+export SATMEDMF=.T.
 export DO_MYNNEDMF=.F.
+
 export IMFSHALCNV=2
 export IMFDEEPCNV=2
 
+export IAER=5111
+export ICLIQ_SW=2
+export IOVR=3
+
+export LHEATSTRG=.T.
+export DO_TOFD=.T.

--- a/tests/tests/fv3_ccpp_thompson_no_aero_debug
+++ b/tests/tests/fv3_ccpp_thompson_no_aero_debug
@@ -85,11 +85,19 @@ export NSRADAR_RESET=3600.0
 export LTAEROSOL=.F.
 
 export FV3_RUN=ccpp_gsd_run.IN
-export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_SUITE=FV3_GFS_v16_thompson
 export INPUT_NML=ccpp_gsd.nml.IN
 
-export HYBEDMF=.T.
+export HYBEDMF=.F.
+export SATMEDMF=.T.
 export DO_MYNNEDMF=.F.
+
 export IMFSHALCNV=2
 export IMFDEEPCNV=2
 
+export IAER=5111
+export ICLIQ_SW=2
+export IOVR=3
+
+export LHEATSTRG=.T.
+export DO_TOFD=.T.


### PR DESCRIPTION
## Description

This PR and the PRs listed below add the capability and regression tests to run GFS v16 physics with Thompson microphysics.

Changes in this PR:
- update existing regression tests for GFS v15 + Thompson to GFS v16 + Thompson
- also included: changes from #419 "Add one regional regression test in DEBUG mode" from @RatkoVasic-NOAA

### Issue(s) addressed

https://github.com/ufs-community/ufs-weather-model/issues/420
https://github.com/ufs-community/ufs-weather-model/pull/419

## Testing

Regression tests will be run on all tier-1 platforms.

The current input data set (input-data-20210212) must be updated to include one additional file (`FV3_input_data_gsd/field_table_thompson_noaero_tke`), no other changes.

New regression test baselines are required, the date tag is `20210217`.

**Regression testing completed on all tier-1 platforms:**
- cheyenne.gnu
- cheyenne.intel
- gaea.intel
- hera.gnu
- hera.intel
- jet.intel
- orion.intel
- wcoss_cray
- wcoss_dell_p3

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/566
https://github.com/NOAA-EMC/fv3atm/pull/238
https://github.com/ufs-community/ufs-weather-model/pull/421
