### PR TITLE
Updates to auto-rt scripts to run on Cheyenne etc

### DIFF
--- a/tests/auto/rt_auto.py
+++ b/tests/auto/rt_auto.py
@@ -42,7 +42,7 @@ def parse_args_in():
     parser = argparse.ArgumentParser()
 
     # Setup Input Arguments
-    choices = ['hera.intel', 'orion.intel', 'gaea.intel', 'jet.intel', 'wcoss_dell_p3']
+    choices = ['cheyenne.gnu', 'hera.intel', 'orion.intel', 'gaea.intel', 'jet.intel', 'wcoss_dell_p3']
     parser.add_argument('-m', '--machine', help='Machine and Compiler combination', required=True, choices=choices, type=str)
     parser.add_argument('-w', '--workdir', help='Working directory', required=True, type=str)
 

--- a/tests/auto/rt_auto.sh
+++ b/tests/auto/rt_auto.sh
@@ -31,10 +31,14 @@ elif [[ $MACHINE_ID = gaea.* ]]; then
   export PATH=/lustre/f2/pdata/esrl/gsd/contrib/miniconda3/4.8.3/envs/ufs-weather-model/bin:$PATH
   export PYTHONPATH=/lustre/f2/pdata/esrl/gsd/contrib/miniconda3/4.8.3/lib/python3.8/site-packages
 elif [[ $MACHINE_ID = cheyenne.* ]]; then
-  #export PATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/bin:$PATH
-  #export PYTHONPATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/lib/python2.7/site-packages
-  echo "cheyenne not currently supported. automated RT not starting"
-  exit 1
+  WORKDIR=/glade/work/heinzell/fv3/ufs-weather-model/auto-rt
+  export ACCNR="P48503002"
+  # DH* 20210226 temporary workaround to be able to use gnu
+  export RT_COMPILER="gnu"
+  export MACHINE_ID="cheyenne.gnu"
+  # *DH 20210226
+  export PATH=/glade/p/ral/jntp/tools/miniconda3/4.8.3/envs/ufs-weather-model/bin:/glade/p/ral/jntp/tools/miniconda3/4.8.3/bin:$PATH
+  export PYTHONPATH=/glade/p/ral/jntp/tools/miniconda3/4.8.3/envs/ufs-weather-model/lib/python3.8/site-packages:/glade/p/ral/jntp/tools/miniconda3/4.8.3/lib/python3.8/site-packages
 else
   echo "No Python Path for this machine. automated RT not starting"
   exit 1


### PR DESCRIPTION
# WORK IN PROGRESS

## Description

Updates to auto-rt scripts to run on Cheyenne, temporary workaround to use GNU instead of Intel on that system. This will be generalized in a future PR.

### Issue(s) addressed

n/a

## Testing

# WORK IN PROGRESS

How were these changes tested?
What compilers / HPCs was it tested with?
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

## Dependencies

This PR will be pulled into and merged as part of https://github.com/ufs-community/ufs-weather-model/pull/425.