### PR TITLE
release/public-v2: Update submodule pointer for fv3atm for ccpp-physics release v5 SCM only mods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v2
+	url = https://github.com/climbfuji/fv3atm
+	branch = ccpp_physics_v5_scm_mods
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v2
-	url = https://github.com/climbfuji/fv3atm
-	branch = ccpp_physics_v5_scm_mods
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description

Update `.gitmodules` and submodule pointer for fv3atm for ccpp-physics SCM-only changes in NCAR/ccpp-physics#572.

## Testing

No testing required, these two files are not used by the ufs-weather-model (they are in fact completely ignored, because they are not in fv3atm's `ccpp/config/ccpp_prebuild_config.py`).

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/572
https://github.com/NOAA-EMC/fv3atm/pull/248
https://github.com/ufs-community/ufs-weather-model/pull/423