### PR TITLE
Add 'netcdf' and 'grib2' to IC input source options in regional IC/LBC routines (re-opened)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/chan-hoo/fv3atm
+  branch = feature/ic_string
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/chan-hoo/fv3atm
-  branch = feature/ic_string
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,19 +1,19 @@
-Fri May  7 09:00:55 MDT 2021
+Mon May 10 16:30:56 MDT 2021
 Start Regression test
 
 Compile 001 elapsed time 408 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp
-Compile 002 elapsed time 409 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP
-Compile 003 elapsed time 456 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
-Compile 004 elapsed time 418 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 005 elapsed time 383 seconds. APP=ATM 32BIT=Y DEBUG=Y
-Compile 006 elapsed time 182 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_RRTMGP DEBUG=Y
-Compile 007 elapsed time 454 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y
-Compile 008 elapsed time 187 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 009 elapsed time 514 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
-Compile 010 elapsed time 412 seconds. APP=DATM_NEMS
+Compile 002 elapsed time 413 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP
+Compile 003 elapsed time 460 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
+Compile 004 elapsed time 414 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 005 elapsed time 382 seconds. APP=ATM 32BIT=Y DEBUG=Y
+Compile 006 elapsed time 177 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_RRTMGP DEBUG=Y
+Compile 007 elapsed time 458 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y
+Compile 008 elapsed time 186 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 009 elapsed time 523 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
+Compile 010 elapsed time 413 seconds. APP=DATM_NEMS
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfdlmp
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfdlmp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfdlmp
 Checking test 001 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -58,13 +58,13 @@ Checking test 001 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 74.276243
+0:The total amount of wall time                        = 74.610694
 
 Test 001 fv3_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16
 Checking test 002 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -141,13 +141,13 @@ Checking test 002 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 235.030437
+0:The total amount of wall time                        = 234.732267
 
 Test 002 fv3_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_restart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_restart
 Checking test 003 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -194,13 +194,13 @@ Checking test 003 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.673441
+0:The total amount of wall time                        = 136.879678
 
 Test 003 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_stochy
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_stochy
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_stochy
 Checking test 004 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -265,13 +265,13 @@ Checking test 004 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 89.829014
+0:The total amount of wall time                        = 89.941963
 
 Test 004 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_flake
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_flake
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_flake
 Checking test 005 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -336,13 +336,13 @@ Checking test 005 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 151.657060
+0:The total amount of wall time                        = 151.082844
 
 Test 005 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_RRTMGP
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_RRTMGP
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_RRTMGP
 Checking test 006 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -419,13 +419,13 @@ Checking test 006 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 311.411397
+0:The total amount of wall time                        = 312.938343
 
 Test 006 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gsd
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gsd
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gsd
 Checking test 007 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -514,13 +514,13 @@ Checking test 007 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.837935
+0:The total amount of wall time                        = 353.292830
 
 Test 007 fv3_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_thompson
 Checking test 008 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -585,13 +585,13 @@ Checking test 008 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 159.887114
+0:The total amount of wall time                        = 159.636994
 
 Test 008 fv3_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_no_aero
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_thompson_no_aero
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_thompson_no_aero
 Checking test 009 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -656,13 +656,13 @@ Checking test 009 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 160.262343
+0:The total amount of wall time                        = 158.303912
 
 Test 009 fv3_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_rrfs_v1alpha
 Checking test 010 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -727,13 +727,13 @@ Checking test 010 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.689977
+0:The total amount of wall time                        = 171.766418
 
 Test 010 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1beta
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_rrfs_v1beta
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_rrfs_v1beta
 Checking test 011 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -798,13 +798,13 @@ Checking test 011 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 171.789731
+0:The total amount of wall time                        = 170.064585
 
 Test 011 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_HAFS_v0_hwrf_thompson
 Checking test 012 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -869,13 +869,13 @@ Checking test 012 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 260.117467
+0:The total amount of wall time                        = 259.555490
 
 Test 012 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -890,13 +890,13 @@ Checking test 013 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 467.323747
+0:The total amount of wall time                        = 461.185191
 
 Test 013 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfsv16_ugwpv1
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfsv16_ugwpv1
 Checking test 014 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -955,13 +955,13 @@ Checking test 014 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 307.438438
+0:The total amount of wall time                        = 305.624112
 
 Test 014 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfsv16_ugwpv1_warmstart
 Checking test 015 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1020,13 +1020,13 @@ Checking test 015 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 304.532889
+0:The total amount of wall time                        = 304.432600
 
 Test 015 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_ras
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_ras
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_ras
 Checking test 016 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 016 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.419817
+0:The total amount of wall time                        = 169.780794
 
 Test 016 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_control_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_control_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_control_debug
 Checking test 017 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1124,13 +1124,13 @@ Checking test 017 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-0:The total amount of wall time                        = 80.497827
+0:The total amount of wall time                        = 76.080808
 
 Test 017 fv3_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_regional_control_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_regional_control_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_regional_control_debug
 Checking test 018 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1138,13 +1138,13 @@ Checking test 018 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 189.412026
+0:The total amount of wall time                        = 187.828535
 
 Test 018 fv3_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_rrfs_v1alpha_debug
 Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1209,13 +1209,13 @@ Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 110.674143
+0:The total amount of wall time                        = 112.266017
 
 Test 019 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_rrfs_v1beta_debug
 Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1280,13 +1280,13 @@ Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 112.072618
+0:The total amount of wall time                        = 112.299907
 
 Test 020 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gsd_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gsd_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gsd_debug
 Checking test 021 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1351,13 +1351,13 @@ Checking test 021 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 117.723324
+0:The total amount of wall time                        = 118.291330
 
 Test 021 fv3_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_thompson_debug
 Checking test 022 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1422,13 +1422,13 @@ Checking test 022 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 190.172586
+0:The total amount of wall time                        = 186.764920
 
 Test 022 fv3_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_no_aero_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_thompson_no_aero_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_thompson_no_aero_debug
 Checking test 023 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1493,13 +1493,13 @@ Checking test 023 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 180.437378
+0:The total amount of wall time                        = 181.674244
 
 Test 023 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v15p2_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v15p2_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v15p2_debug
 Checking test 024 fv3_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1564,13 +1564,13 @@ Checking test 024 fv3_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 140.893176
+0:The total amount of wall time                        = 138.394552
 
 Test 024 fv3_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_debug
 Checking test 025 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1635,13 +1635,13 @@ Checking test 025 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 145.947847
+0:The total amount of wall time                        = 145.811349
 
 Test 025 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_RRTMGP_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_RRTMGP_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_RRTMGP_debug
 Checking test 026 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1706,13 +1706,13 @@ Checking test 026 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 122.907573
+0:The total amount of wall time                        = 123.426500
 
 Test 026 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_multigases
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_multigases
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_multigases
 Checking test 027 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1783,13 +1783,13 @@ Checking test 027 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 177.981192
+0:The total amount of wall time                        = 176.290448
 
 Test 027 fv3_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1854,13 +1854,13 @@ Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 113.533643
+0:The total amount of wall time                        = 114.403713
 
 Test 028 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1875,13 +1875,13 @@ Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 218.543113
+0:The total amount of wall time                        = 219.763396
 
 Test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfsv16_ugwpv1_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfsv16_ugwpv1_debug
 Checking test 030 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1940,13 +1940,13 @@ Checking test 030 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.909120
+0:The total amount of wall time                        = 308.438060
 
 Test 030 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_ras_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_18318/fv3_gfs_v16_ras_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_36887/fv3_gfs_v16_ras_debug
 Checking test 031 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2011,11 +2011,11 @@ Checking test 031 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 177.110922
+0:The total amount of wall time                        = 174.078507
 
 Test 031 fv3_gfs_v16_ras_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 09:20:51 MDT 2021
-Elapsed time: 00h:19m:56s. Have a nice day!
+Mon May 10 16:51:00 MDT 2021
+Elapsed time: 00h:20m:05s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,31 +1,31 @@
-Fri May  7 09:15:54 MDT 2021
+Mon May 10 15:00:53 MDT 2021
 Start Regression test
 
-Compile 001 elapsed time 1052 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 1126 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 350 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 733 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 689 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 006 elapsed time 755 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 776 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 760 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 882 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 995 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 769 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 740 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 807 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 853 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 245 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 264 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 251 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 641 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 236 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 645 seconds. APP=DATM
-Compile 021 elapsed time 244 seconds. APP=DATM DEBUG=Y
+Compile 001 elapsed time 1061 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 1106 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 003 elapsed time 363 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 729 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 687 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 006 elapsed time 756 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 007 elapsed time 765 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 765 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 893 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 992 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 777 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 772 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 813 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 862 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 243 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 268 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 247 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 637 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 232 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 641 seconds. APP=DATM
+Compile 021 elapsed time 242 seconds. APP=DATM DEBUG=Y
 Compile 022 elapsed time 767 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_control
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.163622
+0:The total amount of wall time                        = 98.797000
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 55.331307
+0:The total amount of wall time                        = 55.170276
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_controlfrac
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 97.958845
+0:The total amount of wall time                        = 95.297256
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restartfrac
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 55.193441
+0:The total amount of wall time                        = 53.809326
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_2threads
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 258.702299
+0:The total amount of wall time                        = 256.232969
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_decomp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_decomp
 Checking test 006 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.766639
+0:The total amount of wall time                        = 96.659723
 
 Test 006 cpld_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_satmedmf
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_satmedmf
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_satmedmf
 Checking test 007 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.259978
+0:The total amount of wall time                        = 97.721982
 
 Test 007 cpld_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_ca
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_ca
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_ca
 Checking test 008 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.217201
+0:The total amount of wall time                        = 97.066167
 
 Test 008 cpld_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_control_c192
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_control_c192
 Checking test 009 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 409.059314
+0:The total amount of wall time                        = 408.828423
 
 Test 009 cpld_control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart_c192
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart_c192
 Checking test 010 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 293.950765
+0:The total amount of wall time                        = 283.117515
 
 Test 010 cpld_restart_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_controlfrac_c192
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_controlfrac_c192
 Checking test 011 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 396.393346
+0:The total amount of wall time                        = 409.160389
 
 Test 011 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restartfrac_c192
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restartfrac_c192
 Checking test 012 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -691,13 +691,13 @@ Checking test 012 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 291.368905
+0:The total amount of wall time                        = 294.155383
 
 Test 012 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_control_c384
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_control_c384
 Checking test 013 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -750,13 +750,13 @@ Checking test 013 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 1601.860755
+0:The total amount of wall time                        = 1592.346675
 
 Test 013 cpld_control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart_c384
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart_c384
 Checking test 014 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -809,13 +809,13 @@ Checking test 014 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 838.878529
+0:The total amount of wall time                        = 838.565361
 
 Test 014 cpld_restart_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_controlfrac_c384
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_controlfrac_c384
 Checking test 015 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -868,13 +868,13 @@ Checking test 015 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 1581.454781
+0:The total amount of wall time                        = 1493.967187
 
 Test 015 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restartfrac_c384
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restartfrac_c384
 Checking test 016 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -927,13 +927,13 @@ Checking test 016 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 838.349312
+0:The total amount of wall time                        = 836.235412
 
 Test 016 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmark
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmark
 Checking test 017 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -986,13 +986,13 @@ Checking test 017 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 898.675724
+0:The total amount of wall time                        = 866.353898
 
 Test 017 cpld_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart_bmark
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart_bmark
 Checking test 018 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1045,13 +1045,13 @@ Checking test 018 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 474.224519
+0:The total amount of wall time                        = 490.167079
 
 Test 018 cpld_restart_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmarkfrac
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmarkfrac
 Checking test 019 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1104,13 +1104,13 @@ Checking test 019 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 894.257576
+0:The total amount of wall time                        = 858.648140
 
 Test 019 cpld_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart_bmarkfrac
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart_bmarkfrac
 Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1163,13 +1163,13 @@ Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 483.219218
+0:The total amount of wall time                        = 479.562393
 
 Test 020 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmarkfrac_v16
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmarkfrac_v16
 Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1212,13 +1212,13 @@ Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 850.350336
+0:The total amount of wall time                        = 846.820484
 
 Test 021 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16_nsst
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmarkfrac_v16_nsst
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmarkfrac_v16_nsst
 Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 852.186121
+0:The total amount of wall time                        = 855.654518
 
 Test 022 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_restart_bmarkfrac_v16
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_restart_bmarkfrac_v16
 Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 478.352823
+0:The total amount of wall time                        = 476.852711
 
 Test 023 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark_wave
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmark_wave
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmark_wave
 Checking test 024 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 024 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 1184.033941
+0:The total amount of wall time                        = 1185.654051
 
 Test 024 cpld_bmark_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmarkfrac_wave
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmarkfrac_wave
 Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 1257.653311
+0:The total amount of wall time                        = 1266.075037
 
 Test 025 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_bmarkfrac_wave_v16
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_bmarkfrac_wave_v16
 Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1485,13 +1485,13 @@ Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 916.292247
+0:The total amount of wall time                        = 922.300253
 
 Test 026 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_wave
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_control_wave
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_control_wave
 Checking test 027 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 125.376139
+0:The total amount of wall time                        = 127.466596
 
 Test 027 cpld_control_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 302.295966
+0:The total amount of wall time                        = 302.589964
 
 Test 028 cpld_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debugfrac
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/cpld_debugfrac
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/cpld_debugfrac
 Checking test 029 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 029 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 299.484309
+0:The total amount of wall time                        = 303.404422
 
 Test 029 cpld_debugfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_control
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_control
 Checking test 030 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1727,13 +1727,13 @@ Checking test 030 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 47.708987
+0:The total amount of wall time                        = 47.056323
 
 Test 030 fv3_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_decomp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_decomp
 Checking test 031 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1798,13 +1798,13 @@ Checking test 031 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 48.165244
+0:The total amount of wall time                        = 48.308562
 
 Test 031 fv3_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_2threads
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_2threads
 Checking test 032 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1869,13 +1869,13 @@ Checking test 032 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 106.702398
+0:The total amount of wall time                        = 106.190542
 
 Test 032 fv3_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_restart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_restart
 Checking test 033 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 033 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 22.940729
+0:The total amount of wall time                        = 23.090641
 
 Test 033 fv3_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_read_inc
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_read_inc
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_read_inc
 Checking test 034 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 034 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.489383
+0:The total amount of wall time                        = 46.725041
 
 Test 034 fv3_read_inc PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_esmf
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGauss_netcdf_esmf
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGauss_netcdf_esmf
 Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2044,13 +2044,13 @@ Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 120.481904
+0:The total amount of wall time                        = 120.380277
 
 Test 035 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGauss_netcdf
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGauss_netcdf
 Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2095,13 +2095,13 @@ Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.809452
+0:The total amount of wall time                        = 46.784045
 
 Test 036 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGauss_netcdf_parallel
 Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2110,8 +2110,8 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
@@ -2146,13 +2146,13 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 47.597281
+0:The total amount of wall time                        = 47.249795
 
 Test 037 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGlatlon_netcdf
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGlatlon_netcdf
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGlatlon_netcdf
 Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2197,13 +2197,13 @@ Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.873315
+0:The total amount of wall time                        = 45.787689
 
 Test 038 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGauss_nemsio
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGauss_nemsio
 Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2248,13 +2248,13 @@ Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.925285
+0:The total amount of wall time                        = 46.953987
 
 Test 039 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c192
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_wrtGauss_nemsio_c192
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_wrtGauss_nemsio_c192
 Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2299,13 +2299,13 @@ Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 123.265496
+0:The total amount of wall time                        = 124.883518
 
 Test 040 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stochy
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_stochy
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_stochy
 Checking test 041 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2370,13 +2370,13 @@ Checking test 041 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 56.723762
+0:The total amount of wall time                        = 57.915407
 
 Test 041 fv3_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_ca
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_ca
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_ca
 Checking test 042 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2441,13 +2441,13 @@ Checking test 042 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 29.762032
+0:The total amount of wall time                        = 29.404836
 
 Test 042 fv3_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lndp
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_lndp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_lndp
 Checking test 043 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2512,13 +2512,13 @@ Checking test 043 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 51.829416
+0:The total amount of wall time                        = 51.006240
 
 Test 043 fv3_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_iau
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_iau
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_iau
 Checking test 044 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2583,13 +2583,13 @@ Checking test 044 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.387892
+0:The total amount of wall time                        = 46.693812
 
 Test 044 fv3_iau PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lheatstrg
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_lheatstrg
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_lheatstrg
 Checking test 045 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 045 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 46.460663
+0:The total amount of wall time                        = 47.168329
 
 Test 045 fv3_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_multigases_repro
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_multigases_repro
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_multigases_repro
 Checking test 046 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2711,13 +2711,13 @@ Checking test 046 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 118.422274
+0:The total amount of wall time                        = 115.144387
 
 Test 046 fv3_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_32bit
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_control_32bit
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_control_32bit
 Checking test 047 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2782,13 +2782,13 @@ Checking test 047 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 40.057060
+0:The total amount of wall time                        = 40.122628
 
 Test 047 fv3_control_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_stretched
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_stretched
 Checking test 048 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2841,13 +2841,13 @@ Checking test 048 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 332.866517
+0:The total amount of wall time                        = 333.492388
 
 Test 048 fv3_stretched PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_stretched_nest
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_stretched_nest
 Checking test 049 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2911,13 +2911,13 @@ Checking test 049 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
-0:The total amount of wall time                        = 352.554184
+0:The total amount of wall time                        = 353.655281
 
 Test 049 fv3_stretched_nest PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_control
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_control
 Checking test 050 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2925,25 +2925,25 @@ Checking test 050 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 274.338683
+0:The total amount of wall time                        = 271.273124
 
 Test 050 fv3_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_restart
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_restart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_restart
 Checking test 051 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-0:The total amount of wall time                        = 147.960756
+0:The total amount of wall time                        = 148.036196
 
 Test 051 fv3_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_quilt
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_quilt
 Checking test 052 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2954,13 +2954,13 @@ Checking test 052 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 270.794311
+0:The total amount of wall time                        = 265.559730
 
 Test 052 fv3_regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_hafs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_quilt_hafs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_quilt_hafs
 Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2969,27 +2969,27 @@ Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 271.346442
+0:The total amount of wall time                        = 269.065404
 
 Test 053 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_quilt_netcdf_parallel
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_quilt_netcdf_parallel
 Checking test 054 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 274.252964
+0:The total amount of wall time                        = 265.100369
 
 Test 054 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_quilt_RRTMGP
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_quilt_RRTMGP
 Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -3000,13 +3000,13 @@ Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 382.033124
+0:The total amount of wall time                        = 403.707114
 
 Test 055 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmp
 Checking test 056 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3051,13 +3051,13 @@ Checking test 056 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 53.211729
+0:The total amount of wall time                        = 52.351768
 
 Test 056 fv3_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_gwd
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmprad_gwd
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmprad_gwd
 Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 53.294153
+0:The total amount of wall time                        = 53.910084
 
 Test 057 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_noahmp
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmprad_noahmp
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmprad_noahmp
 Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3153,13 +3153,13 @@ Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 53.286536
+0:The total amount of wall time                        = 52.780615
 
 Test 058 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_csawmg
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_csawmg
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_csawmg
 Checking test 059 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,13 +3204,13 @@ Checking test 059 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 139.840636
+0:The total amount of wall time                        = 136.390044
 
 Test 059 fv3_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmf
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_satmedmf
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_satmedmf
 Checking test 060 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3255,13 +3255,13 @@ Checking test 060 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 59.875988
+0:The total amount of wall time                        = 60.282712
 
 Test 060 fv3_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmfq
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_satmedmfq
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_satmedmfq
 Checking test 061 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,13 +3306,13 @@ Checking test 061 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 59.330529
+0:The total amount of wall time                        = 59.148794
 
 Test 061 fv3_satmedmfq PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp_32bit
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmp_32bit
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmp_32bit
 Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3357,13 +3357,13 @@ Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 41.579696
+0:The total amount of wall time                        = 42.371563
 
 Test 062 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_32bit_post
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmprad_32bit_post
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmprad_32bit_post
 Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3412,13 +3412,13 @@ Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 76.788132
+0:The total amount of wall time                        = 77.187706
 
 Test 063 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_cpt
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_cpt
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_cpt
 Checking test 064 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,13 +3469,13 @@ Checking test 064 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 333.740950
+0:The total amount of wall time                        = 335.573301
 
 Test 064 fv3_cpt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gsd
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gsd
 Checking test 065 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3564,13 +3564,13 @@ Checking test 065 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 194.940234
+0:The total amount of wall time                        = 194.244739
 
 Test 065 fv3_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_rrfs_v1alpha
 Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3635,13 +3635,13 @@ Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 97.577935
+0:The total amount of wall time                        = 97.676710
 
 Test 066 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rap
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_rap
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_rap
 Checking test 067 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3706,13 +3706,13 @@ Checking test 067 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 98.472180
+0:The total amount of wall time                        = 98.989241
 
 Test 067 fv3_rap PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_hrrr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_hrrr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_hrrr
 Checking test 068 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3777,13 +3777,13 @@ Checking test 068 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 96.662476
+0:The total amount of wall time                        = 96.737269
 
 Test 068 fv3_hrrr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_thompson
 Checking test 069 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3848,13 +3848,13 @@ Checking test 069 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 89.743320
+0:The total amount of wall time                        = 89.524895
 
 Test 069 fv3_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_thompson_no_aero
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_thompson_no_aero
 Checking test 070 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3919,13 +3919,13 @@ Checking test 070 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 89.441199
+0:The total amount of wall time                        = 89.306032
 
 Test 070 fv3_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_rrfs_v1beta
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_rrfs_v1beta
 Checking test 071 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3990,13 +3990,13 @@ Checking test 071 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 97.530014
+0:The total amount of wall time                        = 96.987127
 
 Test 071 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16
 Checking test 072 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4073,13 +4073,13 @@ Checking test 072 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.662546
+0:The total amount of wall time                        = 170.494190
 
 Test 072 fv3_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_restart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_restart
 Checking test 073 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4126,13 +4126,13 @@ Checking test 073 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 104.936163
+0:The total amount of wall time                        = 105.669984
 
 Test 073 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_stochy
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_stochy
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_stochy
 Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4197,13 +4197,13 @@ Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 63.613062
+0:The total amount of wall time                        = 63.151284
 
 Test 074 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_RRTMGP
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_RRTMGP
 Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4280,13 +4280,13 @@ Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 245.183654
+0:The total amount of wall time                        = 225.765292
 
 Test 075 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gocart_clm
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gocart_clm
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gocart_clm
 Checking test 076 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4331,13 +4331,13 @@ Checking test 076 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 55.989484
+0:The total amount of wall time                        = 56.407755
 
 Test 076 fv3_gocart_clm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_flake
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_flake
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_flake
 Checking test 077 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4402,13 +4402,13 @@ Checking test 077 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 116.249200
+0:The total amount of wall time                        = 116.978401
 
 Test 077 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_HAFS_v0_hwrf_thompson
 Checking test 078 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4473,13 +4473,13 @@ Checking test 078 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 196.545426
+0:The total amount of wall time                        = 197.872807
 
 Test 078 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4494,13 +4494,13 @@ Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 340.382183
+0:The total amount of wall time                        = 342.360844
 
 Test 079 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfsv16_ugwpv1
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfsv16_ugwpv1
 Checking test 080 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4559,13 +4559,13 @@ Checking test 080 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 216.506103
+0:The total amount of wall time                        = 217.292231
 
 Test 080 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfsv16_ugwpv1_warmstart
 Checking test 081 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4624,13 +4624,13 @@ Checking test 081 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 216.504073
+0:The total amount of wall time                        = 218.091846
 
 Test 081 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_ras
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_ras
 Checking test 082 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4695,13 +4695,13 @@ Checking test 082 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 115.217856
+0:The total amount of wall time                        = 116.184809
 
 Test 082 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_debug
 Checking test 083 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4766,13 +4766,13 @@ Checking test 083 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 262.671680
+0:The total amount of wall time                        = 267.290881
 
 Test 083 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_RRTMGP_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_RRTMGP_debug
 Checking test 084 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4837,13 +4837,13 @@ Checking test 084 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 250.136339
+0:The total amount of wall time                        = 249.836864
 
 Test 084 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_regional_control_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_regional_control_debug
 Checking test 085 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4851,13 +4851,13 @@ Checking test 085 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 368.119017
+0:The total amount of wall time                        = 370.113506
 
 Test 085 fv3_regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_control_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_control_debug
 Checking test 086 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4884,13 +4884,13 @@ Checking test 086 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.888039
+0:The total amount of wall time                        = 144.629797
 
 Test 086 fv3_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_stretched_nest_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_stretched_nest_debug
 Checking test 087 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -4907,13 +4907,13 @@ Checking test 087 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
-0:The total amount of wall time                        = 434.017345
+0:The total amount of wall time                        = 434.371671
 
 Test 087 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gsd_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gsd_debug
 Checking test 088 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4978,13 +4978,13 @@ Checking test 088 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 212.766660
+0:The total amount of wall time                        = 215.087055
 
 Test 088 fv3_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_diag3d_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gsd_diag3d_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gsd_diag3d_debug
 Checking test 089 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5049,13 +5049,13 @@ Checking test 089 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 253.482103
+0:The total amount of wall time                        = 252.170844
 
 Test 089 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_thompson_debug
 Checking test 090 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5120,13 +5120,13 @@ Checking test 090 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 358.146348
+0:The total amount of wall time                        = 358.570801
 
 Test 090 fv3_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_thompson_no_aero_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_thompson_no_aero_debug
 Checking test 091 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5191,13 +5191,13 @@ Checking test 091 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 344.459414
+0:The total amount of wall time                        = 347.154205
 
 Test 091 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_rrfs_v1beta_debug
 Checking test 092 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5262,13 +5262,13 @@ Checking test 092 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 206.511804
+0:The total amount of wall time                        = 206.062637
 
 Test 092 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_rrfs_v1alpha_debug
 Checking test 093 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5333,13 +5333,13 @@ Checking test 093 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 205.963881
+0:The total amount of wall time                        = 206.462736
 
 Test 093 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 094 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5404,13 +5404,13 @@ Checking test 094 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 218.563105
+0:The total amount of wall time                        = 218.727838
 
 Test 094 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 095 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5425,13 +5425,13 @@ Checking test 095 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 399.544247
+0:The total amount of wall time                        = 398.553395
 
 Test 095 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfsv16_ugwpv1_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfsv16_ugwpv1_debug
 Checking test 096 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5490,13 +5490,13 @@ Checking test 096 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 601.174408
+0:The total amount of wall time                        = 604.863966
 
 Test 096 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras_debug
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfs_v16_ras_debug
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfs_v16_ras_debug
 Checking test 097 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5561,73 +5561,73 @@ Checking test 097 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 340.778809
+0:The total amount of wall time                        = 344.690806
 
 Test 097 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_control_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_control_cfsr
 Checking test 098 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 102.163422
+0:The total amount of wall time                        = 101.683416
 
 Test 098 datm_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_restart_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_restart_cfsr
 Checking test 099 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 64.848952
+0:The total amount of wall time                        = 61.919676
 
 Test 099 datm_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_control_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_control_gefs
 Checking test 100 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.118017
+0:The total amount of wall time                        = 92.576045
 
 Test 100 datm_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_bulk_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_bulk_cfsr
 Checking test 101 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.750117
+0:The total amount of wall time                        = 98.406006
 
 Test 101 datm_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_bulk_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_bulk_gefs
 Checking test 102 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.490992
+0:The total amount of wall time                        = 95.700541
 
 Test 102 datm_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_mx025_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_mx025_cfsr
 Checking test 103 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5636,13 +5636,13 @@ Checking test 103 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 395.079955
+0:The total amount of wall time                        = 398.416671
 
 Test 103 datm_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_mx025_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_mx025_gefs
 Checking test 104 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5651,85 +5651,85 @@ Checking test 104 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 390.420133
+0:The total amount of wall time                        = 392.766093
 
 Test 104 datm_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_debug_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_debug_cfsr
 Checking test 105 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 283.023432
+0:The total amount of wall time                        = 283.243912
 
 Test 105 datm_debug_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_control_cfsr
 Checking test 106 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.594350
+0:The total amount of wall time                        = 166.011359
 
 Test 106 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_restart_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_restart_cfsr
 Checking test 107 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 102.214616
+0:The total amount of wall time                        = 101.823229
 
 Test 107 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_control_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_control_gefs
 Checking test 108 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.183275
+0:The total amount of wall time                        = 154.863399
 
 Test 108 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_bulk_cfsr
 Checking test 109 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.867572
+0:The total amount of wall time                        = 166.813694
 
 Test 109 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_bulk_gefs
 Checking test 110 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.271378
+0:The total amount of wall time                        = 159.776527
 
 Test 110 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_mx025_cfsr
 Checking test 111 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5738,13 +5738,13 @@ Checking test 111 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 389.291365
+0:The total amount of wall time                        = 377.265637
 
 Test 111 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_mx025_gefs
 Checking test 112 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5753,25 +5753,25 @@ Checking test 112 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 369.447187
+0:The total amount of wall time                        = 391.294834
 
 Test 112 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/datm_cdeps_debug_cfsr
 Checking test 113 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 463.319926
+0:The total amount of wall time                        = 464.123692
 
 Test 113 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmprad
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmprad
 Checking test 114 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5817,13 +5817,13 @@ Checking test 114 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-0:The total amount of wall time                        = 349.051622
+0:The total amount of wall time                        = 349.058538
 
 Test 114 fv3_gfdlmprad PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_atmwav
-working dir  = /glade/scratch/briancurtis/FV3_RT/rt_13981/fv3_gfdlmprad_atmwav
+working dir  = /glade/scratch/briancurtis/FV3_RT/rt_58084/fv3_gfdlmprad_atmwav
 Checking test 115 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5869,11 +5869,11 @@ Checking test 115 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-0:The total amount of wall time                        = 393.782911
+0:The total amount of wall time                        = 393.095699
 
 Test 115 fv3_gfdlmprad_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 10:55:17 MDT 2021
-Elapsed time: 01h:39m:23s. Have a nice day!
+Mon May 10 16:09:57 MDT 2021
+Elapsed time: 01h:09m:05s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,31 +1,31 @@
-Fri May  7 11:03:33 EDT 2021
+Mon May 10 17:02:21 EDT 2021
 Start Regression test
 
-Compile 001 elapsed time 780 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 001 elapsed time 786 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
 Compile 002 elapsed time 805 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 327 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 713 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 718 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 006 elapsed time 655 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 707 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 664 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 677 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 728 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 665 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 681 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 681 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 687 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 266 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 242 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 257 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 588 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 282 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 585 seconds. APP=DATM
-Compile 021 elapsed time 282 seconds. APP=DATM DEBUG=Y
-Compile 022 elapsed time 731 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
+Compile 003 elapsed time 320 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 743 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 712 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 006 elapsed time 714 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 007 elapsed time 716 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 719 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 736 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 775 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 719 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 706 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 706 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 682 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 267 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 273 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 237 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 574 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 233 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 559 seconds. APP=DATM
+Compile 021 elapsed time 268 seconds. APP=DATM DEBUG=Y
+Compile 022 elapsed time 692 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 127.270301
+The total amount of wall time                        = 95.676137
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 58.920721
+The total amount of wall time                        = 85.912866
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_controlfrac
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 110.157145
+The total amount of wall time                        = 124.345781
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restartfrac
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 55.259856
+The total amount of wall time                        = 87.708545
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 133.413748
+The total amount of wall time                        = 121.336454
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_decomp
 Checking test 006 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 118.421547
+The total amount of wall time                        = 94.283063
 
 Test 006 cpld_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_satmedmf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_satmedmf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_satmedmf
 Checking test 007 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 97.322134
+The total amount of wall time                        = 96.934692
 
 Test 007 cpld_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_ca
 Checking test 008 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 97.285479
+The total amount of wall time                        = 123.907934
 
 Test 008 cpld_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_control_c192
 Checking test 009 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 414.407506
+The total amount of wall time                        = 432.746894
 
 Test 009 cpld_control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart_c192
 Checking test 010 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 284.546595
+The total amount of wall time                        = 288.455728
 
 Test 010 cpld_restart_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_controlfrac_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_controlfrac_c192
 Checking test 011 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 421.921681
+The total amount of wall time                        = 442.785488
 
 Test 011 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restartfrac_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restartfrac_c192
 Checking test 012 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -691,13 +691,13 @@ Checking test 012 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 281.655689
+The total amount of wall time                        = 290.792705
 
 Test 012 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_control_c384
 Checking test 013 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -750,13 +750,13 @@ Checking test 013 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 1556.751755
+The total amount of wall time                        = 1565.404482
 
 Test 013 cpld_control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart_c384
 Checking test 014 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -809,13 +809,13 @@ Checking test 014 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 786.263544
+The total amount of wall time                        = 782.192273
 
 Test 014 cpld_restart_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_controlfrac_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_controlfrac_c384
 Checking test 015 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -868,13 +868,13 @@ Checking test 015 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 1536.875582
+The total amount of wall time                        = 1549.964926
 
 Test 015 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restartfrac_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restartfrac_c384
 Checking test 016 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -927,13 +927,13 @@ Checking test 016 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 769.698698
+The total amount of wall time                        = 794.337374
 
 Test 016 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmark
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmark
 Checking test 017 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -986,13 +986,13 @@ Checking test 017 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 880.038800
+The total amount of wall time                        = 886.438825
 
 Test 017 cpld_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart_bmark
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart_bmark
 Checking test 018 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1045,13 +1045,13 @@ Checking test 018 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 452.087460
+The total amount of wall time                        = 473.059976
 
 Test 018 cpld_restart_bmark PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmarkfrac
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmarkfrac
 Checking test 019 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1104,13 +1104,13 @@ Checking test 019 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 862.523782
+The total amount of wall time                        = 862.512595
 
 Test 019 cpld_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart_bmarkfrac
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart_bmarkfrac
 Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1163,13 +1163,13 @@ Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 446.996248
+The total amount of wall time                        = 446.461613
 
 Test 020 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmarkfrac_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmarkfrac_v16
 Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1212,13 +1212,13 @@ Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 831.009607
+The total amount of wall time                        = 827.956468
 
 Test 021 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16_nsst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmarkfrac_v16_nsst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmarkfrac_v16_nsst
 Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 826.712612
+The total amount of wall time                        = 807.376327
 
 Test 022 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_restart_bmarkfrac_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_restart_bmarkfrac_v16
 Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 448.972399
+The total amount of wall time                        = 418.812424
 
 Test 023 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmark_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmark_wave
 Checking test 024 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 024 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 1257.660243
+The total amount of wall time                        = 1233.212786
 
 Test 024 cpld_bmark_wave PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmarkfrac_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmarkfrac_wave
 Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 1283.297551
+The total amount of wall time                        = 1243.412640
 
 Test 025 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_bmarkfrac_wave_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_bmarkfrac_wave_v16
 Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1485,13 +1485,13 @@ Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 958.244141
+The total amount of wall time                        = 910.120290
 
 Test 026 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_control_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_control_wave
 Checking test 027 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 143.897313
+The total amount of wall time                        = 146.868433
 
 Test 027 cpld_control_wave PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 330.030119
+The total amount of wall time                        = 271.141542
 
 Test 028 cpld_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debugfrac
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/cpld_debugfrac
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/cpld_debugfrac
 Checking test 029 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 029 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 273.688391
+The total amount of wall time                        = 297.586575
 
 Test 029 cpld_debugfrac PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_control
 Checking test 030 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1727,13 +1727,13 @@ Checking test 030 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 44.502115
+The total amount of wall time                        = 44.972306
 
 Test 030 fv3_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_decomp
 Checking test 031 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1798,13 +1798,13 @@ Checking test 031 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 46.301497
+The total amount of wall time                        = 45.628197
 
 Test 031 fv3_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_2threads
 Checking test 032 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1869,13 +1869,13 @@ Checking test 032 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 56.881567
+The total amount of wall time                        = 57.696265
 
 Test 032 fv3_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_restart
 Checking test 033 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 033 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 21.372865
+The total amount of wall time                        = 53.137274
 
 Test 033 fv3_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_read_inc
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_read_inc
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_read_inc
 Checking test 034 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 034 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 68.462536
+The total amount of wall time                        = 45.956593
 
 Test 034 fv3_read_inc PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_esmf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGauss_netcdf_esmf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGauss_netcdf_esmf
 Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2044,13 +2044,13 @@ Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 104.799074
+The total amount of wall time                        = 104.617448
 
 Test 035 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGauss_netcdf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGauss_netcdf
 Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2095,13 +2095,13 @@ Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 41.819985
+The total amount of wall time                        = 43.385328
 
 Test 036 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGauss_netcdf_parallel
 Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2146,13 +2146,13 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 168.248620
+The total amount of wall time                        = 182.937827
 
 Test 037 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGlatlon_netcdf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGlatlon_netcdf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGlatlon_netcdf
 Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2197,13 +2197,13 @@ Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 42.438789
+The total amount of wall time                        = 42.887451
 
 Test 038 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGauss_nemsio
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGauss_nemsio
 Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2248,13 +2248,13 @@ Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 41.578948
+The total amount of wall time                        = 42.591395
 
 Test 039 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_wrtGauss_nemsio_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_wrtGauss_nemsio_c192
 Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2299,13 +2299,13 @@ Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 112.146664
+The total amount of wall time                        = 113.148388
 
 Test 040 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_stochy
 Checking test 041 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2370,13 +2370,13 @@ Checking test 041 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 49.191173
+The total amount of wall time                        = 47.743790
 
 Test 041 fv3_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_ca
 Checking test 042 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2441,13 +2441,13 @@ Checking test 042 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 31.747122
+The total amount of wall time                        = 30.121876
 
 Test 042 fv3_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_lndp
 Checking test 043 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2512,13 +2512,13 @@ Checking test 043 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 51.112261
+The total amount of wall time                        = 54.359788
 
 Test 043 fv3_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_iau
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_iau
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_iau
 Checking test 044 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2583,13 +2583,13 @@ Checking test 044 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 69.414388
+The total amount of wall time                        = 74.641601
 
 Test 044 fv3_iau PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lheatstrg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_lheatstrg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_lheatstrg
 Checking test 045 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 045 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 41.256239
+The total amount of wall time                        = 41.714079
 
 Test 045 fv3_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_multigases_repro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_multigases_repro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_multigases_repro
 Checking test 046 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2711,13 +2711,13 @@ Checking test 046 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 95.246696
+The total amount of wall time                        = 121.332806
 
 Test 046 fv3_multigases PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_32bit
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_control_32bit
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_control_32bit
 Checking test 047 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2782,13 +2782,13 @@ Checking test 047 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 42.488612
+The total amount of wall time                        = 64.446378
 
 Test 047 fv3_control_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_stretched
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_stretched
 Checking test 048 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2841,13 +2841,13 @@ Checking test 048 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 302.577569
+The total amount of wall time                        = 302.627120
 
 Test 048 fv3_stretched PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_stretched_nest
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_stretched_nest
 Checking test 049 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2911,13 +2911,13 @@ Checking test 049 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
-The total amount of wall time                        = 332.952323
+The total amount of wall time                        = 369.516503
 
 Test 049 fv3_stretched_nest PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_control
 Checking test 050 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2925,25 +2925,25 @@ Checking test 050 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 251.878902
+The total amount of wall time                        = 249.651798
 
 Test 050 fv3_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_restart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_restart
 Checking test 051 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 135.066296
+The total amount of wall time                        = 165.339430
 
 Test 051 fv3_regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_quilt
 Checking test 052 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2954,13 +2954,13 @@ Checking test 052 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 250.650105
+The total amount of wall time                        = 249.360023
 
 Test 052 fv3_regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_quilt_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_quilt_hafs
 Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2969,27 +2969,27 @@ Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 245.455712
+The total amount of wall time                        = 245.711764
 
 Test 053 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_quilt_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_quilt_netcdf_parallel
 Checking test 054 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 268.983631
+The total amount of wall time                        = 374.394931
 
 Test 054 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_quilt_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_quilt_RRTMGP
 Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -3000,13 +3000,13 @@ Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 341.790968
+The total amount of wall time                        = 338.511066
 
 Test 055 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmp
 Checking test 056 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3051,13 +3051,13 @@ Checking test 056 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 79.449909
+The total amount of wall time                        = 77.221732
 
 Test 056 fv3_gfdlmp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_gwd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmprad_gwd
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmprad_gwd
 Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 80.287749
+The total amount of wall time                        = 47.358448
 
 Test 057 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmprad_noahmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmprad_noahmp
 Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3153,13 +3153,13 @@ Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 76.160952
+The total amount of wall time                        = 47.926179
 
 Test 058 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_csawmg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_csawmg
 Checking test 059 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,13 +3204,13 @@ Checking test 059 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 126.335534
+The total amount of wall time                        = 123.727253
 
 Test 059 fv3_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_satmedmf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_satmedmf
 Checking test 060 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3255,13 +3255,13 @@ Checking test 060 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 67.959691
+The total amount of wall time                        = 53.201095
 
 Test 060 fv3_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmfq
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_satmedmfq
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_satmedmfq
 Checking test 061 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,13 +3306,13 @@ Checking test 061 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 63.229309
+The total amount of wall time                        = 54.812451
 
 Test 061 fv3_satmedmfq PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp_32bit
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmp_32bit
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmp_32bit
 Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3357,13 +3357,13 @@ Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 39.688888
+The total amount of wall time                        = 39.653237
 
 Test 062 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_32bit_post
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmprad_32bit_post
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmprad_32bit_post
 Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3412,13 +3412,13 @@ Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 84.089085
+The total amount of wall time                        = 93.020092
 
 Test 063 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_cpt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_cpt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_cpt
 Checking test 064 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,13 +3469,13 @@ Checking test 064 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 290.004093
+The total amount of wall time                        = 321.095768
 
 Test 064 fv3_cpt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gsd
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gsd
 Checking test 065 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3564,13 +3564,13 @@ Checking test 065 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.266956
+The total amount of wall time                        = 213.025812
 
 Test 065 fv3_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_rrfs_v1alpha
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_rrfs_v1alpha
 Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3635,13 +3635,13 @@ Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 91.674085
+The total amount of wall time                        = 136.991981
 
 Test 066 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rap
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_rap
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_rap
 Checking test 067 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3706,13 +3706,13 @@ Checking test 067 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 92.245562
+The total amount of wall time                        = 127.959938
 
 Test 067 fv3_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_hrrr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_hrrr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_hrrr
 Checking test 068 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3777,13 +3777,13 @@ Checking test 068 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 118.516913
+The total amount of wall time                        = 121.199635
 
 Test 068 fv3_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_thompson
 Checking test 069 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3848,13 +3848,13 @@ Checking test 069 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.682402
+The total amount of wall time                        = 112.871224
 
 Test 069 fv3_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_thompson_no_aero
 Checking test 070 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3919,13 +3919,13 @@ Checking test 070 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 133.323179
+The total amount of wall time                        = 110.411218
 
 Test 070 fv3_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_rrfs_v1beta
 Checking test 071 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3990,13 +3990,13 @@ Checking test 071 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 113.010343
+The total amount of wall time                        = 120.854936
 
 Test 071 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16
 Checking test 072 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4073,13 +4073,13 @@ Checking test 072 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 154.348163
+The total amount of wall time                        = 223.178400
 
 Test 072 fv3_gfs_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_restart
 Checking test 073 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4126,13 +4126,13 @@ Checking test 073 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 90.887538
+The total amount of wall time                        = 91.855357
 
 Test 073 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_stochy
 Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4197,13 +4197,13 @@ Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 100.632311
+The total amount of wall time                        = 84.452699
 
 Test 074 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_RRTMGP
 Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4280,13 +4280,13 @@ Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 203.441076
+The total amount of wall time                        = 271.524229
 
 Test 075 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfsv16_csawmg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfsv16_csawmg
 Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4331,13 +4331,13 @@ Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.286679
+The total amount of wall time                        = 137.535908
 
 Test 076 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfsv16_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfsv16_csawmgt
 Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4382,13 +4382,13 @@ Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 130.983064
+The total amount of wall time                        = 161.428419
 
 Test 077 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gocart_clm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gocart_clm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gocart_clm
 Checking test 078 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4433,13 +4433,13 @@ Checking test 078 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 69.668652
+The total amount of wall time                        = 79.061608
 
 Test 078 fv3_gocart_clm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_flake
 Checking test 079 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4504,13 +4504,13 @@ Checking test 079 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 109.703147
+The total amount of wall time                        = 113.468730
 
 Test 079 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_HAFS_v0_hwrf_thompson
 Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4575,13 +4575,13 @@ Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 162.598746
+The total amount of wall time                        = 166.219936
 
 Test 080 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4596,13 +4596,13 @@ Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 319.465172
+The total amount of wall time                        = 326.506490
 
 Test 081 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfsv16_ugwpv1
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfsv16_ugwpv1
 Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4661,13 +4661,13 @@ Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 187.644564
+The total amount of wall time                        = 187.361689
 
 Test 082 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfsv16_ugwpv1_warmstart
 Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4726,13 +4726,13 @@ Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.579948
+The total amount of wall time                        = 218.770917
 
 Test 083 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_ras
 Checking test 084 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4797,13 +4797,13 @@ Checking test 084 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 104.462670
+The total amount of wall time                        = 134.424044
 
 Test 084 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_debug
 Checking test 085 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4868,13 +4868,13 @@ Checking test 085 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 248.091879
+The total amount of wall time                        = 282.852162
 
 Test 085 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_RRTMGP_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_RRTMGP_debug
 Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4939,13 +4939,13 @@ Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 263.539497
+The total amount of wall time                        = 268.201634
 
 Test 086 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_regional_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_regional_control_debug
 Checking test 087 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4953,13 +4953,13 @@ Checking test 087 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 368.541784
+The total amount of wall time                        = 368.827927
 
 Test 087 fv3_regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_control_debug
 Checking test 088 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4986,13 +4986,13 @@ Checking test 088 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-The total amount of wall time                        = 139.690237
+The total amount of wall time                        = 141.808404
 
 Test 088 fv3_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_stretched_nest_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_stretched_nest_debug
 Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -5009,13 +5009,13 @@ Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
-The total amount of wall time                        = 469.788425
+The total amount of wall time                        = 440.635530
 
 Test 089 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gsd_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gsd_debug
 Checking test 090 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5080,13 +5080,13 @@ Checking test 090 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 203.800060
+The total amount of wall time                        = 201.192066
 
 Test 090 fv3_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_diag3d_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gsd_diag3d_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gsd_diag3d_debug
 Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5151,13 +5151,13 @@ Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 241.807558
+The total amount of wall time                        = 241.153905
 
 Test 091 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_thompson_debug
 Checking test 092 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5222,13 +5222,13 @@ Checking test 092 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 351.076042
+The total amount of wall time                        = 348.879293
 
 Test 092 fv3_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_thompson_no_aero_debug
 Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5293,13 +5293,13 @@ Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 337.680004
+The total amount of wall time                        = 338.343555
 
 Test 093 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_rrfs_v1beta_debug
 Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5364,13 +5364,13 @@ Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.828638
+The total amount of wall time                        = 196.525621
 
 Test 094 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_rrfs_v1alpha_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_rrfs_v1alpha_debug
 Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5435,13 +5435,13 @@ Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.746105
+The total amount of wall time                        = 226.710375
 
 Test 095 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5506,13 +5506,13 @@ Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 209.523535
+The total amount of wall time                        = 211.600172
 
 Test 096 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5527,13 +5527,13 @@ Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 379.832044
+The total amount of wall time                        = 379.530499
 
 Test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfsv16_ugwpv1_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfsv16_ugwpv1_debug
 Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5592,13 +5592,13 @@ Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 612.079018
+The total amount of wall time                        = 615.141338
 
 Test 098 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfs_v16_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfs_v16_ras_debug
 Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5663,73 +5663,73 @@ Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 354.135436
+The total amount of wall time                        = 357.597845
 
 Test 099 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_control_cfsr
 Checking test 100 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 104.060538
+The total amount of wall time                        = 123.650183
 
 Test 100 datm_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_restart_cfsr
 Checking test 101 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 56.739656
+The total amount of wall time                        = 58.281426
 
 Test 101 datm_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_control_gefs
 Checking test 102 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 94.336841
+The total amount of wall time                        = 95.232217
 
 Test 102 datm_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_bulk_cfsr
 Checking test 103 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 96.578962
+The total amount of wall time                        = 98.078346
 
 Test 103 datm_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_bulk_gefs
 Checking test 104 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 89.963346
+The total amount of wall time                        = 90.644056
 
 Test 104 datm_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_mx025_gefs
 Checking test 105 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5738,85 +5738,85 @@ Checking test 105 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 414.401403
+The total amount of wall time                        = 384.387158
 
 Test 105 datm_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_debug_cfsr
 Checking test 106 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 255.887621
+The total amount of wall time                        = 227.917061
 
 Test 106 datm_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_control_cfsr
 Checking test 107 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 149.421129
+The total amount of wall time                        = 150.817995
 
 Test 107 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_restart_cfsr
 Checking test 108 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 86.398950
+The total amount of wall time                        = 86.541903
 
 Test 108 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_control_gefs
 Checking test 109 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 150.850203
+The total amount of wall time                        = 147.623857
 
 Test 109 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_bulk_cfsr
 Checking test 110 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 149.824088
+The total amount of wall time                        = 148.844703
 
 Test 110 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_bulk_gefs
 Checking test 111 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 147.995222
+The total amount of wall time                        = 146.271169
 
 Test 111 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_mx025_gefs
 Checking test 112 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5825,25 +5825,25 @@ Checking test 112 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 413.453132
+The total amount of wall time                        = 406.878345
 
 Test 112 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/datm_cdeps_debug_cfsr
 Checking test 113 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 371.687292
+The total amount of wall time                        = 369.105795
 
 Test 113 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmprad
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmprad
 Checking test 114 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5889,13 +5889,13 @@ Checking test 114 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-The total amount of wall time                        = 366.505840
+The total amount of wall time                        = 368.857167
 
 Test 114 fv3_gfdlmprad PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_8225/fv3_gfdlmprad_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_33046/fv3_gfdlmprad_atmwav
 Checking test 115 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5941,11 +5941,11 @@ Checking test 115 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-The total amount of wall time                        = 414.496598
+The total amount of wall time                        = 412.001041
 
 Test 115 fv3_gfdlmprad_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 12:29:43 EDT 2021
-Elapsed time: 01h:26m:11s. Have a nice day!
+Mon May 10 18:26:37 EDT 2021
+Elapsed time: 01h:24m:17s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,19 +1,19 @@
-Fri May  7 15:02:51 UTC 2021
+Mon May 10 21:02:38 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 267 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp
-Compile 002 elapsed time 268 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP
-Compile 003 elapsed time 369 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
-Compile 004 elapsed time 266 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 005 elapsed time 176 seconds. APP=ATM 32BIT=Y DEBUG=Y
-Compile 006 elapsed time 101 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_RRTMGP DEBUG=Y
-Compile 007 elapsed time 286 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y
-Compile 008 elapsed time 132 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 009 elapsed time 275 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
-Compile 010 elapsed time 235 seconds. APP=DATM_NEMS
+Compile 001 elapsed time 305 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp
+Compile 002 elapsed time 277 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP
+Compile 003 elapsed time 322 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
+Compile 004 elapsed time 269 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 005 elapsed time 164 seconds. APP=ATM 32BIT=Y DEBUG=Y
+Compile 006 elapsed time 99 seconds. APP=ATM SUITES=FV3_GFS_v15p2,FV3_GFS_v16,FV3_GFS_v16_RRTMGP DEBUG=Y
+Compile 007 elapsed time 304 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y
+Compile 008 elapsed time 101 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 009 elapsed time 311 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
+Compile 010 elapsed time 301 seconds. APP=DATM_NEMS
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfdlmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfdlmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfdlmp
 Checking test 001 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -58,13 +58,13 @@ Checking test 001 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.678037
+  0: The total amount of wall time                        = 220.016408
 
 Test 001 fv3_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16
 Checking test 002 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -141,13 +141,13 @@ Checking test 002 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 635.278911
+  0: The total amount of wall time                        = 636.993456
 
 Test 002 fv3_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_restart
 Checking test 003 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -194,13 +194,13 @@ Checking test 003 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 314.522558
+  0: The total amount of wall time                        = 329.806820
 
 Test 003 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_stochy
 Checking test 004 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -265,13 +265,13 @@ Checking test 004 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 353.182389
+  0: The total amount of wall time                        = 373.061361
 
 Test 004 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_flake
 Checking test 005 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -336,13 +336,13 @@ Checking test 005 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 598.374095
+  0: The total amount of wall time                        = 579.401201
 
 Test 005 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_RRTMGP
 Checking test 006 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -419,13 +419,13 @@ Checking test 006 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 689.938950
+  0: The total amount of wall time                        = 674.909313
 
 Test 006 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gsd
 Checking test 007 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -514,13 +514,13 @@ Checking test 007 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 829.703214
+  0: The total amount of wall time                        = 779.405935
 
 Test 007 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_thompson
 Checking test 008 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -585,13 +585,13 @@ Checking test 008 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 376.089853
+  0: The total amount of wall time                        = 389.169184
 
 Test 008 fv3_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_thompson_no_aero
 Checking test 009 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -656,13 +656,13 @@ Checking test 009 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 385.279220
+  0: The total amount of wall time                        = 380.837763
 
 Test 009 fv3_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_rrfs_v1alpha
 Checking test 010 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -727,13 +727,13 @@ Checking test 010 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 399.592066
+  0: The total amount of wall time                        = 377.647541
 
 Test 010 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_rrfs_v1beta
 Checking test 011 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -798,13 +798,13 @@ Checking test 011 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 387.646471
+  0: The total amount of wall time                        = 388.956738
 
 Test 011 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_HAFS_v0_hwrf_thompson
 Checking test 012 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -869,13 +869,13 @@ Checking test 012 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 828.668471
+  0: The total amount of wall time                        = 627.122331
 
 Test 012 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -890,13 +890,13 @@ Checking test 013 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 444.027724
+ 0: The total amount of wall time                        = 436.915466
 
 Test 013 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfsv16_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfsv16_ugwpv1
 Checking test 014 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -955,13 +955,13 @@ Checking test 014 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 914.423714
+  0: The total amount of wall time                        = 919.539422
 
 Test 014 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfsv16_ugwpv1_warmstart
 Checking test 015 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1020,13 +1020,13 @@ Checking test 015 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 888.829873
+  0: The total amount of wall time                        = 897.364735
 
 Test 015 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_ras
 Checking test 016 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 016 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 569.380770
+  0: The total amount of wall time                        = 577.357778
 
 Test 016 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_control_debug
 Checking test 017 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1124,13 +1124,13 @@ Checking test 017 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.593721
+  0: The total amount of wall time                        = 82.959852
 
 Test 017 fv3_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_regional_control_debug
 Checking test 018 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1138,13 +1138,13 @@ Checking test 018 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 169.210534
+ 0: The total amount of wall time                        = 173.305786
 
 Test 018 fv3_regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_rrfs_v1alpha_debug
 Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1209,13 +1209,13 @@ Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 112.382113
+  0: The total amount of wall time                        = 114.653312
 
 Test 019 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_rrfs_v1beta_debug
 Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1280,13 +1280,13 @@ Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.092979
+  0: The total amount of wall time                        = 112.694275
 
 Test 020 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gsd_debug
 Checking test 021 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1351,13 +1351,13 @@ Checking test 021 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.234980
+  0: The total amount of wall time                        = 119.719275
 
 Test 021 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_thompson_debug
 Checking test 022 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1422,13 +1422,13 @@ Checking test 022 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.243418
+  0: The total amount of wall time                        = 195.113510
 
 Test 022 fv3_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_thompson_no_aero_debug
 Checking test 023 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1493,13 +1493,13 @@ Checking test 023 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 188.993195
+  0: The total amount of wall time                        = 194.748276
 
 Test 023 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v15p2_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v15p2_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v15p2_debug
 Checking test 024 fv3_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1564,13 +1564,13 @@ Checking test 024 fv3_gfs_v15p2_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 268.937992
+  0: The total amount of wall time                        = 305.232665
 
 Test 024 fv3_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_debug
 Checking test 025 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1635,13 +1635,13 @@ Checking test 025 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 164.393295
+  0: The total amount of wall time                        = 166.603516
 
 Test 025 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_RRTMGP_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_RRTMGP_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_RRTMGP_debug
 Checking test 026 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1706,13 +1706,13 @@ Checking test 026 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 148.054851
+  0: The total amount of wall time                        = 146.868126
 
 Test 026 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_multigases
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_multigases
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_multigases
 Checking test 027 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1783,13 +1783,13 @@ Checking test 027 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 424.154910
+  0: The total amount of wall time                        = 431.016416
 
 Test 027 fv3_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1854,13 +1854,13 @@ Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.893766
+  0: The total amount of wall time                        = 126.681050
 
 Test 028 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1875,13 +1875,13 @@ Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 221.376001
+ 0: The total amount of wall time                        = 223.429680
 
 Test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfsv16_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfsv16_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfsv16_ugwpv1_debug
 Checking test 030 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1940,13 +1940,13 @@ Checking test 030 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 380.884779
+  0: The total amount of wall time                        = 382.841439
 
 Test 030 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/GNU/fv3_gfs_v16_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_9484/fv3_gfs_v16_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_242052/fv3_gfs_v16_ras_debug
 Checking test 031 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2011,11 +2011,11 @@ Checking test 031 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 216.125803
+  0: The total amount of wall time                        = 215.448824
 
 Test 031 fv3_gfs_v16_ras_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 18:02:00 UTC 2021
-Elapsed time: 02h:59m:10s. Have a nice day!
+Mon May 10 21:38:26 UTC 2021
+Elapsed time: 00h:35m:48s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,31 +1,31 @@
-Fri May  7 15:17:33 UTC 2021
+Mon May 10 19:47:44 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 792 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 722 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 192 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 526 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 505 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 001 elapsed time 567 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 580 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 003 elapsed time 183 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 545 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 570 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
 Compile 006 elapsed time 512 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 881 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 1074 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 538 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 569 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 553 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 525 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 521 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 534 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 162 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 149 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 142 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 387 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 138 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 394 seconds. APP=DATM
-Compile 021 elapsed time 137 seconds. APP=DATM DEBUG=Y
-Compile 022 elapsed time 553 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
+Compile 007 elapsed time 516 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 526 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 1149 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 603 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 801 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 561 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 528 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 742 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 204 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 389 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 324 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 372 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 239 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 434 seconds. APP=DATM
+Compile 021 elapsed time 150 seconds. APP=DATM DEBUG=Y
+Compile 022 elapsed time 617 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 91.056366
+  0: The total amount of wall time                        = 92.003379
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 62.295706
+  0: The total amount of wall time                        = 57.636926
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_controlfrac
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 89.382863
+  0: The total amount of wall time                        = 88.835832
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restartfrac
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 56.157983
+  0: The total amount of wall time                        = 55.068065
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 95.929706
+  0: The total amount of wall time                        = 94.817382
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_decomp
 Checking test 006 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 88.226367
+  0: The total amount of wall time                        = 87.307347
 
 Test 006 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_satmedmf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_satmedmf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_satmedmf
 Checking test 007 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 88.889130
+  0: The total amount of wall time                        = 90.346949
 
 Test 007 cpld_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_ca
 Checking test 008 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 91.311390
+  0: The total amount of wall time                        = 87.092020
 
 Test 008 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_control_c192
 Checking test 009 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 411.938618
+  0: The total amount of wall time                        = 376.492696
 
 Test 009 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart_c192
 Checking test 010 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 297.524186
+  0: The total amount of wall time                        = 282.961703
 
 Test 010 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_controlfrac_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_controlfrac_c192
 Checking test 011 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 397.051975
+  0: The total amount of wall time                        = 372.188574
 
 Test 011 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restartfrac_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restartfrac_c192
 Checking test 012 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -691,13 +691,13 @@ Checking test 012 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 273.211111
+  0: The total amount of wall time                        = 270.427938
 
 Test 012 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_control_c384
 Checking test 013 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -750,13 +750,13 @@ Checking test 013 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1380.521329
+  0: The total amount of wall time                        = 1325.772023
 
 Test 013 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart_c384
 Checking test 014 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -809,13 +809,13 @@ Checking test 014 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 727.984308
+  0: The total amount of wall time                        = 707.044788
 
 Test 014 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_controlfrac_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_controlfrac_c384
 Checking test 015 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -868,13 +868,13 @@ Checking test 015 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1382.176192
+  0: The total amount of wall time                        = 1339.044193
 
 Test 015 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restartfrac_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restartfrac_c384
 Checking test 016 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -927,13 +927,13 @@ Checking test 016 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 714.039601
+  0: The total amount of wall time                        = 701.417429
 
 Test 016 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmark
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmark
 Checking test 017 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -986,13 +986,13 @@ Checking test 017 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 886.475001
+  0: The total amount of wall time                        = 806.624277
 
 Test 017 cpld_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart_bmark
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart_bmark
 Checking test 018 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1045,13 +1045,13 @@ Checking test 018 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 479.216074
+  0: The total amount of wall time                        = 467.200130
 
 Test 018 cpld_restart_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmarkfrac
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmarkfrac
 Checking test 019 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1104,13 +1104,13 @@ Checking test 019 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 834.966063
+  0: The total amount of wall time                        = 799.695678
 
 Test 019 cpld_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart_bmarkfrac
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart_bmarkfrac
 Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1163,13 +1163,13 @@ Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 463.427608
+  0: The total amount of wall time                        = 457.366186
 
 Test 020 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmarkfrac_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmarkfrac_v16
 Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1212,13 +1212,13 @@ Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 789.021458
+  0: The total amount of wall time                        = 735.919954
 
 Test 021 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16_nsst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmarkfrac_v16_nsst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmarkfrac_v16_nsst
 Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 763.850464
+  0: The total amount of wall time                        = 728.046927
 
 Test 022 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_restart_bmarkfrac_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_restart_bmarkfrac_v16
 Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 458.279233
+  0: The total amount of wall time                        = 433.824194
 
 Test 023 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmark_wave
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmark_wave
 Checking test 024 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 024 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 936.500632
+  0: The total amount of wall time                        = 917.215048
 
 Test 024 cpld_bmark_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmarkfrac_wave
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmarkfrac_wave
 Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 931.753439
+  0: The total amount of wall time                        = 905.383504
 
 Test 025 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_bmarkfrac_wave_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_bmarkfrac_wave_v16
 Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1485,13 +1485,13 @@ Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 800.055777
+  0: The total amount of wall time                        = 745.110273
 
 Test 026 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_control_wave
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_control_wave
 Checking test 027 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 126.911243
+  0: The total amount of wall time                        = 110.564683
 
 Test 027 cpld_control_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 286.049292
+  0: The total amount of wall time                        = 281.113143
 
 Test 028 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debugfrac
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/cpld_debugfrac
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/cpld_debugfrac
 Checking test 029 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 029 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 291.827835
+  0: The total amount of wall time                        = 281.794351
 
 Test 029 cpld_debugfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_control
 Checking test 030 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1727,13 +1727,13 @@ Checking test 030 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 39.311100
+  0: The total amount of wall time                        = 40.548742
 
 Test 030 fv3_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_decomp
 Checking test 031 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1798,13 +1798,13 @@ Checking test 031 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 40.394442
+  0: The total amount of wall time                        = 41.406633
 
 Test 031 fv3_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_2threads
 Checking test 032 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1869,13 +1869,13 @@ Checking test 032 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 42.376974
+ 0: The total amount of wall time                        = 42.111513
 
 Test 032 fv3_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_restart
 Checking test 033 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 033 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 18.967624
+  0: The total amount of wall time                        = 19.507304
 
 Test 033 fv3_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_read_inc
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_read_inc
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_read_inc
 Checking test 034 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 034 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 37.100831
+  0: The total amount of wall time                        = 37.051447
 
 Test 034 fv3_read_inc PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_esmf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_netcdf_esmf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_netcdf_esmf
 Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2044,13 +2044,13 @@ Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 109.095803
+  0: The total amount of wall time                        = 105.517754
 
 Test 035 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_netcdf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_netcdf
 Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2095,13 +2095,13 @@ Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 37.189848
+  0: The total amount of wall time                        = 37.574432
 
 Test 036 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_netcdf_parallel
 Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2109,7 +2109,7 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
@@ -2146,13 +2146,13 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 49.021124
+  0: The total amount of wall time                        = 51.356124
 
 Test 037 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGlatlon_netcdf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGlatlon_netcdf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGlatlon_netcdf
 Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2197,13 +2197,13 @@ Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 37.911190
+  0: The total amount of wall time                        = 37.743191
 
 Test 038 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_nemsio
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_nemsio
 Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2248,13 +2248,13 @@ Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 36.667924
+  0: The total amount of wall time                        = 36.765344
 
 Test 039 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_nemsio_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_nemsio_c192
 Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2299,13 +2299,13 @@ Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 96.430985
+  0: The total amount of wall time                        = 96.280179
 
 Test 040 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_stochy
 Checking test 041 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2370,13 +2370,13 @@ Checking test 041 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 40.910831
+  0: The total amount of wall time                        = 41.941606
 
 Test 041 fv3_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_ca
 Checking test 042 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2441,13 +2441,13 @@ Checking test 042 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 26.220318
+  0: The total amount of wall time                        = 26.122234
 
 Test 042 fv3_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_lndp
 Checking test 043 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2512,13 +2512,13 @@ Checking test 043 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 43.805348
+  0: The total amount of wall time                        = 43.341158
 
 Test 043 fv3_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_iau
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_iau
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_iau
 Checking test 044 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2583,13 +2583,13 @@ Checking test 044 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 36.739033
+  0: The total amount of wall time                        = 36.609437
 
 Test 044 fv3_iau PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lheatstrg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_lheatstrg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_lheatstrg
 Checking test 045 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 045 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 37.221048
+  0: The total amount of wall time                        = 36.788601
 
 Test 045 fv3_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_multigases_repro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_multigases_repro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_multigases_repro
 Checking test 046 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2711,13 +2711,13 @@ Checking test 046 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 96.513282
+  0: The total amount of wall time                        = 95.755467
 
 Test 046 fv3_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_32bit
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_control_32bit
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_control_32bit
 Checking test 047 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2782,13 +2782,13 @@ Checking test 047 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 36.229566
+  0: The total amount of wall time                        = 36.153816
 
 Test 047 fv3_control_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_stretched
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_stretched
 Checking test 048 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2841,13 +2841,13 @@ Checking test 048 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 221.562262
+ 0: The total amount of wall time                        = 224.412930
 
 Test 048 fv3_stretched PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_stretched_nest
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_stretched_nest
 Checking test 049 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2911,13 +2911,13 @@ Checking test 049 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
- 0: The total amount of wall time                        = 246.778974
+ 0: The total amount of wall time                        = 239.583958
 
 Test 049 fv3_stretched_nest PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_control
 Checking test 050 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2925,25 +2925,25 @@ Checking test 050 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 237.979286
+ 0: The total amount of wall time                        = 235.000073
 
 Test 050 fv3_regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_restart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_restart
 Checking test 051 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 142.454842
+ 0: The total amount of wall time                        = 126.606225
 
 Test 051 fv3_regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_quilt
 Checking test 052 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2954,13 +2954,13 @@ Checking test 052 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 213.842716
+ 0: The total amount of wall time                        = 212.517580
 
 Test 052 fv3_regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_quilt_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_quilt_hafs
 Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2969,27 +2969,27 @@ Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 216.570192
+ 0: The total amount of wall time                        = 216.336697
 
 Test 053 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_quilt_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_quilt_netcdf_parallel
 Checking test 054 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 219.560999
+ 0: The total amount of wall time                        = 214.099690
 
 Test 054 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_quilt_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_quilt_RRTMGP
 Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -3000,13 +3000,13 @@ Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 284.362425
+ 0: The total amount of wall time                        = 276.277157
 
 Test 055 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmp
 Checking test 056 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3051,13 +3051,13 @@ Checking test 056 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 42.700667
+  0: The total amount of wall time                        = 42.972743
 
 Test 056 fv3_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_gwd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmprad_gwd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmprad_gwd
 Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 42.800299
+  0: The total amount of wall time                        = 42.243141
 
 Test 057 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmprad_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmprad_noahmp
 Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3153,13 +3153,13 @@ Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 42.560158
+  0: The total amount of wall time                        = 42.508664
 
 Test 058 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_csawmg
 Checking test 059 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,13 +3204,13 @@ Checking test 059 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 109.331176
+  0: The total amount of wall time                        = 112.138560
 
 Test 059 fv3_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_satmedmf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_satmedmf
 Checking test 060 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3255,13 +3255,13 @@ Checking test 060 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 45.550669
+  0: The total amount of wall time                        = 56.667851
 
 Test 060 fv3_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmfq
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_satmedmfq
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_satmedmfq
 Checking test 061 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,13 +3306,13 @@ Checking test 061 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 45.250463
+  0: The total amount of wall time                        = 52.461354
 
 Test 061 fv3_satmedmfq PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp_32bit
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmp_32bit
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmp_32bit
 Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3357,13 +3357,13 @@ Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 36.832877
+  0: The total amount of wall time                        = 40.182757
 
 Test 062 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_32bit_post
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmprad_32bit_post
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmprad_32bit_post
 Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3412,13 +3412,13 @@ Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 72.149545
+  0: The total amount of wall time                        = 74.551258
 
 Test 063 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_cpt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_cpt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_cpt
 Checking test 064 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,13 +3469,13 @@ Checking test 064 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.432371
+  0: The total amount of wall time                        = 258.835565
 
 Test 064 fv3_cpt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gsd
 Checking test 065 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3564,13 +3564,13 @@ Checking test 065 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.769126
+  0: The total amount of wall time                        = 168.154431
 
 Test 065 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_rrfs_v1alpha
 Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3635,13 +3635,13 @@ Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 85.530246
+  0: The total amount of wall time                        = 87.460651
 
 Test 066 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rap
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_rap
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_rap
 Checking test 067 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3706,13 +3706,13 @@ Checking test 067 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.220208
+  0: The total amount of wall time                        = 83.894888
 
 Test 067 fv3_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_hrrr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_hrrr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_hrrr
 Checking test 068 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3777,13 +3777,13 @@ Checking test 068 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.019414
+  0: The total amount of wall time                        = 83.974901
 
 Test 068 fv3_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_thompson
 Checking test 069 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3848,13 +3848,13 @@ Checking test 069 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 77.963627
+  0: The total amount of wall time                        = 77.274903
 
 Test 069 fv3_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_thompson_no_aero
 Checking test 070 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3919,13 +3919,13 @@ Checking test 070 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 77.848529
+  0: The total amount of wall time                        = 78.270455
 
 Test 070 fv3_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_rrfs_v1beta
 Checking test 071 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3990,13 +3990,13 @@ Checking test 071 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.293084
+  0: The total amount of wall time                        = 87.205051
 
 Test 071 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16
 Checking test 072 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4073,13 +4073,13 @@ Checking test 072 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.013036
+  0: The total amount of wall time                        = 129.138944
 
 Test 072 fv3_gfs_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_restart
 Checking test 073 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4126,13 +4126,13 @@ Checking test 073 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 80.066880
+  0: The total amount of wall time                        = 78.946622
 
 Test 073 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_stochy
 Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4197,13 +4197,13 @@ Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 47.074259
+  0: The total amount of wall time                        = 46.952571
 
 Test 074 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_RRTMGP
 Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4280,13 +4280,13 @@ Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.060146
+  0: The total amount of wall time                        = 170.586852
 
 Test 075 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfsv16_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfsv16_csawmg
 Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4331,13 +4331,13 @@ Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 114.803316
+  0: The total amount of wall time                        = 122.450650
 
 Test 076 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfsv16_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfsv16_csawmgt
 Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4382,13 +4382,13 @@ Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.244960
+  0: The total amount of wall time                        = 121.050824
 
 Test 077 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gocart_clm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gocart_clm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gocart_clm
 Checking test 078 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4433,13 +4433,13 @@ Checking test 078 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 47.681556
+  0: The total amount of wall time                        = 58.822398
 
 Test 078 fv3_gocart_clm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_flake
 Checking test 079 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4504,13 +4504,13 @@ Checking test 079 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 98.544036
+  0: The total amount of wall time                        = 112.584209
 
 Test 079 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_HAFS_v0_hwrf_thompson
 Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4575,13 +4575,13 @@ Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.905435
+  0: The total amount of wall time                        = 141.248664
 
 Test 080 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4596,13 +4596,13 @@ Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 279.983676
+ 0: The total amount of wall time                        = 284.887750
 
 Test 081 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfsv16_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfsv16_ugwpv1
 Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4661,13 +4661,13 @@ Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.855016
+  0: The total amount of wall time                        = 164.874325
 
 Test 082 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfsv16_ugwpv1_warmstart
 Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4726,13 +4726,13 @@ Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.023863
+  0: The total amount of wall time                        = 164.219251
 
 Test 083 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_ras
 Checking test 084 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4797,13 +4797,13 @@ Checking test 084 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.655215
+  0: The total amount of wall time                        = 88.479291
 
 Test 084 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_debug
 Checking test 085 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4868,13 +4868,13 @@ Checking test 085 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.602623
+  0: The total amount of wall time                        = 232.212509
 
 Test 085 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_RRTMGP_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_RRTMGP_debug
 Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4939,13 +4939,13 @@ Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.596973
+  0: The total amount of wall time                        = 226.251711
 
 Test 086 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_regional_control_debug
 Checking test 087 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4953,13 +4953,13 @@ Checking test 087 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 340.309139
+ 0: The total amount of wall time                        = 354.852077
 
 Test 087 fv3_regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_control_debug
 Checking test 088 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4986,13 +4986,13 @@ Checking test 088 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.993848
+  0: The total amount of wall time                        = 126.392828
 
 Test 088 fv3_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_stretched_nest_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_stretched_nest_debug
 Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -5009,13 +5009,13 @@ Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 375.819803
+ 0: The total amount of wall time                        = 355.492449
 
 Test 089 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gsd_debug
 Checking test 090 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5080,13 +5080,13 @@ Checking test 090 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.601514
+  0: The total amount of wall time                        = 195.506088
 
 Test 090 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_diag3d_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gsd_diag3d_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gsd_diag3d_debug
 Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5151,13 +5151,13 @@ Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.308486
+  0: The total amount of wall time                        = 235.675432
 
 Test 091 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_thompson_debug
 Checking test 092 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5222,13 +5222,13 @@ Checking test 092 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.189073
+  0: The total amount of wall time                        = 337.913097
 
 Test 092 fv3_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_thompson_no_aero_debug
 Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5293,13 +5293,13 @@ Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.667579
+  0: The total amount of wall time                        = 316.649984
 
 Test 093 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_rrfs_v1beta_debug
 Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5364,13 +5364,13 @@ Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 185.579345
+  0: The total amount of wall time                        = 190.118670
 
 Test 094 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_rrfs_v1alpha_debug
 Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5435,13 +5435,13 @@ Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.077513
+  0: The total amount of wall time                        = 189.800239
 
 Test 095 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5506,13 +5506,13 @@ Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 198.327004
+  0: The total amount of wall time                        = 200.718918
 
 Test 096 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5527,13 +5527,13 @@ Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 380.576898
+ 0: The total amount of wall time                        = 404.850315
 
 Test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfsv16_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfsv16_ugwpv1_debug
 Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5592,13 +5592,13 @@ Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 550.294529
+  0: The total amount of wall time                        = 557.180648
 
 Test 098 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfs_v16_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfs_v16_ras_debug
 Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5663,73 +5663,73 @@ Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.769737
+  0: The total amount of wall time                        = 308.190787
 
 Test 099 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_control_cfsr
 Checking test 100 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 98.991523
+  0: The total amount of wall time                        = 95.807647
 
 Test 100 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_restart_cfsr
 Checking test 101 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 68.207852
+  0: The total amount of wall time                        = 65.072573
 
 Test 101 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_control_gefs
 Checking test 102 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 96.586385
+  0: The total amount of wall time                        = 89.859984
 
 Test 102 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_bulk_cfsr
 Checking test 103 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 111.452330
+  0: The total amount of wall time                        = 91.377486
 
 Test 103 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_bulk_gefs
 Checking test 104 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 91.642841
+  0: The total amount of wall time                        = 89.035668
 
 Test 104 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_mx025_cfsr
 Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5738,13 +5738,13 @@ Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 386.631851
+  0: The total amount of wall time                        = 395.256901
 
 Test 105 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_mx025_gefs
 Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5753,85 +5753,85 @@ Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 381.725549
+  0: The total amount of wall time                        = 351.080867
 
 Test 106 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_debug_cfsr
 Checking test 107 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 288.056656
+  0: The total amount of wall time                        = 268.567852
 
 Test 107 datm_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.802316
+ 0: The total amount of wall time                        = 150.030975
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.106385
+ 0: The total amount of wall time                        = 113.853933
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.056722
+ 0: The total amount of wall time                        = 142.719534
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_bulk_cfsr
 Checking test 111 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.807160
+ 0: The total amount of wall time                        = 142.252136
 
 Test 111 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_bulk_gefs
 Checking test 112 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.369192
+ 0: The total amount of wall time                        = 139.833406
 
 Test 112 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_mx025_cfsr
 Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5840,13 +5840,13 @@ Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 379.623545
+  0: The total amount of wall time                        = 356.142477
 
 Test 113 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_mx025_gefs
 Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5855,25 +5855,25 @@ Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 369.549682
+  0: The total amount of wall time                        = 353.221303
 
 Test 114 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/datm_cdeps_debug_cfsr
 Checking test 115 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 444.983301
+ 0: The total amount of wall time                        = 452.226345
 
 Test 115 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmprad
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmprad
 Checking test 116 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5919,13 +5919,13 @@ Checking test 116 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-  0: The total amount of wall time                        = 345.788074
+  0: The total amount of wall time                        = 335.758411
 
 Test 116 fv3_gfdlmprad PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_gfdlmprad_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_gfdlmprad_atmwav
 Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5971,13 +5971,13 @@ Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-  0: The total amount of wall time                        = 377.194087
+  0: The total amount of wall time                        = 371.351173
 
 Test 117 fv3_gfdlmprad_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c768
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_122889/fv3_wrtGauss_nemsio_c768
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_118770/fv3_wrtGauss_nemsio_c768
 Checking test 118 fv3_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -6023,11 +6023,11 @@ Checking test 118 fv3_wrtGauss_nemsio_c768 results ....
  Comparing out_grd.ant_9km .........OK
  Comparing out_grd.aoc_9km .........OK
 
-  0: The total amount of wall time                        = 549.506667
+  0: The total amount of wall time                        = 544.070970
 
 Test 118 fv3_wrtGauss_nemsio_c768 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 20:25:52 UTC 2021
-Elapsed time: 05h:08m:20s. Have a nice day!
+Mon May 10 20:42:50 UTC 2021
+Elapsed time: 00h:55m:06s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,31 +1,31 @@
-Fri May  7 20:52:25 GMT 2021
+Tue May 11 02:31:27 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 2407 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 2583 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 2667 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 2404 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 861 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 006 elapsed time 3050 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 3655 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 2639 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 3734 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 5769 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 2746 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 6385 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 3709 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 5589 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 4006 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 1642 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 2159 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 2914 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 1886 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 1988 seconds. APP=DATM
-Compile 021 elapsed time 769 seconds. APP=DATM DEBUG=Y
-Compile 022 elapsed time 2822 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
+Compile 001 elapsed time 2429 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 2436 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 003 elapsed time 851 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 2509 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 724 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 006 elapsed time 2900 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 007 elapsed time 3652 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 2365 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 2361 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 2480 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 3652 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 3044 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 3058 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 3777 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 1750 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 448 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 366 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 1366 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 199 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 1326 seconds. APP=DATM
+Compile 021 elapsed time 219 seconds. APP=DATM DEBUG=Y
+Compile 022 elapsed time 2316 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 163.761881
+The total amount of wall time                        = 167.014348
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 85.657924
+The total amount of wall time                        = 104.619533
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_controlfrac
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 164.288129
+The total amount of wall time                        = 161.966863
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restartfrac
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 86.202536
+The total amount of wall time                        = 86.242026
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 528.587862
+The total amount of wall time                        = 519.022411
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_satmedmf
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_satmedmf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_satmedmf
 Checking test 006 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 149.706044
+The total amount of wall time                        = 130.262196
 
 Test 006 cpld_satmedmf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_ca
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_ca
 Checking test 007 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 146.681868
+The total amount of wall time                        = 171.868862
 
 Test 007 cpld_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_control_c192
 Checking test 008 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 561.398729
+The total amount of wall time                        = 596.538564
 
 Test 008 cpld_control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restart_c192
 Checking test 009 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 398.748286
+The total amount of wall time                        = 425.808553
 
 Test 009 cpld_restart_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_controlfrac_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_controlfrac_c192
 Checking test 010 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 590.822024
+The total amount of wall time                        = 595.060858
 
 Test 010 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restartfrac_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restartfrac_c192
 Checking test 011 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 406.728011
+The total amount of wall time                        = 437.616795
 
 Test 011 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_261147/cpld_control_c384
 Checking test 012 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -694,13 +694,13 @@ Checking test 012 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 1064.791575
+The total amount of wall time                        = 1318.352807
 
 Test 012 cpld_control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_261147/cpld_restart_c384
 Checking test 013 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -753,13 +753,13 @@ Checking test 013 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 830.625015
+The total amount of wall time                        = 608.148573
 
 Test 013 cpld_restart_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_controlfrac_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_controlfrac_c384
 Checking test 014 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -812,13 +812,13 @@ Checking test 014 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 1083.096136
+The total amount of wall time                        = 1288.218062
 
 Test 014 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restartfrac_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restartfrac_c384
 Checking test 015 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -871,13 +871,13 @@ Checking test 015 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 831.548196
+The total amount of wall time                        = 676.557464
 
 Test 015 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmark
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmark
 Checking test 016 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -930,13 +930,13 @@ Checking test 016 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 1161.755274
+The total amount of wall time                        = 1365.364142
 
 Test 016 cpld_bmark PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart_bmark
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restart_bmark
 Checking test 017 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -989,13 +989,13 @@ Checking test 017 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 630.879541
+The total amount of wall time                        = 741.296991
 
 Test 017 cpld_restart_bmark PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmarkfrac
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmarkfrac
 Checking test 018 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1048,13 +1048,13 @@ Checking test 018 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 1160.650614
+The total amount of wall time                        = 1375.351916
 
 Test 018 cpld_bmarkfrac PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart_bmarkfrac
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restart_bmarkfrac
 Checking test 019 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1107,13 +1107,13 @@ Checking test 019 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 638.561239
+The total amount of wall time                        = 717.510433
 
 Test 019 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmarkfrac_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmarkfrac_v16
 Checking test 020 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1156,13 +1156,13 @@ Checking test 020 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 1090.194067
+The total amount of wall time                        = 1254.576788
 
 Test 020 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16_nsst
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmarkfrac_v16_nsst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmarkfrac_v16_nsst
 Checking test 021 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1205,13 +1205,13 @@ Checking test 021 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 1078.221377
+The total amount of wall time                        = 1198.395800
 
 Test 021 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_restart_bmarkfrac_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_restart_bmarkfrac_v16
 Checking test 022 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1254,13 +1254,13 @@ Checking test 022 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 611.487317
+The total amount of wall time                        = 649.814363
 
 Test 022 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark_wave
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmark_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmark_wave
 Checking test 023 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1316,13 +1316,13 @@ Checking test 023 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 2078.857245
+The total amount of wall time                        = 2060.071155
 
 Test 023 cpld_bmark_wave PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmarkfrac_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmarkfrac_wave
 Checking test 024 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1378,13 +1378,13 @@ Checking test 024 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-The total amount of wall time                        = 2092.687864
+The total amount of wall time                        = 2058.131382
 
 Test 024 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave_v16
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_bmarkfrac_wave_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_bmarkfrac_wave_v16
 Checking test 025 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1429,13 +1429,13 @@ Checking test 025 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 1485.335852
+The total amount of wall time                        = 1374.048835
 
 Test 025 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_wave
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_control_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_control_wave
 Checking test 026 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1488,13 +1488,13 @@ Checking test 026 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 1210.253972
+The total amount of wall time                        = 1201.329470
 
 Test 026 cpld_control_wave PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_debug
 Checking test 027 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 389.842737
+The total amount of wall time                        = 417.105019
 
 Test 027 cpld_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debugfrac
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/cpld_debugfrac
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/cpld_debugfrac
 Checking test 028 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 391.307779
+The total amount of wall time                        = 406.027324
 
 Test 028 cpld_debugfrac PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_control
 Checking test 029 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1671,13 +1671,13 @@ Checking test 029 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 96.340619
+The total amount of wall time                        = 74.664327
 
 Test 029 fv3_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_2threads
 Checking test 030 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1742,13 +1742,13 @@ Checking test 030 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 286.885153
+The total amount of wall time                        = 241.140647
 
 Test 030 fv3_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_restart
 Checking test 031 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1795,13 +1795,13 @@ Checking test 031 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 33.480571
+The total amount of wall time                        = 31.251885
 
 Test 031 fv3_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_read_inc
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_read_inc
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_read_inc
 Checking test 032 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1866,13 +1866,13 @@ Checking test 032 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 60.667313
+The total amount of wall time                        = 58.943138
 
 Test 032 fv3_read_inc PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_esmf
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGauss_netcdf_esmf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_261147/fv3_wrtGauss_netcdf_esmf
 Checking test 033 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1917,13 +1917,13 @@ Checking test 033 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 239.551614
+The total amount of wall time                        = 362.201430
 
 Test 033 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGauss_netcdf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_wrtGauss_netcdf
 Checking test 034 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1968,13 +1968,13 @@ Checking test 034 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 55.026874
+The total amount of wall time                        = 58.694401
 
 Test 034 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_wrtGauss_netcdf_parallel
 Checking test 035 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2019,13 +2019,13 @@ Checking test 035 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 79.456594
+The total amount of wall time                        = 93.371281
 
 Test 035 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGlatlon_netcdf
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGlatlon_netcdf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_wrtGlatlon_netcdf
 Checking test 036 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2070,13 +2070,13 @@ Checking test 036 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 61.934377
+The total amount of wall time                        = 63.543166
 
 Test 036 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGauss_nemsio
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_wrtGauss_nemsio
 Checking test 037 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2121,13 +2121,13 @@ Checking test 037 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 55.558991
+The total amount of wall time                        = 57.559783
 
 Test 037 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_wrtGauss_nemsio_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_wrtGauss_nemsio_c192
 Checking test 038 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2172,13 +2172,13 @@ Checking test 038 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.057926
+The total amount of wall time                        = 149.862000
 
 Test 038 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stochy
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_stochy
 Checking test 039 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2243,13 +2243,13 @@ Checking test 039 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 82.594528
+The total amount of wall time                        = 299.999427
 
 Test 039 fv3_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_ca
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_ca
 Checking test 040 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2314,13 +2314,13 @@ Checking test 040 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 79.240897
+The total amount of wall time                        = 50.473676
 
 Test 040 fv3_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lndp
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_lndp
 Checking test 041 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2385,13 +2385,13 @@ Checking test 041 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 81.844796
+The total amount of wall time                        = 82.620237
 
 Test 041 fv3_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_iau
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_iau
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_iau
 Checking test 042 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2456,13 +2456,13 @@ Checking test 042 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 57.000777
+The total amount of wall time                        = 56.020437
 
 Test 042 fv3_iau PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lheatstrg
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_lheatstrg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_lheatstrg
 Checking test 043 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2507,13 +2507,13 @@ Checking test 043 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 54.119831
+The total amount of wall time                        = 55.402678
 
 Test 043 fv3_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_multigases_repro
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_multigases_repro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_multigases_repro
 Checking test 044 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2584,13 +2584,13 @@ Checking test 044 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 148.627424
+The total amount of wall time                        = 137.944683
 
 Test 044 fv3_multigases PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_32bit
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_control_32bit
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_control_32bit
 Checking test 045 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2655,13 +2655,13 @@ Checking test 045 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 264.885927
+The total amount of wall time                        = 98.276241
 
 Test 045 fv3_control_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_stretched
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_stretched
 Checking test 046 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2714,13 +2714,13 @@ Checking test 046 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 410.971668
+The total amount of wall time                        = 420.690702
 
 Test 046 fv3_stretched PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_stretched_nest
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_stretched_nest
 Checking test 047 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2784,13 +2784,13 @@ Checking test 047 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
-The total amount of wall time                        = 593.371064
+The total amount of wall time                        = 460.975165
 
 Test 047 fv3_stretched_nest PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_control
 Checking test 048 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2798,25 +2798,25 @@ Checking test 048 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 314.472046
+The total amount of wall time                        = 348.930357
 
 Test 048 fv3_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_restart
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_restart
 Checking test 049 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 172.989095
+The total amount of wall time                        = 183.230980
 
 Test 049 fv3_regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_quilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_261147/fv3_regional_quilt
 Checking test 050 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2827,13 +2827,13 @@ Checking test 050 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 310.800934
+The total amount of wall time                        = 324.902148
 
 Test 050 fv3_regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_hafs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_quilt_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_quilt_hafs
 Checking test 051 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2842,27 +2842,27 @@ Checking test 051 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 311.825041
+The total amount of wall time                        = 340.095346
 
 Test 051 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_quilt_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_quilt_netcdf_parallel
 Checking test 052 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 307.639436
+The total amount of wall time                        = 354.039998
 
 Test 052 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_quilt_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_quilt_RRTMGP
 Checking test 053 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2873,13 +2873,13 @@ Checking test 053 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 394.722604
+The total amount of wall time                        = 446.143513
 
 Test 053 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmp
 Checking test 054 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2924,13 +2924,13 @@ Checking test 054 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 63.717885
+The total amount of wall time                        = 91.921881
 
 Test 054 fv3_gfdlmp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_gwd
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmprad_gwd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmprad_gwd
 Checking test 055 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2975,13 +2975,13 @@ Checking test 055 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 65.218214
+The total amount of wall time                        = 71.888451
 
 Test 055 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_noahmp
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmprad_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmprad_noahmp
 Checking test 056 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3026,13 +3026,13 @@ Checking test 056 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 65.136032
+The total amount of wall time                        = 80.507919
 
 Test 056 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_csawmg
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_csawmg
 Checking test 057 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3077,13 +3077,13 @@ Checking test 057 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 202.410577
+The total amount of wall time                        = 168.981596
 
 Test 057 fv3_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmf
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_satmedmf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_satmedmf
 Checking test 058 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3128,13 +3128,13 @@ Checking test 058 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 94.846889
+The total amount of wall time                        = 72.561424
 
 Test 058 fv3_satmedmf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmfq
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_satmedmfq
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_satmedmfq
 Checking test 059 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3179,13 +3179,13 @@ Checking test 059 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 76.087300
+The total amount of wall time                        = 77.359424
 
 Test 059 fv3_satmedmfq PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp_32bit
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmp_32bit
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmp_32bit
 Checking test 060 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3230,13 +3230,13 @@ Checking test 060 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 57.139376
+The total amount of wall time                        = 66.745956
 
 Test 060 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_32bit_post
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmprad_32bit_post
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmprad_32bit_post
 Checking test 061 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3285,13 +3285,13 @@ Checking test 061 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 111.112792
+The total amount of wall time                        = 127.370018
 
 Test 061 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_cpt
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_cpt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_cpt
 Checking test 062 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3342,13 +3342,13 @@ Checking test 062 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.152256
+The total amount of wall time                        = 374.671895
 
 Test 062 fv3_cpt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gsd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gsd
 Checking test 063 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3437,13 +3437,13 @@ Checking test 063 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 270.952395
+The total amount of wall time                        = 253.296047
 
 Test 063 fv3_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_rrfs_v1alpha
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_rrfs_v1alpha
 Checking test 064 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3508,13 +3508,13 @@ Checking test 064 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 133.176272
+The total amount of wall time                        = 139.011578
 
 Test 064 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_thompson
 Checking test 065 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3579,13 +3579,13 @@ Checking test 065 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 125.045303
+The total amount of wall time                        = 130.587987
 
 Test 065 fv3_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_thompson_no_aero
 Checking test 066 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3650,13 +3650,13 @@ Checking test 066 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 133.442103
+The total amount of wall time                        = 116.704585
 
 Test 066 fv3_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16
 Checking test 067 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3733,13 +3733,13 @@ Checking test 067 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 205.105433
+The total amount of wall time                        = 208.509257
 
 Test 067 fv3_gfs_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_restart
 Checking test 068 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -3786,13 +3786,13 @@ Checking test 068 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.243783
+The total amount of wall time                        = 120.297667
 
 Test 068 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_stochy
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_261147/fv3_gfs_v16_stochy
 Checking test 069 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3857,13 +3857,13 @@ Checking test 069 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 81.451442
+The total amount of wall time                        = 233.200821
 
 Test 069 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_RRTMGP
 Checking test 070 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3940,13 +3940,13 @@ Checking test 070 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 250.029143
+The total amount of wall time                        = 403.469827
 
 Test 070 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmg
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfsv16_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfsv16_csawmg
 Checking test 071 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3991,13 +3991,13 @@ Checking test 071 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 163.372842
+The total amount of wall time                        = 169.589685
 
 Test 071 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmgt
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfsv16_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfsv16_csawmgt
 Checking test 072 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4042,13 +4042,13 @@ Checking test 072 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.016719
+The total amount of wall time                        = 305.392784
 
 Test 072 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gocart_clm
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gocart_clm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gocart_clm
 Checking test 073 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4093,13 +4093,13 @@ Checking test 073 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 70.052085
+The total amount of wall time                        = 71.761607
 
 Test 073 fv3_gocart_clm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_flake
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_flake
 Checking test 074 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4164,13 +4164,13 @@ Checking test 074 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 138.172473
+The total amount of wall time                        = 181.898069
 
 Test 074 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_HAFS_v0_hwrf_thompson
 Checking test 075 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4235,13 +4235,13 @@ Checking test 075 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 213.188133
+The total amount of wall time                        = 201.807415
 
 Test 075 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 076 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4256,13 +4256,13 @@ Checking test 076 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 365.515206
+The total amount of wall time                        = 372.494527
 
 Test 076 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfsv16_ugwpv1
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfsv16_ugwpv1
 Checking test 077 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4321,13 +4321,13 @@ Checking test 077 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 241.597331
+The total amount of wall time                        = 238.830260
 
 Test 077 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfsv16_ugwpv1_warmstart
 Checking test 078 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4386,13 +4386,13 @@ Checking test 078 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 235.734564
+The total amount of wall time                        = 246.970488
 
 Test 078 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_ras
 Checking test 079 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4457,13 +4457,13 @@ Checking test 079 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 126.501397
+The total amount of wall time                        = 136.452269
 
 Test 079 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_debug
 Checking test 080 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4528,13 +4528,13 @@ Checking test 080 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 339.252293
+The total amount of wall time                        = 325.235427
 
 Test 080 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_RRTMGP_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_RRTMGP_debug
 Checking test 081 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4599,13 +4599,13 @@ Checking test 081 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 308.840156
+The total amount of wall time                        = 314.205209
 
 Test 081 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_regional_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_regional_control_debug
 Checking test 082 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4613,13 +4613,13 @@ Checking test 082 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 491.115286
+The total amount of wall time                        = 462.705142
 
 Test 082 fv3_regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_control_debug
 Checking test 083 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4646,13 +4646,13 @@ Checking test 083 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-The total amount of wall time                        = 210.865256
+The total amount of wall time                        = 181.355877
 
 Test 083 fv3_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_stretched_nest_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_stretched_nest_debug
 Checking test 084 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -4669,13 +4669,13 @@ Checking test 084 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
-The total amount of wall time                        = 537.843944
+The total amount of wall time                        = 539.814386
 
 Test 084 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gsd_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gsd_debug
 Checking test 085 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4740,13 +4740,13 @@ Checking test 085 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 262.821408
+The total amount of wall time                        = 264.034369
 
 Test 085 fv3_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_diag3d_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gsd_diag3d_debug
+working dir  = /lfs4/HFIP/h-nems/Minsuk.Ji/RT_RUNDIRS/Minsuk.Ji/FV3_RT/rt_135786/fv3_gsd_diag3d_debug
 Checking test 086 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4811,13 +4811,13 @@ Checking test 086 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 414.357940
+The total amount of wall time                        = 341.565327
 
 Test 086 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_thompson_debug
 Checking test 087 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4882,13 +4882,13 @@ Checking test 087 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 440.155830
+The total amount of wall time                        = 444.747445
 
 Test 087 fv3_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_thompson_no_aero_debug
 Checking test 088 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4953,13 +4953,13 @@ Checking test 088 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 444.802997
+The total amount of wall time                        = 438.575606
 
 Test 088 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_rrfs_v1beta_debug
 Checking test 089 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5024,13 +5024,13 @@ Checking test 089 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 261.007967
+The total amount of wall time                        = 262.799275
 
 Test 089 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_rrfs_v1alpha_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_rrfs_v1alpha_debug
 Checking test 090 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5095,13 +5095,13 @@ Checking test 090 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 261.624928
+The total amount of wall time                        = 261.941368
 
 Test 090 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 091 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5166,13 +5166,13 @@ Checking test 091 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 273.055290
+The total amount of wall time                        = 278.796729
 
 Test 091 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 092 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5187,13 +5187,13 @@ Checking test 092 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 579.325945
+The total amount of wall time                        = 512.339345
 
 Test 092 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfsv16_ugwpv1_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfsv16_ugwpv1_debug
 Checking test 093 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5252,13 +5252,13 @@ Checking test 093 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 739.971442
+The total amount of wall time                        = 740.863850
 
 Test 093 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfs_v16_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfs_v16_ras_debug
 Checking test 094 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5323,73 +5323,73 @@ Checking test 094 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 419.382477
+The total amount of wall time                        = 422.407595
 
 Test 094 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_control_cfsr
 Checking test 095 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 132.500887
+The total amount of wall time                        = 142.722069
 
 Test 095 datm_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_restart_cfsr
 Checking test 096 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 84.455049
+The total amount of wall time                        = 88.097385
 
 Test 096 datm_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_control_gefs
 Checking test 097 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 127.254317
+The total amount of wall time                        = 138.459457
 
 Test 097 datm_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_bulk_cfsr
 Checking test 098 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 129.533703
+The total amount of wall time                        = 132.901155
 
 Test 098 datm_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_bulk_gefs
 Checking test 099 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 124.120255
+The total amount of wall time                        = 139.285046
 
 Test 099 datm_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_mx025_cfsr
 Checking test 100 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5398,13 +5398,13 @@ Checking test 100 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 512.515674
+The total amount of wall time                        = 545.329320
 
 Test 100 datm_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_mx025_gefs
 Checking test 101 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5413,85 +5413,85 @@ Checking test 101 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 479.967637
+The total amount of wall time                        = 536.353591
 
 Test 101 datm_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_debug_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_debug_cfsr
 Checking test 102 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 361.515428
+The total amount of wall time                        = 368.679072
 
 Test 102 datm_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_control_cfsr
 Checking test 103 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 212.919092
+The total amount of wall time                        = 231.361846
 
 Test 103 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_restart_cfsr
 Checking test 104 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 125.189390
+The total amount of wall time                        = 127.153155
 
 Test 104 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_control_gefs
 Checking test 105 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 216.059759
+The total amount of wall time                        = 248.605655
 
 Test 105 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_bulk_cfsr
 Checking test 106 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 283.570023
+The total amount of wall time                        = 236.639310
 
 Test 106 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_bulk_gefs
 Checking test 107 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 211.767812
+The total amount of wall time                        = 249.521723
 
 Test 107 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_mx025_cfsr
 Checking test 108 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5500,13 +5500,13 @@ Checking test 108 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 521.405279
+The total amount of wall time                        = 582.935899
 
 Test 108 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_mx025_gefs
 Checking test 109 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5515,25 +5515,25 @@ Checking test 109 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 481.193614
+The total amount of wall time                        = 599.722642
 
 Test 109 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/datm_cdeps_debug_cfsr
 Checking test 110 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 598.026883
+The total amount of wall time                        = 591.608701
 
 Test 110 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmprad
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmprad
 Checking test 111 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5579,13 +5579,13 @@ Checking test 111 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-The total amount of wall time                        = 427.548103
+The total amount of wall time                        = 470.850415
 
 Test 111 fv3_gfdlmprad PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_atmwav
-working dir  = /lfs4/HFIP/hfv3gfs/Dusan.Jovic/ufs/ccpp_cmake_cleanup_p1/ufs-weather-model/tests/tmp/RT_RUNDIRS/Dusan.Jovic/FV3_RT/rt_116599/fv3_gfdlmprad_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12752/fv3_gfdlmprad_atmwav
 Checking test 112 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5631,11 +5631,11 @@ Checking test 112 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-The total amount of wall time                        = 478.298788
+The total amount of wall time                        = 660.865824
 
 Test 112 fv3_gfdlmprad_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat May  8 02:35:58 GMT 2021
-Elapsed time: 05h:43m:34s. Have a nice day!
+Wed May 12 10:44:31 GMT 2021
+Elapsed time: 03h:45m:50s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,31 +1,31 @@
-Fri May  7 10:01:57 CDT 2021
+Tue May 11 13:15:20 CDT 2021
 Start Regression test
 
-Compile 001 elapsed time 707 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 726 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 242 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 579 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 529 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 006 elapsed time 639 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 572 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 590 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 649 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 652 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 701 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 591 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 593 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 613 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 222 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 282 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 220 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 450 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 149 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 417 seconds. APP=DATM
-Compile 021 elapsed time 145 seconds. APP=DATM DEBUG=Y
-Compile 022 elapsed time 573 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
+Compile 001 elapsed time 1069 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 645 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 003 elapsed time 171 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 574 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 566 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 006 elapsed time 811 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 007 elapsed time 539 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 586 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 576 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 596 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 890 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 553 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 538 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 574 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 144 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 171 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 145 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 398 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 127 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 402 seconds. APP=DATM
+Compile 021 elapsed time 136 seconds. APP=DATM DEBUG=Y
+Compile 022 elapsed time 557 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_control
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 138.720081
+  0: The total amount of wall time                        = 111.296729
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 82.891859
+  0: The total amount of wall time                        = 77.143600
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_controlfrac
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 123.049525
+  0: The total amount of wall time                        = 98.954365
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restartfrac
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.309518
+  0: The total amount of wall time                        = 73.024851
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_2threads
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 117.434884
+  0: The total amount of wall time                        = 114.988621
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_decomp
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_decomp
 Checking test 006 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 112.877469
+  0: The total amount of wall time                        = 102.970734
 
 Test 006 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_satmedmf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_satmedmf
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_satmedmf
 Checking test 007 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 131.787393
+  0: The total amount of wall time                        = 109.863308
 
 Test 007 cpld_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_ca
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_ca
 Checking test 008 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 115.639761
+  0: The total amount of wall time                        = 106.453125
 
 Test 008 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_control_c192
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_control_c192
 Checking test 009 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 412.349480
+  0: The total amount of wall time                        = 390.627509
 
 Test 009 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart_c192
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart_c192
 Checking test 010 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 291.006511
+  0: The total amount of wall time                        = 281.004912
 
 Test 010 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_controlfrac_c192
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_controlfrac_c192
 Checking test 011 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 443.199302
+  0: The total amount of wall time                        = 395.967168
 
 Test 011 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restartfrac_c192
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restartfrac_c192
 Checking test 012 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -691,13 +691,13 @@ Checking test 012 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 289.543627
+  0: The total amount of wall time                        = 273.827814
 
 Test 012 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_control_c384
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_control_c384
 Checking test 013 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -750,13 +750,13 @@ Checking test 013 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1403.936403
+  0: The total amount of wall time                        = 1329.985308
 
 Test 013 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart_c384
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart_c384
 Checking test 014 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -809,13 +809,13 @@ Checking test 014 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 796.252677
+  0: The total amount of wall time                        = 707.570780
 
 Test 014 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_controlfrac_c384
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_controlfrac_c384
 Checking test 015 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -868,13 +868,13 @@ Checking test 015 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1415.504213
+  0: The total amount of wall time                        = 1324.343706
 
 Test 015 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_controlfrac_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restartfrac_c384
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restartfrac_c384
 Checking test 016 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -927,13 +927,13 @@ Checking test 016 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 724.316983
+  0: The total amount of wall time                        = 706.114228
 
 Test 016 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmark
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmark
 Checking test 017 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -986,13 +986,13 @@ Checking test 017 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 921.953176
+  0: The total amount of wall time                        = 855.236460
 
 Test 017 cpld_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart_bmark
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart_bmark
 Checking test 018 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1045,13 +1045,13 @@ Checking test 018 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 458.047095
+  0: The total amount of wall time                        = 447.445666
 
 Test 018 cpld_restart_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmarkfrac
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmarkfrac
 Checking test 019 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1104,13 +1104,13 @@ Checking test 019 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 901.723750
+  0: The total amount of wall time                        = 840.205157
 
 Test 019 cpld_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart_bmarkfrac
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart_bmarkfrac
 Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1163,13 +1163,13 @@ Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 480.655093
+  0: The total amount of wall time                        = 448.892373
 
 Test 020 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmarkfrac_v16
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmarkfrac_v16
 Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1212,13 +1212,13 @@ Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 847.823982
+  0: The total amount of wall time                        = 794.558106
 
 Test 021 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16_nsst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmarkfrac_v16_nsst
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmarkfrac_v16_nsst
 Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 827.573651
+  0: The total amount of wall time                        = 777.738304
 
 Test 022 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_restart_bmarkfrac_v16
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_restart_bmarkfrac_v16
 Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 463.175658
+  0: The total amount of wall time                        = 415.893905
 
 Test 023 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmark_wave
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmark_wave
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmark_wave
 Checking test 024 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 024 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1032.241115
+  0: The total amount of wall time                        = 1036.236669
 
 Test 024 cpld_bmark_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmarkfrac_wave
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmarkfrac_wave
 Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1037.378532
+  0: The total amount of wall time                        = 1006.500491
 
 Test 025 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_bmarkfrac_wave_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_bmarkfrac_wave_v16
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_bmarkfrac_wave_v16
 Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1485,13 +1485,13 @@ Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 929.973777
+  0: The total amount of wall time                        = 806.942994
 
 Test 026 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_control_wave
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_control_wave
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_control_wave
 Checking test 027 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 144.256060
+  0: The total amount of wall time                        = 131.865295
 
 Test 027 cpld_control_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 461.712328
+  0: The total amount of wall time                        = 359.474398
 
 Test 028 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/cpld_debugfrac
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/cpld_debugfrac
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/cpld_debugfrac
 Checking test 029 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 029 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 405.168570
+  0: The total amount of wall time                        = 361.848485
 
 Test 029 cpld_debugfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_control
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_control
 Checking test 030 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1727,13 +1727,13 @@ Checking test 030 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.579018
+  0: The total amount of wall time                        = 47.002344
 
 Test 030 fv3_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_decomp
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_decomp
 Checking test 031 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1798,13 +1798,13 @@ Checking test 031 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 111.868182
+  0: The total amount of wall time                        = 50.845204
 
 Test 031 fv3_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_2threads
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_2threads
 Checking test 032 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1869,13 +1869,13 @@ Checking test 032 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 141.898479
+ 0: The total amount of wall time                        = 44.587323
 
 Test 032 fv3_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_restart
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_restart
 Checking test 033 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 033 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 25.817029
+  0: The total amount of wall time                        = 26.743024
 
 Test 033 fv3_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_read_inc
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_read_inc
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_read_inc
 Checking test 034 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 034 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 57.246115
+  0: The total amount of wall time                        = 48.826167
 
 Test 034 fv3_read_inc PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_esmf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGauss_netcdf_esmf
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGauss_netcdf_esmf
 Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2044,13 +2044,13 @@ Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 350.596486
+  0: The total amount of wall time                        = 230.027922
 
 Test 035 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGauss_netcdf
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGauss_netcdf
 Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2095,13 +2095,13 @@ Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.369393
+  0: The total amount of wall time                        = 49.971819
 
 Test 036 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGauss_netcdf_parallel
 Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2146,13 +2146,13 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 200.487765
+  0: The total amount of wall time                        = 78.742444
 
 Test 037 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGlatlon_netcdf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGlatlon_netcdf
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGlatlon_netcdf
 Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2197,13 +2197,13 @@ Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.407003
+  0: The total amount of wall time                        = 50.324825
 
 Test 038 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGauss_nemsio
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGauss_nemsio
 Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2248,13 +2248,13 @@ Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.395006
+  0: The total amount of wall time                        = 42.648591
 
 Test 039 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_wrtGauss_nemsio_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_wrtGauss_nemsio_c192
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_wrtGauss_nemsio_c192
 Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2299,13 +2299,13 @@ Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.727793
+  0: The total amount of wall time                        = 109.795524
 
 Test 040 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_stochy
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_stochy
 Checking test 041 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2370,13 +2370,13 @@ Checking test 041 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.655611
+  0: The total amount of wall time                        = 47.882133
 
 Test 041 fv3_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_ca
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_ca
 Checking test 042 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2441,13 +2441,13 @@ Checking test 042 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.135049
+  0: The total amount of wall time                        = 34.232077
 
 Test 042 fv3_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_lndp
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_lndp
 Checking test 043 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2512,13 +2512,13 @@ Checking test 043 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.732655
+  0: The total amount of wall time                        = 55.296320
 
 Test 043 fv3_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_iau
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_iau
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_iau
 Checking test 044 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2583,13 +2583,13 @@ Checking test 044 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 53.981846
+  0: The total amount of wall time                        = 47.878122
 
 Test 044 fv3_iau PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_lheatstrg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_lheatstrg
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_lheatstrg
 Checking test 045 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 045 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 99.157572
+  0: The total amount of wall time                        = 41.493935
 
 Test 045 fv3_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_multigases_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_multigases_repro
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_multigases_repro
 Checking test 046 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2711,13 +2711,13 @@ Checking test 046 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.468168
+  0: The total amount of wall time                        = 103.732443
 
 Test 046 fv3_multigases PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_32bit
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_control_32bit
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_control_32bit
 Checking test 047 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2782,13 +2782,13 @@ Checking test 047 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.254462
+  0: The total amount of wall time                        = 44.630315
 
 Test 047 fv3_control_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_stretched
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_stretched
 Checking test 048 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2841,13 +2841,13 @@ Checking test 048 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 279.656020
+ 0: The total amount of wall time                        = 219.740257
 
 Test 048 fv3_stretched PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_stretched_nest
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_stretched_nest
 Checking test 049 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2911,13 +2911,13 @@ Checking test 049 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
- 0: The total amount of wall time                        = 319.412491
+ 0: The total amount of wall time                        = 244.548506
 
 Test 049 fv3_stretched_nest PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_control
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_control
 Checking test 050 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2925,25 +2925,25 @@ Checking test 050 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 300.961895
+ 0: The total amount of wall time                        = 240.135937
 
 Test 050 fv3_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_restart
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_restart
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_restart
 Checking test 051 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 137.932543
+ 0: The total amount of wall time                        = 137.915735
 
 Test 051 fv3_regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_quilt
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_quilt
 Checking test 052 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2954,13 +2954,13 @@ Checking test 052 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 303.905197
+ 0: The total amount of wall time                        = 226.372004
 
 Test 052 fv3_regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_quilt_hafs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_quilt_hafs
 Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2969,27 +2969,27 @@ Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 326.036268
+ 0: The total amount of wall time                        = 226.388073
 
 Test 053 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_quilt_netcdf_parallel
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_quilt_netcdf_parallel
 Checking test 054 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 320.076575
+ 0: The total amount of wall time                        = 229.819441
 
 Test 054 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_quilt_RRTMGP
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_quilt_RRTMGP
 Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -3000,13 +3000,13 @@ Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 343.214272
+ 0: The total amount of wall time                        = 290.379078
 
 Test 055 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmp
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmp
 Checking test 056 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3051,13 +3051,13 @@ Checking test 056 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.604806
+  0: The total amount of wall time                        = 48.662977
 
 Test 056 fv3_gfdlmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_gwd
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmprad_gwd
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmprad_gwd
 Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.936994
+  0: The total amount of wall time                        = 56.771943
 
 Test 057 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_noahmp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmprad_noahmp
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmprad_noahmp
 Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3153,13 +3153,13 @@ Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 140.428580
+  0: The total amount of wall time                        = 48.115911
 
 Test 058 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_csawmg
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_csawmg
 Checking test 059 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,13 +3204,13 @@ Checking test 059 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.605294
+  0: The total amount of wall time                        = 157.747007
 
 Test 059 fv3_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_satmedmf
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_satmedmf
 Checking test 060 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3255,13 +3255,13 @@ Checking test 060 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 59.734703
+  0: The total amount of wall time                        = 54.347328
 
 Test 060 fv3_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_satmedmfq
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_satmedmfq
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_satmedmfq
 Checking test 061 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,13 +3306,13 @@ Checking test 061 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 52.815053
+  0: The total amount of wall time                        = 50.097386
 
 Test 061 fv3_satmedmfq PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmp_32bit
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmp_32bit
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmp_32bit
 Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3357,13 +3357,13 @@ Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 49.822259
+  0: The total amount of wall time                        = 46.450338
 
 Test 062 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_32bit_post
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmprad_32bit_post
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmprad_32bit_post
 Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3412,13 +3412,13 @@ Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 85.167364
+  0: The total amount of wall time                        = 84.887110
 
 Test 063 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_cpt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_cpt
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_cpt
 Checking test 064 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,13 +3469,13 @@ Checking test 064 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 284.027323
+  0: The total amount of wall time                        = 263.098270
 
 Test 064 fv3_cpt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gsd
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gsd
 Checking test 065 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3564,13 +3564,13 @@ Checking test 065 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.689665
+  0: The total amount of wall time                        = 178.094188
 
 Test 065 fv3_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_rrfs_v1alpha
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_rrfs_v1alpha
 Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3635,13 +3635,13 @@ Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 100.800851
+  0: The total amount of wall time                        = 95.907701
 
 Test 066 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rap
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_rap
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_rap
 Checking test 067 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3706,13 +3706,13 @@ Checking test 067 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.670340
+  0: The total amount of wall time                        = 98.622387
 
 Test 067 fv3_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_hrrr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_hrrr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_hrrr
 Checking test 068 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3777,13 +3777,13 @@ Checking test 068 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 111.741033
+  0: The total amount of wall time                        = 98.635308
 
 Test 068 fv3_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_thompson
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_thompson
 Checking test 069 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3848,13 +3848,13 @@ Checking test 069 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 112.725139
+  0: The total amount of wall time                        = 87.657920
 
 Test 069 fv3_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_thompson_no_aero
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_thompson_no_aero
 Checking test 070 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3919,13 +3919,13 @@ Checking test 070 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 101.013202
+  0: The total amount of wall time                        = 93.705490
 
 Test 070 fv3_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_rrfs_v1beta
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_rrfs_v1beta
 Checking test 071 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3990,13 +3990,13 @@ Checking test 071 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 103.812398
+  0: The total amount of wall time                        = 91.635482
 
 Test 071 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16
 Checking test 072 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4073,13 +4073,13 @@ Checking test 072 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.990329
+  0: The total amount of wall time                        = 208.110138
 
 Test 072 fv3_gfs_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_restart
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_restart
 Checking test 073 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4126,13 +4126,13 @@ Checking test 073 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.255154
+  0: The total amount of wall time                        = 161.767361
 
 Test 073 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_stochy
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_stochy
 Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4197,13 +4197,13 @@ Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 65.409303
+  0: The total amount of wall time                        = 56.603186
 
 Test 074 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_RRTMGP
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_RRTMGP
 Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4280,13 +4280,13 @@ Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 271.307353
+  0: The total amount of wall time                        = 243.431161
 
 Test 075 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfsv16_csawmg
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfsv16_csawmg
 Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4331,13 +4331,13 @@ Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.790968
+  0: The total amount of wall time                        = 127.099633
 
 Test 076 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfsv16_csawmgt
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfsv16_csawmgt
 Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4382,13 +4382,13 @@ Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.669489
+  0: The total amount of wall time                        = 120.960245
 
 Test 077 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gocart_clm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gocart_clm
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gocart_clm
 Checking test 078 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4433,13 +4433,13 @@ Checking test 078 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 60.044740
+  0: The total amount of wall time                        = 57.151749
 
 Test 078 fv3_gocart_clm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_flake
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_flake
 Checking test 079 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4504,13 +4504,13 @@ Checking test 079 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.162158
+  0: The total amount of wall time                        = 108.123518
 
 Test 079 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_HAFS_v0_hwrf_thompson
 Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4575,13 +4575,13 @@ Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 150.829762
+  0: The total amount of wall time                        = 150.805524
 
 Test 080 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4596,13 +4596,13 @@ Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 311.574742
+ 0: The total amount of wall time                        = 300.647197
 
 Test 081 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfsv16_ugwpv1
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfsv16_ugwpv1
 Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4661,13 +4661,13 @@ Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.525363
+  0: The total amount of wall time                        = 176.882264
 
 Test 082 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfsv16_ugwpv1_warmstart
 Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4726,13 +4726,13 @@ Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.193085
+  0: The total amount of wall time                        = 178.773398
 
 Test 083 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_ras
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_ras
 Checking test 084 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4797,13 +4797,13 @@ Checking test 084 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 105.473926
+  0: The total amount of wall time                        = 97.054224
 
 Test 084 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_debug
 Checking test 085 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4868,13 +4868,13 @@ Checking test 085 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 297.674581
+  0: The total amount of wall time                        = 298.926686
 
 Test 085 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_RRTMGP_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_RRTMGP_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_RRTMGP_debug
 Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4939,13 +4939,13 @@ Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 265.539766
+  0: The total amount of wall time                        = 247.432954
 
 Test 086 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_regional_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_regional_control_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_regional_control_debug
 Checking test 087 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4953,13 +4953,13 @@ Checking test 087 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 379.856581
+ 0: The total amount of wall time                        = 384.129011
 
 Test 087 fv3_regional_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_control_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_control_debug
 Checking test 088 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4986,13 +4986,13 @@ Checking test 088 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.383587
+  0: The total amount of wall time                        = 145.397963
 
 Test 088 fv3_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_stretched_nest_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_stretched_nest_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_stretched_nest_debug
 Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -5009,13 +5009,13 @@ Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 411.464884
+ 0: The total amount of wall time                        = 396.140811
 
 Test 089 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gsd_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gsd_debug
 Checking test 090 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5080,13 +5080,13 @@ Checking test 090 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.266075
+  0: The total amount of wall time                        = 227.980803
 
 Test 090 fv3_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gsd_diag3d_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gsd_diag3d_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gsd_diag3d_debug
 Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5151,13 +5151,13 @@ Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 341.791722
+  0: The total amount of wall time                        = 336.722632
 
 Test 091 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_thompson_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_thompson_debug
 Checking test 092 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5222,13 +5222,13 @@ Checking test 092 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 359.147613
+  0: The total amount of wall time                        = 353.629134
 
 Test 092 fv3_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_thompson_no_aero_debug
 Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5293,13 +5293,13 @@ Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 349.201103
+  0: The total amount of wall time                        = 348.199015
 
 Test 093 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_rrfs_v1beta_debug
 Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5364,13 +5364,13 @@ Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 220.088272
+  0: The total amount of wall time                        = 215.622612
 
 Test 094 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_rrfs_v1alpha_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_rrfs_v1alpha_debug
 Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5435,13 +5435,13 @@ Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 221.519878
+  0: The total amount of wall time                        = 214.860882
 
 Test 095 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5506,13 +5506,13 @@ Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.636999
+  0: The total amount of wall time                        = 220.629911
 
 Test 096 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5527,13 +5527,13 @@ Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 414.588138
+ 0: The total amount of wall time                        = 415.558326
 
 Test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfsv16_ugwpv1_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfsv16_ugwpv1_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfsv16_ugwpv1_debug
 Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5592,13 +5592,13 @@ Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 594.979673
+  0: The total amount of wall time                        = 573.340409
 
 Test 098 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfs_v16_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfs_v16_ras_debug
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfs_v16_ras_debug
 Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5663,73 +5663,73 @@ Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 336.194201
+  0: The total amount of wall time                        = 331.169095
 
 Test 099 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_control_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_control_cfsr
 Checking test 100 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 108.695614
+  0: The total amount of wall time                        = 114.406683
 
 Test 100 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_restart_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_restart_cfsr
 Checking test 101 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 75.809506
+  0: The total amount of wall time                        = 71.666903
 
 Test 101 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_control_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_control_gefs
 Checking test 102 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 113.179327
+  0: The total amount of wall time                        = 103.989568
 
 Test 102 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_bulk_cfsr
 Checking test 103 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 104.966877
+  0: The total amount of wall time                        = 104.251407
 
 Test 103 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_bulk_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_bulk_gefs
 Checking test 104 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 103.843585
+  0: The total amount of wall time                        = 96.376318
 
 Test 104 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_mx025_cfsr
 Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5738,13 +5738,13 @@ Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 414.265037
+  0: The total amount of wall time                        = 405.139419
 
 Test 105 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_mx025_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_mx025_gefs
 Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5753,85 +5753,85 @@ Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 403.661517
+  0: The total amount of wall time                        = 387.464103
 
 Test 106 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_debug_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_debug_cfsr
 Checking test 107 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 298.921381
+  0: The total amount of wall time                        = 287.251272
 
 Test 107 datm_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.314610
+ 0: The total amount of wall time                        = 154.115820
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 110.837747
+ 0: The total amount of wall time                        = 97.909538
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.255587
+ 0: The total amount of wall time                        = 158.821438
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_bulk_cfsr
 Checking test 111 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.663683
+ 0: The total amount of wall time                        = 156.506335
 
 Test 111 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_bulk_gefs
 Checking test 112 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.444193
+ 0: The total amount of wall time                        = 149.914502
 
 Test 112 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_mx025_cfsr
 Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5840,13 +5840,13 @@ Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 405.307963
+  0: The total amount of wall time                        = 403.592586
 
 Test 113 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_mx025_gefs
 Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5855,25 +5855,25 @@ Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 397.010075
+  0: The total amount of wall time                        = 387.339106
 
 Test 114 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/datm_cdeps_debug_cfsr
 Checking test 115 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 465.482086
+ 0: The total amount of wall time                        = 478.931480
 
 Test 115 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmprad
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmprad
 Checking test 116 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5919,13 +5919,13 @@ Checking test 116 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-  0: The total amount of wall time                        = 355.778232
+  0: The total amount of wall time                        = 355.952529
 
 Test 116 fv3_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/INTEL/fv3_gfdlmprad_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_7506/fv3_gfdlmprad_atmwav
+working dir  = /work/noaa/stmp/jminsuk/stmp/jminsuk/FV3_RT/rt_342193/fv3_gfdlmprad_atmwav
 Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5971,11 +5971,11 @@ Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-  0: The total amount of wall time                        = 410.323717
+  0: The total amount of wall time                        = 389.022595
 
 Test 117 fv3_gfdlmprad_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 11:24:27 CDT 2021
-Elapsed time: 01h:22m:31s. Have a nice day!
+Tue May 11 14:47:30 CDT 2021
+Elapsed time: 01h:32m:10s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,23 +1,23 @@
-Fri May  7 14:57:59 UTC 2021
+Mon May 10 19:40:17 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 1056 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 002 elapsed time 959 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 003 elapsed time 940 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 004 elapsed time 1018 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 005 elapsed time 989 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 006 elapsed time 961 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 007 elapsed time 1006 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 935 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 009 elapsed time 965 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 010 elapsed time 966 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 011 elapsed time 1096 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 012 elapsed time 525 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 013 elapsed time 517 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 014 elapsed time 544 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 001 elapsed time 991 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 002 elapsed time 974 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 003 elapsed time 946 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 004 elapsed time 1014 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 005 elapsed time 970 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 006 elapsed time 1020 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 007 elapsed time 1032 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 1021 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 009 elapsed time 955 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 010 elapsed time 941 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 011 elapsed time 1042 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 012 elapsed time 541 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 013 elapsed time 556 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 014 elapsed time 546 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_control
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_control
 Checking test 001 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -82,13 +82,13 @@ Checking test 001 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 51.622673
+The total amount of wall time                        = 66.019895
 
 Test 001 fv3_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_decomp
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_decomp
 Checking test 002 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -153,13 +153,13 @@ Checking test 002 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 51.755703
+The total amount of wall time                        = 66.699618
 
 Test 002 fv3_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_2threads
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_2threads
 Checking test 003 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -224,13 +224,13 @@ Checking test 003 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 41.572522
+The total amount of wall time                        = 52.172029
 
 Test 003 fv3_2threads PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_restart
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_restart
 Checking test 004 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -277,13 +277,13 @@ Checking test 004 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 23.804017
+The total amount of wall time                        = 27.501024
 
 Test 004 fv3_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_read_inc
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_read_inc
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_read_inc
 Checking test 005 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -348,13 +348,13 @@ Checking test 005 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 50.008590
+The total amount of wall time                        = 53.145148
 
 Test 005 fv3_read_inc PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf_esmf
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGauss_netcdf_esmf
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGauss_netcdf_esmf
 Checking test 006 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -399,13 +399,13 @@ Checking test 006 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 126.478695
+The total amount of wall time                        = 139.728817
 
 Test 006 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGauss_netcdf
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGauss_netcdf
 Checking test 007 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -450,13 +450,13 @@ Checking test 007 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 52.813161
+The total amount of wall time                        = 59.301992
 
 Test 007 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGauss_netcdf_parallel
 Checking test 008 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -501,13 +501,13 @@ Checking test 008 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 55.584602
+The total amount of wall time                        = 73.347049
 
 Test 008 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGlatlon_netcdf
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGlatlon_netcdf
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGlatlon_netcdf
 Checking test 009 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -552,13 +552,13 @@ Checking test 009 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 50.454866
+The total amount of wall time                        = 66.005107
 
 Test 009 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_nemsio
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGauss_nemsio
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGauss_nemsio
 Checking test 010 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -603,13 +603,13 @@ Checking test 010 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 50.169210
+The total amount of wall time                        = 62.419948
 
 Test 010 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_nemsio_c192
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_wrtGauss_nemsio_c192
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_wrtGauss_nemsio_c192
 Checking test 011 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -654,13 +654,13 @@ Checking test 011 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 117.941377
+The total amount of wall time                        = 127.723762
 
 Test 011 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stochy
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_stochy
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_stochy
 Checking test 012 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -725,13 +725,13 @@ Checking test 012 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 52.041130
+The total amount of wall time                        = 60.416372
 
 Test 012 fv3_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_ca
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_ca
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_ca
 Checking test 013 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -796,13 +796,13 @@ Checking test 013 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 36.192875
+The total amount of wall time                        = 51.184024
 
 Test 013 fv3_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_lndp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_lndp
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_lndp
 Checking test 014 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -867,13 +867,13 @@ Checking test 014 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 55.328653
+The total amount of wall time                        = 74.457859
 
 Test 014 fv3_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_iau
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_iau
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_iau
 Checking test 015 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -938,13 +938,13 @@ Checking test 015 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 48.942231
+The total amount of wall time                        = 52.467628
 
 Test 015 fv3_iau PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_lheatstrg
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_lheatstrg
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_lheatstrg
 Checking test 016 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -989,13 +989,13 @@ Checking test 016 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 50.815186
+The total amount of wall time                        = 55.614957
 
 Test 016 fv3_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_multigases_repro
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_multigases_repro
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_multigases_repro
 Checking test 017 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1066,13 +1066,13 @@ Checking test 017 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 101.624331
+The total amount of wall time                        = 105.047839
 
 Test 017 fv3_multigases PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control_32bit
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_control_32bit
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_control_32bit
 Checking test 018 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1137,13 +1137,13 @@ Checking test 018 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 58.416613
+The total amount of wall time                        = 51.573946
 
 Test 018 fv3_control_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_stretched
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_stretched
 Checking test 019 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1196,13 +1196,13 @@ Checking test 019 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 328.148795
+The total amount of wall time                        = 331.211702
 
 Test 019 fv3_stretched PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched_nest
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_stretched_nest
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_stretched_nest
 Checking test 020 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1266,13 +1266,13 @@ Checking test 020 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
-The total amount of wall time                        = 365.976800
+The total amount of wall time                        = 363.632023
 
 Test 020 fv3_stretched_nest PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_control
 Checking test 021 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1280,25 +1280,25 @@ Checking test 021 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 262.211438
+The total amount of wall time                        = 297.906230
 
 Test 021 fv3_regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_restart
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_restart
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_restart
 Checking test 022 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 161.869324
+The total amount of wall time                        = 166.125229
 
 Test 022 fv3_regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_quilt
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_quilt
 Checking test 023 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1309,13 +1309,13 @@ Checking test 023 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 245.658379
+The total amount of wall time                        = 256.822680
 
 Test 023 fv3_regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_hafs
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_quilt_hafs
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_quilt_hafs
 Checking test 024 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1324,13 +1324,13 @@ Checking test 024 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 244.980341
+The total amount of wall time                        = 260.057162
 
 Test 024 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_quilt_netcdf_parallel
 Checking test 025 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1338,13 +1338,13 @@ Checking test 025 fv3_regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 244.999236
+The total amount of wall time                        = 252.981924
 
 Test 025 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_quilt_RRTMGP
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_quilt_RRTMGP
 Checking test 026 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1355,13 +1355,13 @@ Checking test 026 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 327.093058
+The total amount of wall time                        = 332.871463
 
 Test 026 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfdlmp
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfdlmp
 Checking test 027 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1406,13 +1406,13 @@ Checking test 027 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 57.128919
+The total amount of wall time                        = 64.955690
 
 Test 027 fv3_gfdlmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_gwd
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfdlmprad_gwd
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfdlmprad_gwd
 Checking test 028 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1457,13 +1457,13 @@ Checking test 028 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 60.569321
+The total amount of wall time                        = 69.784038
 
 Test 028 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_noahmp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfdlmprad_noahmp
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfdlmprad_noahmp
 Checking test 029 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1508,13 +1508,13 @@ Checking test 029 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 57.333799
+The total amount of wall time                        = 77.081696
 
 Test 029 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_csawmg
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_csawmg
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_csawmg
 Checking test 030 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1559,13 +1559,13 @@ Checking test 030 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 126.857504
+The total amount of wall time                        = 135.264836
 
 Test 030 fv3_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_satmedmf
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_satmedmf
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_satmedmf
 Checking test 031 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1610,13 +1610,13 @@ Checking test 031 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 59.449345
+The total amount of wall time                        = 60.776161
 
 Test 031 fv3_satmedmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_satmedmfq
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_satmedmfq
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_satmedmfq
 Checking test 032 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1661,13 +1661,13 @@ Checking test 032 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 58.316959
+The total amount of wall time                        = 62.544325
 
 Test 032 fv3_satmedmfq PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmp_32bit
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfdlmp_32bit
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfdlmp_32bit
 Checking test 033 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1712,13 +1712,13 @@ Checking test 033 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 50.286812
+The total amount of wall time                        = 64.331428
 
 Test 033 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_32bit_post
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfdlmprad_32bit_post
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfdlmprad_32bit_post
 Checking test 034 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1767,13 +1767,13 @@ Checking test 034 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 101.461352
+The total amount of wall time                        = 104.762792
 
 Test 034 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_cpt
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_cpt
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_cpt
 Checking test 035 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,13 +1824,13 @@ Checking test 035 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 285.847884
+The total amount of wall time                        = 287.059562
 
 Test 035 fv3_cpt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gsd
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gsd
 Checking test 036 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1919,13 +1919,13 @@ Checking test 036 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 188.592701
+The total amount of wall time                        = 191.997159
 
 Test 036 fv3_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1alpha
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_rrfs_v1alpha
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_rrfs_v1alpha
 Checking test 037 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1990,13 +1990,13 @@ Checking test 037 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.662384
+The total amount of wall time                        = 100.917014
 
 Test 037 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rap
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_rap
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_rap
 Checking test 038 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2061,13 +2061,13 @@ Checking test 038 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 101.505617
+The total amount of wall time                        = 101.965430
 
 Test 038 fv3_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_hrrr
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_hrrr
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_hrrr
 Checking test 039 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2132,13 +2132,13 @@ Checking test 039 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.919442
+The total amount of wall time                        = 105.177105
 
 Test 039 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_thompson
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_thompson
 Checking test 040 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2203,13 +2203,13 @@ Checking test 040 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 92.076510
+The total amount of wall time                        = 93.185561
 
 Test 040 fv3_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_no_aero
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_thompson_no_aero
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_thompson_no_aero
 Checking test 041 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2274,13 +2274,13 @@ Checking test 041 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 89.928344
+The total amount of wall time                        = 94.820030
 
 Test 041 fv3_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_rrfs_v1beta
 Checking test 042 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2345,13 +2345,13 @@ Checking test 042 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 98.071415
+The total amount of wall time                        = 101.110557
 
 Test 042 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16
 Checking test 043 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2428,13 +2428,13 @@ Checking test 043 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.323822
+The total amount of wall time                        = 212.084680
 
 Test 043 fv3_gfs_v16 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_restart
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_restart
 Checking test 044 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2481,13 +2481,13 @@ Checking test 044 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 111.940262
+The total amount of wall time                        = 186.208204
 
 Test 044 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_stochy
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_stochy
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_stochy
 Checking test 045 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2552,13 +2552,13 @@ Checking test 045 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 61.902169
+The total amount of wall time                        = 76.439594
 
 Test 045 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_RRTMGP
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_RRTMGP
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_RRTMGP
 Checking test 046 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2635,13 +2635,13 @@ Checking test 046 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 229.241402
+The total amount of wall time                        = 246.451993
 
 Test 046 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_csawmg
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfsv16_csawmg
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfsv16_csawmg
 Checking test 047 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2686,13 +2686,13 @@ Checking test 047 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 138.127241
+The total amount of wall time                        = 144.935095
 
 Test 047 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_csawmgt
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfsv16_csawmgt
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfsv16_csawmgt
 Checking test 048 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2737,13 +2737,13 @@ Checking test 048 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 137.464356
+The total amount of wall time                        = 146.009742
 
 Test 048 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gocart_clm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gocart_clm
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gocart_clm
 Checking test 049 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2788,13 +2788,13 @@ Checking test 049 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 67.691134
+The total amount of wall time                        = 68.015105
 
 Test 049 fv3_gocart_clm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_flake
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_flake
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_flake
 Checking test 050 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2859,13 +2859,13 @@ Checking test 050 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 102.381340
+The total amount of wall time                        = 107.631313
 
 Test 050 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_HAFS_v0_hwrf_thompson
 Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2930,13 +2930,13 @@ Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 161.613925
+The total amount of wall time                        = 166.722667
 
 Test 051 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2951,13 +2951,13 @@ Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 305.669668
+The total amount of wall time                        = 361.998995
 
 Test 052 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfsv16_ugwpv1
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfsv16_ugwpv1
 Checking test 053 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3016,13 +3016,13 @@ Checking test 053 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 194.171586
+The total amount of wall time                        = 194.923200
 
 Test 053 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfsv16_ugwpv1_warmstart
 Checking test 054 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3081,13 +3081,13 @@ Checking test 054 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 193.533374
+The total amount of wall time                        = 195.850441
 
 Test 054 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_ras
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_ras
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_ras
 Checking test 055 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3152,13 +3152,13 @@ Checking test 055 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 104.795127
+The total amount of wall time                        = 117.693730
 
 Test 055 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_debug
 Checking test 056 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3223,13 +3223,13 @@ Checking test 056 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 245.269581
+The total amount of wall time                        = 245.677313
 
 Test 056 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_RRTMGP_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_RRTMGP_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_RRTMGP_debug
 Checking test 057 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3294,13 +3294,13 @@ Checking test 057 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 226.169632
+The total amount of wall time                        = 229.937670
 
 Test 057 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_control_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_regional_control_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_regional_control_debug
 Checking test 058 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -3308,13 +3308,13 @@ Checking test 058 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 348.617294
+The total amount of wall time                        = 350.864160
 
 Test 058 fv3_regional_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_control_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_control_debug
 Checking test 059 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3341,13 +3341,13 @@ Checking test 059 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-The total amount of wall time                        = 128.575557
+The total amount of wall time                        = 133.328963
 
 Test 059 fv3_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched_nest_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_stretched_nest_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_stretched_nest_debug
 Checking test 060 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -3364,13 +3364,13 @@ Checking test 060 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
-The total amount of wall time                        = 413.038504
+The total amount of wall time                        = 418.450781
 
 Test 060 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gsd_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gsd_debug
 Checking test 061 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3435,13 +3435,13 @@ Checking test 061 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.914745
+The total amount of wall time                        = 202.049036
 
 Test 061 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd_diag3d_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gsd_diag3d_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gsd_diag3d_debug
 Checking test 062 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3506,13 +3506,13 @@ Checking test 062 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.856999
+The total amount of wall time                        = 257.957768
 
 Test 062 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_thompson_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_thompson_debug
 Checking test 063 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3577,13 +3577,13 @@ Checking test 063 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 330.538771
+The total amount of wall time                        = 341.435487
 
 Test 063 fv3_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_thompson_no_aero_debug
 Checking test 064 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3648,13 +3648,13 @@ Checking test 064 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 318.429685
+The total amount of wall time                        = 327.693724
 
 Test 064 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_rrfs_v1beta_debug
 Checking test 065 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3719,13 +3719,13 @@ Checking test 065 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 190.985536
+The total amount of wall time                        = 198.696085
 
 Test 065 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_rrfs_v1alpha_debug
 Checking test 066 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3790,13 +3790,13 @@ Checking test 066 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 191.518312
+The total amount of wall time                        = 195.905392
 
 Test 066 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 067 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3861,13 +3861,13 @@ Checking test 067 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.969025
+The total amount of wall time                        = 198.962671
 
 Test 067 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3882,13 +3882,13 @@ Checking test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 357.040215
+The total amount of wall time                        = 359.321065
 
 Test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfsv16_ugwpv1_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfsv16_ugwpv1_debug
 Checking test 069 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -3947,13 +3947,13 @@ Checking test 069 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 553.671991
+The total amount of wall time                        = 558.496297
 
 Test 069 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_ras_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_42879/fv3_gfs_v16_ras_debug
+working dir  = /gpfs/hps3/stmp/Chan-Hoo.Jeon/FV3_RT/rt_369/fv3_gfs_v16_ras_debug
 Checking test 070 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4018,11 +4018,11 @@ Checking test 070 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 310.865439
+The total amount of wall time                        = 317.665716
 
 Test 070 fv3_gfs_v16_ras_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 15:41:31 UTC 2021
-Elapsed time: 00h:43m:32s. Have a nice day!
+Mon May 10 20:24:11 UTC 2021
+Elapsed time: 00h:43m:55s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,31 +1,31 @@
-Fri May  7 14:57:16 UTC 2021
+Tue May 11 10:07:38 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 2646 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 3045 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 003 elapsed time 866 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 1866 seconds. APP=ATM SUITES=FV3_GFS_2017
-Compile 005 elapsed time 1388 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
-Compile 006 elapsed time 1709 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
-Compile 007 elapsed time 1643 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 008 elapsed time 1691 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
-Compile 009 elapsed time 1840 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
-Compile 010 elapsed time 2447 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 011 elapsed time 2140 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 012 elapsed time 1730 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
-Compile 013 elapsed time 1696 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
-Compile 014 elapsed time 1774 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
-Compile 015 elapsed time 514 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
-Compile 016 elapsed time 514 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 017 elapsed time 516 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
-Compile 018 elapsed time 1326 seconds. APP=DATM_NEMS
-Compile 019 elapsed time 395 seconds. APP=DATM_NEMS DEBUG=Y
-Compile 020 elapsed time 1483 seconds. APP=DATM
-Compile 021 elapsed time 498 seconds. APP=DATM DEBUG=Y
-Compile 022 elapsed time 1570 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
+Compile 001 elapsed time 2600 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 2833 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 003 elapsed time 662 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 1488 seconds. APP=ATM SUITES=FV3_GFS_2017
+Compile 005 elapsed time 1440 seconds. APP=ATM SUITES=FV3_GFS_2017_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y
+Compile 006 elapsed time 1571 seconds. APP=ATM SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y
+Compile 007 elapsed time 1599 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 008 elapsed time 1581 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp
+Compile 009 elapsed time 1760 seconds. APP=ATM SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq
+Compile 010 elapsed time 2053 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 011 elapsed time 1697 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 012 elapsed time 1571 seconds. APP=ATM SUITES=FV3_GFS_v16_csawmg
+Compile 013 elapsed time 1646 seconds. APP=ATM SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_v16_flake
+Compile 014 elapsed time 1735 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras
+Compile 015 elapsed time 411 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP
+Compile 016 elapsed time 403 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_2017,FV3_GFS_2017_stretched,FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 017 elapsed time 367 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf,FV3_GFS_v16b_ugwpv1,FV3_GFS_v16_ras DEBUG=Y
+Compile 018 elapsed time 1324 seconds. APP=DATM_NEMS
+Compile 019 elapsed time 421 seconds. APP=DATM_NEMS DEBUG=Y
+Compile 020 elapsed time 1367 seconds. APP=DATM
+Compile 021 elapsed time 422 seconds. APP=DATM DEBUG=Y
+Compile 022 elapsed time 1572 seconds. APP=ATMW SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_control
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_control
 Checking test 001 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -75,13 +75,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 103.988599
+[0] The total amount of wall time                        = 103.763407
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -131,13 +131,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 69.662805
+[0] The total amount of wall time                        = 71.154942
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_controlfrac
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_controlfrac
 Checking test 003 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -187,13 +187,13 @@ Checking test 003 cpld_controlfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 103.939944
+[0] The total amount of wall time                        = 104.815374
 
 Test 003 cpld_controlfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restartfrac
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restartfrac
 Checking test 004 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -243,13 +243,13 @@ Checking test 004 cpld_restartfrac results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 70.066499
+[0] The total amount of wall time                        = 67.598718
 
 Test 004 cpld_restartfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_2threads
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_2threads
 Checking test 005 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -299,13 +299,13 @@ Checking test 005 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 98.315214
+[0] The total amount of wall time                        = 98.666972
 
 Test 005 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_decomp
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_decomp
 Checking test 006 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -355,13 +355,13 @@ Checking test 006 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.037579
+[0] The total amount of wall time                        = 102.833874
 
 Test 006 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_satmedmf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_satmedmf
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_satmedmf
 Checking test 007 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_satmedmf results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 103.161554
+[0] The total amount of wall time                        = 104.051142
 
 Test 007 cpld_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_ca
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_ca
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_ca
 Checking test 008 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.079133
+[0] The total amount of wall time                        = 103.647796
 
 Test 008 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_control_c192
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_control_c192
 Checking test 009 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 009 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 420.086039
+[0] The total amount of wall time                        = 419.890515
 
 Test 009 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart_c192
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart_c192
 Checking test 010 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -579,13 +579,13 @@ Checking test 010 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 318.188443
+[0] The total amount of wall time                        = 318.871073
 
 Test 010 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_controlfrac_c192
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_controlfrac_c192
 Checking test 011 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -635,13 +635,13 @@ Checking test 011 cpld_controlfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 419.992412
+[0] The total amount of wall time                        = 418.692484
 
 Test 011 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restartfrac_c192
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restartfrac_c192
 Checking test 012 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -691,13 +691,13 @@ Checking test 012 cpld_restartfrac_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 316.918780
+[0] The total amount of wall time                        = 319.473084
 
 Test 012 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_control_c384
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_control_c384
 Checking test 013 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -750,13 +750,13 @@ Checking test 013 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1473.429425
+[0] The total amount of wall time                        = 1465.347021
 
 Test 013 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart_c384
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart_c384
 Checking test 014 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -809,13 +809,13 @@ Checking test 014 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 803.609650
+[0] The total amount of wall time                        = 822.573650
 
 Test 014 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac_c384
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_controlfrac_c384
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_controlfrac_c384
 Checking test 015 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -868,13 +868,13 @@ Checking test 015 cpld_controlfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1459.387245
+[0] The total amount of wall time                        = 1461.976880
 
 Test 015 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_controlfrac_c384
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restartfrac_c384
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restartfrac_c384
 Checking test 016 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -927,13 +927,13 @@ Checking test 016 cpld_restartfrac_c384 results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 802.717291
+[0] The total amount of wall time                        = 820.209749
 
 Test 016 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmark
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmark
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmark
 Checking test 017 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -986,13 +986,13 @@ Checking test 017 cpld_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 881.281990
+[0] The total amount of wall time                        = 918.708789
 
 Test 017 cpld_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmark
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart_bmark
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart_bmark
 Checking test 018 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1045,13 +1045,13 @@ Checking test 018 cpld_restart_bmark results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 521.542908
+[0] The total amount of wall time                        = 524.894956
 
 Test 018 cpld_restart_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmarkfrac
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmarkfrac
 Checking test 019 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1104,13 +1104,13 @@ Checking test 019 cpld_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 915.146653
+[0] The total amount of wall time                        = 915.552021
 
 Test 019 cpld_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart_bmarkfrac
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart_bmarkfrac
 Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1163,13 +1163,13 @@ Checking test 020 cpld_restart_bmarkfrac results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 517.362374
+[0] The total amount of wall time                        = 522.818286
 
 Test 020 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac_v16
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmarkfrac_v16
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmarkfrac_v16
 Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1212,13 +1212,13 @@ Checking test 021 cpld_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 823.937221
+[0] The total amount of wall time                        = 852.293925
 
 Test 021 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac_v16_nsst
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmarkfrac_v16_nsst
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmarkfrac_v16_nsst
 Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 022 cpld_bmarkfrac_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 833.263386
+[0] The total amount of wall time                        = 857.607843
 
 Test 022 cpld_bmarkfrac_v16_nsst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac_v16
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_restart_bmarkfrac_v16
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_restart_bmarkfrac_v16
 Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 023 cpld_restart_bmarkfrac_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 518.083511
+[0] The total amount of wall time                        = 526.366256
 
 Test 023 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmark_wave
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmark_wave
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmark_wave
 Checking test 024 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 024 cpld_bmark_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1104.885684
+[0] The total amount of wall time                        = 1102.088508
 
 Test 024 cpld_bmark_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac_wave
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmarkfrac_wave
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmarkfrac_wave
 Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 025 cpld_bmarkfrac_wave results ....
  Comparing RESTART/iced.2013-04-02-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1051.008544
+[0] The total amount of wall time                        = 1102.751124
 
 Test 025 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_bmarkfrac_wave_v16
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_bmarkfrac_wave_v16
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_bmarkfrac_wave_v16
 Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf006.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1485,13 +1485,13 @@ Checking test 026 cpld_bmarkfrac_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 926.160751
+[0] The total amount of wall time                        = 944.403022
 
 Test 026 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_control_wave
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_control_wave
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_control_wave
 Checking test 027 cpld_control_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1544,13 +1544,13 @@ Checking test 027 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 126.424581
+[0] The total amount of wall time                        = 131.742911
 
 Test 027 cpld_control_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1600,13 +1600,13 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 328.200175
+[0] The total amount of wall time                        = 326.820670
 
 Test 028 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/cpld_debugfrac
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/cpld_debugfrac
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/cpld_debugfrac
 Checking test 029 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 029 cpld_debugfrac results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 325.785775
+[0] The total amount of wall time                        = 325.644750
 
 Test 029 cpld_debugfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_control
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_control
 Checking test 030 fv3_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1727,13 +1727,13 @@ Checking test 030 fv3_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 49.497970
+[0] The total amount of wall time                        = 49.306001
 
 Test 030 fv3_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_decomp
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_decomp
 Checking test 031 fv3_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1798,13 +1798,13 @@ Checking test 031 fv3_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 49.737409
+[0] The total amount of wall time                        = 50.094846
 
 Test 031 fv3_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_2threads
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_2threads
 Checking test 032 fv3_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1869,13 +1869,13 @@ Checking test 032 fv3_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 41.134613
+[0] The total amount of wall time                        = 41.001657
 
 Test 032 fv3_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_restart
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_restart
 Checking test 033 fv3_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 033 fv3_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 24.815782
+[0] The total amount of wall time                        = 25.470260
 
 Test 033 fv3_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_read_inc
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_read_inc
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_read_inc
 Checking test 034 fv3_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 034 fv3_read_inc results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.839163
+[0] The total amount of wall time                        = 45.262887
 
 Test 034 fv3_read_inc PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf_esmf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGauss_netcdf_esmf
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGauss_netcdf_esmf
 Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2044,13 +2044,13 @@ Checking test 035 fv3_wrtGauss_netcdf_esmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 151.202704
+[0] The total amount of wall time                        = 157.012077
 
 Test 035 fv3_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGauss_netcdf
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGauss_netcdf
 Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2095,13 +2095,13 @@ Checking test 036 fv3_wrtGauss_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.821903
+[0] The total amount of wall time                        = 45.579757
 
 Test 036 fv3_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGauss_netcdf_parallel
 Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2109,10 +2109,10 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile4.nc .........OK
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -2146,13 +2146,13 @@ Checking test 037 fv3_wrtGauss_netcdf_parallel results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 58.928817
+[0] The total amount of wall time                        = 60.290217
 
 Test 037 fv3_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGlatlon_netcdf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGlatlon_netcdf
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGlatlon_netcdf
 Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2197,13 +2197,13 @@ Checking test 038 fv3_wrtGlatlon_netcdf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.617674
+[0] The total amount of wall time                        = 45.805654
 
 Test 038 fv3_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_nemsio
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGauss_nemsio
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGauss_nemsio
 Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2248,13 +2248,13 @@ Checking test 039 fv3_wrtGauss_nemsio results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.543012
+[0] The total amount of wall time                        = 45.425503
 
 Test 039 fv3_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_wrtGauss_nemsio_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_wrtGauss_nemsio_c192
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_wrtGauss_nemsio_c192
 Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2299,13 +2299,13 @@ Checking test 040 fv3_wrtGauss_nemsio_c192 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 121.032183
+[0] The total amount of wall time                        = 119.443436
 
 Test 040 fv3_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stochy
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_stochy
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_stochy
 Checking test 041 fv3_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2370,13 +2370,13 @@ Checking test 041 fv3_stochy results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 52.090016
+[0] The total amount of wall time                        = 51.809120
 
 Test 041 fv3_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_ca
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_ca
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_ca
 Checking test 042 fv3_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2441,13 +2441,13 @@ Checking test 042 fv3_ca results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 33.804420
+[0] The total amount of wall time                        = 33.687784
 
 Test 042 fv3_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_lndp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_lndp
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_lndp
 Checking test 043 fv3_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2512,13 +2512,13 @@ Checking test 043 fv3_lndp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 52.787368
+[0] The total amount of wall time                        = 53.320254
 
 Test 043 fv3_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_iau
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_iau
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_iau
 Checking test 044 fv3_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2583,13 +2583,13 @@ Checking test 044 fv3_iau results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 44.817221
+[0] The total amount of wall time                        = 44.943932
 
 Test 044 fv3_iau PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_lheatstrg
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_lheatstrg
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_lheatstrg
 Checking test 045 fv3_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 045 fv3_lheatstrg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.198959
+[0] The total amount of wall time                        = 44.926182
 
 Test 045 fv3_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_multigases_repro
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_multigases_repro
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_multigases_repro
 Checking test 046 fv3_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2711,13 +2711,13 @@ Checking test 046 fv3_multigases results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 115.930702
+[0] The total amount of wall time                        = 114.988879
 
 Test 046 fv3_multigases PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control_32bit
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_control_32bit
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_control_32bit
 Checking test 047 fv3_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2782,13 +2782,13 @@ Checking test 047 fv3_control_32bit results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 44.394139
+[0] The total amount of wall time                        = 44.877521
 
 Test 047 fv3_control_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_stretched
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_stretched
 Checking test 048 fv3_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2841,13 +2841,13 @@ Checking test 048 fv3_stretched results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 327.869610
+[0] The total amount of wall time                        = 327.037402
 
 Test 048 fv3_stretched PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched_nest
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_stretched_nest
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_stretched_nest
 Checking test 049 fv3_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2911,13 +2911,13 @@ Checking test 049 fv3_stretched_nest results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing RESTART/sfc_data.nest02.tile7.nc .........OK
 
-[0] The total amount of wall time                        = 351.517973
+[0] The total amount of wall time                        = 349.351664
 
 Test 049 fv3_stretched_nest PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_control
 Checking test 050 fv3_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2925,25 +2925,25 @@ Checking test 050 fv3_regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 264.330130
+[0] The total amount of wall time                        = 263.680091
 
 Test 050 fv3_regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_restart
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_restart
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_restart
 Checking test 051 fv3_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-[0] The total amount of wall time                        = 151.633871
+[0] The total amount of wall time                        = 151.947917
 
 Test 051 fv3_regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_quilt
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_quilt
 Checking test 052 fv3_regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2954,13 +2954,13 @@ Checking test 052 fv3_regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 260.034611
+[0] The total amount of wall time                        = 261.955365
 
 Test 052 fv3_regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_hafs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_quilt_hafs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_quilt_hafs
 Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -2969,27 +2969,27 @@ Checking test 053 fv3_regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 259.179896
+[0] The total amount of wall time                        = 259.396795
 
 Test 053 fv3_regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_quilt_netcdf_parallel
 Checking test 054 fv3_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 428.234054
+[0] The total amount of wall time                        = 429.728370
 
 Test 054 fv3_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_quilt_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_quilt_RRTMGP
 Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -3000,13 +3000,13 @@ Checking test 055 fv3_regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 354.329907
+[0] The total amount of wall time                        = 355.298467
 
 Test 055 fv3_regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmp
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmp
 Checking test 056 fv3_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3051,13 +3051,13 @@ Checking test 056 fv3_gfdlmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 51.779039
+[0] The total amount of wall time                        = 52.040714
 
 Test 056 fv3_gfdlmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_gwd
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmprad_gwd
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmprad_gwd
 Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 057 fv3_gfdlmprad_gwd results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 52.540075
+[0] The total amount of wall time                        = 52.009985
 
 Test 057 fv3_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_noahmp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmprad_noahmp
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmprad_noahmp
 Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3153,13 +3153,13 @@ Checking test 058 fv3_gfdlmprad_noahmp results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 51.907531
+[0] The total amount of wall time                        = 52.391618
 
 Test 058 fv3_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_csawmg
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_csawmg
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_csawmg
 Checking test 059 fv3_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3204,13 +3204,13 @@ Checking test 059 fv3_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 131.200850
+[0] The total amount of wall time                        = 130.114049
 
 Test 059 fv3_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_satmedmf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_satmedmf
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_satmedmf
 Checking test 060 fv3_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3255,13 +3255,13 @@ Checking test 060 fv3_satmedmf results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 56.533298
+[0] The total amount of wall time                        = 56.518794
 
 Test 060 fv3_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_satmedmfq
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_satmedmfq
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_satmedmfq
 Checking test 061 fv3_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3306,13 +3306,13 @@ Checking test 061 fv3_satmedmfq results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 56.254386
+[0] The total amount of wall time                        = 56.394674
 
 Test 061 fv3_satmedmfq PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmp_32bit
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmp_32bit
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmp_32bit
 Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3357,13 +3357,13 @@ Checking test 062 fv3_gfdlmp_32bit results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 45.008842
+[0] The total amount of wall time                        = 44.609141
 
 Test 062 fv3_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_32bit_post
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmprad_32bit_post
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmprad_32bit_post
 Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3412,13 +3412,13 @@ Checking test 063 fv3_gfdlmprad_32bit_post results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 85.421093
+[0] The total amount of wall time                        = 84.802301
 
 Test 063 fv3_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_cpt
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_cpt
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_cpt
 Checking test 064 fv3_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3469,13 +3469,13 @@ Checking test 064 fv3_cpt results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 309.695727
+[0] The total amount of wall time                        = 306.164926
 
 Test 064 fv3_cpt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gsd
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gsd
 Checking test 065 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3564,13 +3564,13 @@ Checking test 065 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 199.195141
+[0] The total amount of wall time                        = 199.081172
 
 Test 065 fv3_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1alpha
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_rrfs_v1alpha
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_rrfs_v1alpha
 Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3635,13 +3635,13 @@ Checking test 066 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.397787
+[0] The total amount of wall time                        = 101.988066
 
 Test 066 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rap
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_rap
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_rap
 Checking test 067 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3706,13 +3706,13 @@ Checking test 067 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 100.982022
+[0] The total amount of wall time                        = 100.235680
 
 Test 067 fv3_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_hrrr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_hrrr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_hrrr
 Checking test 068 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3777,13 +3777,13 @@ Checking test 068 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 100.410119
+[0] The total amount of wall time                        = 100.690889
 
 Test 068 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_thompson
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_thompson
 Checking test 069 fv3_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3848,13 +3848,13 @@ Checking test 069 fv3_thompson results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 92.471298
+[0] The total amount of wall time                        = 91.864834
 
 Test 069 fv3_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_thompson_no_aero
 Checking test 070 fv3_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3919,13 +3919,13 @@ Checking test 070 fv3_thompson_no_aero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 94.732906
+[0] The total amount of wall time                        = 91.794306
 
 Test 070 fv3_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_rrfs_v1beta
 Checking test 071 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3990,13 +3990,13 @@ Checking test 071 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.357873
+[0] The total amount of wall time                        = 101.939860
 
 Test 071 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16
 Checking test 072 fv3_gfs_v16 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4073,13 +4073,13 @@ Checking test 072 fv3_gfs_v16 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 152.807889
+[0] The total amount of wall time                        = 152.826160
 
 Test 072 fv3_gfs_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_restart
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_restart
 Checking test 073 fv3_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4126,13 +4126,13 @@ Checking test 073 fv3_gfs_v16_restart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 93.009408
+[0] The total amount of wall time                        = 92.606551
 
 Test 073 fv3_gfs_v16_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_stochy
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_stochy
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_stochy
 Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4197,13 +4197,13 @@ Checking test 074 fv3_gfs_v16_stochy results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 59.979698
+[0] The total amount of wall time                        = 59.369162
 
 Test 074 fv3_gfs_v16_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_RRTMGP
 Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4280,13 +4280,13 @@ Checking test 075 fv3_gfs_v16_RRTMGP results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 205.922187
+[0] The total amount of wall time                        = 205.373670
 
 Test 075 fv3_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_csawmg
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfsv16_csawmg
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfsv16_csawmg
 Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4331,13 +4331,13 @@ Checking test 076 fv3_gfsv16_csawmg results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 139.180348
+[0] The total amount of wall time                        = 138.906558
 
 Test 076 fv3_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_csawmgt
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfsv16_csawmgt
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfsv16_csawmgt
 Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4382,13 +4382,13 @@ Checking test 077 fv3_gfsv16_csawmgt results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 137.058800
+[0] The total amount of wall time                        = 138.294424
 
 Test 077 fv3_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gocart_clm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gocart_clm
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gocart_clm
 Checking test 078 fv3_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4433,13 +4433,13 @@ Checking test 078 fv3_gocart_clm results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 56.873677
+[0] The total amount of wall time                        = 57.647377
 
 Test 078 fv3_gocart_clm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_flake
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_flake
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_flake
 Checking test 079 fv3_gfs_v16_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4504,13 +4504,13 @@ Checking test 079 fv3_gfs_v16_flake results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 114.195585
+[0] The total amount of wall time                        = 114.666866
 
 Test 079 fv3_gfs_v16_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_HAFS_v0_hwrf_thompson
 Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4575,13 +4575,13 @@ Checking test 080 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 171.852891
+[0] The total amount of wall time                        = 171.753192
 
 Test 080 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4596,13 +4596,13 @@ Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 316.693201
+[0] The total amount of wall time                        = 321.048363
 
 Test 081 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfsv16_ugwpv1
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfsv16_ugwpv1
 Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4661,13 +4661,13 @@ Checking test 082 fv3_gfsv16_ugwpv1 results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 198.800660
+[0] The total amount of wall time                        = 197.480779
 
 Test 082 fv3_gfsv16_ugwpv1 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1_warmstart
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfsv16_ugwpv1_warmstart
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfsv16_ugwpv1_warmstart
 Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4726,13 +4726,13 @@ Checking test 083 fv3_gfsv16_ugwpv1_warmstart results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 198.287206
+[0] The total amount of wall time                        = 197.250293
 
 Test 083 fv3_gfsv16_ugwpv1_warmstart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_ras
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_ras
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_ras
 Checking test 084 fv3_gfs_v16_ras results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4797,13 +4797,13 @@ Checking test 084 fv3_gfs_v16_ras results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 107.913023
+[0] The total amount of wall time                        = 108.478397
 
 Test 084 fv3_gfs_v16_ras PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_debug
 Checking test 085 fv3_gfs_v16_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4868,13 +4868,13 @@ Checking test 085 fv3_gfs_v16_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 282.756352
+[0] The total amount of wall time                        = 282.723320
 
 Test 085 fv3_gfs_v16_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_RRTMGP_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_RRTMGP_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_RRTMGP_debug
 Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -4939,13 +4939,13 @@ Checking test 086 fv3_gfs_v16_RRTMGP_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 270.348861
+[0] The total amount of wall time                        = 271.706767
 
 Test 086 fv3_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_regional_control_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_regional_control_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_regional_control_debug
 Checking test 087 fv3_regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -4953,13 +4953,13 @@ Checking test 087 fv3_regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 400.125850
+[0] The total amount of wall time                        = 400.892857
 
 Test 087 fv3_regional_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_control_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_control_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_control_debug
 Checking test 088 fv3_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -4986,13 +4986,13 @@ Checking test 088 fv3_control_debug results ....
  Comparing dynf006.tile5.nc .........OK
  Comparing dynf006.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 154.789837
+[0] The total amount of wall time                        = 154.584438
 
 Test 088 fv3_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_stretched_nest_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_stretched_nest_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_stretched_nest_debug
 Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -5009,13 +5009,13 @@ Checking test 089 fv3_stretched_nest_debug results ....
  Comparing fv3_history.tile5.nc .........OK
  Comparing fv3_history.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 473.447451
+[0] The total amount of wall time                        = 474.878500
 
 Test 089 fv3_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gsd_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gsd_debug
 Checking test 090 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5080,13 +5080,13 @@ Checking test 090 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 230.810471
+[0] The total amount of wall time                        = 230.344325
 
 Test 090 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gsd_diag3d_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gsd_diag3d_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gsd_diag3d_debug
 Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5151,13 +5151,13 @@ Checking test 091 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 301.219389
+[0] The total amount of wall time                        = 288.514548
 
 Test 091 fv3_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_thompson_debug
 Checking test 092 fv3_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5222,13 +5222,13 @@ Checking test 092 fv3_thompson_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 388.960743
+[0] The total amount of wall time                        = 389.400780
 
 Test 092 fv3_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_thompson_no_aero_debug
 Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5293,13 +5293,13 @@ Checking test 093 fv3_thompson_no_aero_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 375.364046
+[0] The total amount of wall time                        = 374.955099
 
 Test 093 fv3_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_rrfs_v1beta_debug
 Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5364,13 +5364,13 @@ Checking test 094 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 224.202407
+[0] The total amount of wall time                        = 224.114434
 
 Test 094 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_rrfs_v1alpha_debug
 Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5435,13 +5435,13 @@ Checking test 095 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 223.881452
+[0] The total amount of wall time                        = 223.838123
 
 Test 095 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5506,13 +5506,13 @@ Checking test 096 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 237.661380
+[0] The total amount of wall time                        = 236.967603
 
 Test 096 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -5527,13 +5527,13 @@ Checking test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 436.480954
+[0] The total amount of wall time                        = 438.247644
 
 Test 097 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfsv16_ugwpv1_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfsv16_ugwpv1_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfsv16_ugwpv1_debug
 Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -5592,13 +5592,13 @@ Checking test 098 fv3_gfsv16_ugwpv1_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 652.633366
+[0] The total amount of wall time                        = 653.004865
 
 Test 098 fv3_gfsv16_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfs_v16_ras_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfs_v16_ras_debug
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfs_v16_ras_debug
 Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5663,73 +5663,73 @@ Checking test 099 fv3_gfs_v16_ras_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 368.447429
+[0] The total amount of wall time                        = 368.464124
 
 Test 099 fv3_gfs_v16_ras_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_control_cfsr
 Checking test 100 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 107.849408
+[0] The total amount of wall time                        = 107.805877
 
 Test 100 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_restart_cfsr
 Checking test 101 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 77.435583
+[0] The total amount of wall time                        = 77.490013
 
 Test 101 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_control_gefs
 Checking test 102 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 100.741767
+[0] The total amount of wall time                        = 100.720001
 
 Test 102 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_bulk_cfsr
 Checking test 103 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 104.201846
+[0] The total amount of wall time                        = 104.591844
 
 Test 103 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_bulk_gefs
 Checking test 104 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.099108
+[0] The total amount of wall time                        = 100.693166
 
 Test 104 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_mx025_cfsr
 Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5738,13 +5738,13 @@ Checking test 105 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 404.082060
+[0] The total amount of wall time                        = 398.350119
 
 Test 105 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_mx025_gefs
 Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5753,85 +5753,85 @@ Checking test 106 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 399.949142
+[0] The total amount of wall time                        = 396.147172
 
 Test 106 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_debug_cfsr
 Checking test 107 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 311.184002
+[0] The total amount of wall time                        = 310.595626
 
 Test 107 datm_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 175.675901
+[0] The total amount of wall time                        = 174.643159
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 119.940294
+[0] The total amount of wall time                        = 118.819398
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.820627
+[0] The total amount of wall time                        = 168.142896
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_bulk_cfsr
 Checking test 111 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 175.554699
+[0] The total amount of wall time                        = 175.519843
 
 Test 111 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_bulk_gefs
 Checking test 112 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 166.896284
+[0] The total amount of wall time                        = 168.422449
 
 Test 112 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_mx025_cfsr
 Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5840,13 +5840,13 @@ Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 398.264264
+[0] The total amount of wall time                        = 391.138263
 
 Test 113 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_mx025_gefs
 Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5855,25 +5855,25 @@ Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 385.662032
+[0] The total amount of wall time                        = 390.649595
 
 Test 114 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/datm_cdeps_debug_cfsr
 Checking test 115 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 508.966382
+[0] The total amount of wall time                        = 508.581344
 
 Test 115 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmprad
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmprad
 Checking test 116 fv3_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5919,13 +5919,13 @@ Checking test 116 fv3_gfdlmprad results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-[0] The total amount of wall time                        = 352.839659
+[0] The total amount of wall time                        = 352.637197
 
 Test 116 fv3_gfdlmprad PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210506/fv3_gfdlmprad_atmwav
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_71089/fv3_gfdlmprad_atmwav
+working dir  = /gpfs/dell2/ptmp/Chan-Hoo.Jeon/FV3_RT/rt_448606/fv3_gfdlmprad_atmwav
 Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -5971,11 +5971,11 @@ Checking test 117 fv3_gfdlmprad_atmwav results ....
  Comparing RESTART/phy_data.tile6.nc .........OK
  Comparing out_grd.glo_30m .........OK
 
-[0] The total amount of wall time                        = 393.593261
+[0] The total amount of wall time                        = 390.582552
 
 Test 117 fv3_gfdlmprad_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  7 17:00:58 UTC 2021
-Elapsed time: 02h:03m:45s. Have a nice day!
+Tue May 11 11:38:22 UTC 2021
+Elapsed time: 01h:30m:46s. Have a nice day!


### PR DESCRIPTION
## Description
- Add 'netcdf' and 'grib2' to the IC input source options in the regional IC/LBC routines of 'atmos_cubed_sphere'.
- Re-opend PR of https://github.com/ufs-community/ufs-weather-model/pull/526.


### Issue(s) addressed
- Fixes #523 
- Fixes https://github.com/NOAA-EMC/fv3atm/issues/281
- Fixes https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/issues/97


## Testing
- Passed the regression test of the ufs weather model on WCOSS (dell/cray) and Hera with intel compiler.
- Completed a LAMDA test successfully with 'netcdf' input files from GFS.

Regression tests:
- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3


## Dependencies
- https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/96
- waiting on https://github.com/NOAA-EMC/fv3atm/pull/297


## Contributors
@JamesAbeles-NOAA, @EricRogers-NOAA
