### PR TITLE
release/public-v2: Final update of submodule pointer for fv3atm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-EMC/fv3atm
-	#branch = release/public-v2
-	url = https://github.com/climbfuji/fv3atm
-	branch = update_submodule_pointers_final_release_public_v2
+	url = https://github.com/NOAA-EMC/fv3atm
+	branch = release/public-v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-EMC/fv3atm
-	branch = release/public-v2
+	#url = https://github.com/NOAA-EMC/fv3atm
+	#branch = release/public-v2
+	url = https://github.com/climbfuji/fv3atm
+	branch = update_submodule_pointers_final_release_public_v2
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Sun Feb 14 14:35:39 MST 2021
+Mon Feb 22 20:13:49 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_repro
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_repro
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_repro
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_39088/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_66681/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Feb 14 14:53:34 MST 2021
-Elapsed time: 00h:17m:56s. Have a nice day!
+Mon Feb 22 20:31:44 MST 2021
+Elapsed time: 00h:17m:55s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Sun Feb 14 14:35:33 MST 2021
+Mon Feb 22 20:13:39 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_repro
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_29993/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_4364/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Feb 14 15:14:48 MST 2021
-Elapsed time: 00h:39m:16s. Have a nice day!
+Mon Feb 22 20:52:51 MST 2021
+Elapsed time: 00h:39m:13s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Mon Feb 15 22:05:43 EST 2021
+Mon Feb 22 22:23:14 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_warmstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_repro
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_repro
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_repro
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_control_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_583/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_15579/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 16 01:08:35 EST 2021
-Elapsed time: 03h:02m:53s. Have a nice day!
+Tue Feb 23 01:01:28 EST 2021
+Elapsed time: 02h:38m:15s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Sun Feb 14 21:01:02 UTC 2021
+Tue Feb 23 03:22:38 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_warmstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_repro
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_158937/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_183451/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Feb 14 21:42:59 UTC 2021
-Elapsed time: 00h:41m:58s. Have a nice day!
+Tue Feb 23 03:48:45 UTC 2021
+Elapsed time: 00h:26m:08s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Mon Feb 15 15:46:56 GMT 2021
+Tue Feb 23 03:14:42 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_warmstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_repro
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_repro
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_repro
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_control_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_regional_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_276954/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_260713/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 15 17:33:03 GMT 2021
-Elapsed time: 01h:46m:09s. Have a nice day!
+Tue Feb 23 04:28:36 GMT 2021
+Elapsed time: 01h:13m:57s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Fri Feb 12 16:16:03 CST 2021
+Mon Feb 22 21:14:22 CST 2021
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_control_prod
 Checking test 001 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -23,7 +23,7 @@ Test 001 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_decomp_prod
 Checking test 002 fv3_ccpp_regional_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -42,7 +42,7 @@ Test 002 fv3_ccpp_regional_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_2threads_prod
 Checking test 003 fv3_ccpp_regional_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -60,7 +60,7 @@ Test 003 fv3_ccpp_regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_coldstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_coldstart_prod
 Checking test 004 fv3_ccpp_regional_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -70,7 +70,7 @@ Test 004 fv3_ccpp_regional_coldstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_warmstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_warmstart_prod
 Checking test 005 fv3_ccpp_regional_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -85,7 +85,7 @@ Test 005 fv3_ccpp_regional_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_prod
 Checking test 006 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -105,7 +105,7 @@ Test 006 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_2threads_prod
 Checking test 007 fv3_ccpp_regional_v15p2_2threads results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -123,7 +123,7 @@ Test 007 fv3_ccpp_regional_v15p2_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_coldstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_coldstart_prod
 Checking test 008 fv3_ccpp_regional_v15p2_coldstart results ....
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
@@ -133,7 +133,7 @@ Test 008 fv3_ccpp_regional_v15p2_coldstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_warmstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_warmstart_prod
 Checking test 009 fv3_ccpp_regional_v15p2_warmstart results ....
  Comparing phyf012.nc .........OK
  Comparing dynf012.nc .........OK
@@ -148,7 +148,7 @@ Test 009 fv3_ccpp_regional_v15p2_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_prod
 Checking test 010 fv3_ccpp_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -228,7 +228,7 @@ Test 010 fv3_ccpp_rrfs_v1alpha PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_decomp_prod
 Checking test 011 fv3_ccpp_rrfs_v1alpha_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -302,7 +302,7 @@ Test 011 fv3_ccpp_rrfs_v1alpha_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_2threads_prod
 Checking test 012 fv3_ccpp_rrfs_v1alpha_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -382,7 +382,7 @@ Test 012 fv3_ccpp_rrfs_v1alpha_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_coldstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_coldstart_prod
 Checking test 013 fv3_ccpp_rrfs_v1alpha_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -412,7 +412,7 @@ Test 013 fv3_ccpp_rrfs_v1alpha_coldstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_warmstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_warmstart_prod
 Checking test 014 fv3_ccpp_rrfs_v1alpha_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -462,7 +462,7 @@ Test 014 fv3_ccpp_rrfs_v1alpha_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_gfs_v15p2_prod
 Checking test 015 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -542,7 +542,7 @@ Test 015 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_gfs_v15p2_coldstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_gfs_v15p2_coldstart_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_coldstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -572,7 +572,7 @@ Test 016 fv3_ccpp_gfs_v15p2_coldstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_gfs_v15p2_warmstart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_gfs_v15p2_warmstart_prod
 Checking test 017 fv3_ccpp_gfs_v15p2_warmstart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -622,7 +622,7 @@ Test 017 fv3_ccpp_gfs_v15p2_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_repro
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_repro
 Checking test 018 fv3_ccpp_regional_v15p2 results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -642,7 +642,7 @@ Test 018 fv3_ccpp_regional_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_repro
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_decomp_repro
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_decomp_repro
 Checking test 019 fv3_ccpp_regional_v15p2_decomp results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -659,7 +659,7 @@ Test 019 fv3_ccpp_regional_v15p2_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_control_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_control_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_control_debug_prod
 Checking test 020 fv3_ccpp_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -677,7 +677,7 @@ Test 020 fv3_ccpp_regional_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_regional_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_regional_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_regional_v15p2_debug_prod
 Checking test 021 fv3_ccpp_regional_v15p2_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -695,7 +695,7 @@ Test 021 fv3_ccpp_regional_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_rrfs_v1alpha_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_rrfs_v1alpha_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_rrfs_v1alpha_debug_prod
 Checking test 022 fv3_ccpp_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -763,7 +763,7 @@ Test 022 fv3_ccpp_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/ufs-public-release-v2-20210212/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_188344/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_298392/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 023 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -831,5 +831,5 @@ Test 023 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Feb 12 16:42:48 CST 2021
-Elapsed time: 00h:26m:47s. Have a nice day!
+Mon Feb 22 21:47:19 CST 2021
+Elapsed time: 00h:32m:58s. Have a nice day!


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for fv3atm for the changes described in https://github.com/NOAA-EMC/fv3atm/pull/250. These changes are in submodules GFDL_atmos_cubed_sphere and ccpp-physics only and should not affect the ufs-weather-model physics and regression test results.

## Testing

Regression tests for the ufs-weather-model passed on all tier-1 platforms for release/public-v2, logs updated in the PR. No changes to the baselines.

## Dependencies

https://github.com/NOAA-EMC/fv3atm/pull/250
https://github.com/ufs-community/ufs-weather-model/pull/432