### PR TITLE
Add hourly maximum precipitation rate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+#  url = https://github.com/NOAA-EMC/fv3atm
+#  branch = develop
+  url = https://github.com/ericaligo-NOAA/fv3atm.git 
+  branch = feature/pratemax 
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-#  url = https://github.com/NOAA-EMC/fv3atm
-#  branch = develop
-  url = https://github.com/ericaligo-NOAA/fv3atm.git 
-  branch = feature/pratemax 
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,17 +1,17 @@
-Fri Jun 11 14:00:52 MDT 2021
+Tue Jun 15 08:20:27 MDT 2021
 Start Regression test
 
 Compile 001 elapsed time 331 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras
-Compile 002 elapsed time 323 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
-Compile 003 elapsed time 299 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 004 elapsed time 351 seconds. APP=ATM 32BIT=Y DEBUG=Y
-Compile 005 elapsed time 153 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 006 elapsed time 440 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
-Compile 007 elapsed time 225 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled DEBUG=Y
-Compile 008 elapsed time 227 seconds. APP=NG-GODAS-NEMSDATM
+Compile 002 elapsed time 322 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
+Compile 003 elapsed time 300 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 004 elapsed time 360 seconds. APP=ATM 32BIT=Y DEBUG=Y
+Compile 005 elapsed time 156 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 006 elapsed time 437 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
+Compile 007 elapsed time 234 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled DEBUG=Y
+Compile 008 elapsed time 230 seconds. APP=NG-GODAS-NEMSDATM
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,13 +54,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 288.268317
+0:The total amount of wall time                        = 289.947347
 
 Test 001 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -99,13 +99,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 139.695679
+0:The total amount of wall time                        = 140.215543
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_stochy
 Checking test 003 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -116,13 +116,13 @@ Checking test 003 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 176.284460
+0:The total amount of wall time                        = 177.490589
 
 Test 003 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_flake
 Checking test 004 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -133,13 +133,13 @@ Checking test 004 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 358.369294
+0:The total amount of wall time                        = 361.531825
 
 Test 004 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_rrtmgp
 Checking test 005 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -150,13 +150,13 @@ Checking test 005 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 335.870348
+0:The total amount of wall time                        = 354.517490
 
 Test 005 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -167,13 +167,13 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 368.843287
+0:The total amount of wall time                        = 369.662620
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,13 +184,13 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 355.312768
+0:The total amount of wall time                        = 356.359139
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_ugwpv1
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_ugwpv1
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_ugwpv1
 Checking test 008 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -201,13 +201,13 @@ Checking test 008 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 302.089072
+0:The total amount of wall time                        = 310.398884
 
 Test 008 control_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -218,13 +218,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 284.662475
+0:The total amount of wall time                        = 288.119393
 
 Test 009 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_gsd
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_gsd
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_gsd
 Checking test 010 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -313,13 +313,13 @@ Checking test 010 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 353.496338
+0:The total amount of wall time                        = 354.475974
 
 Test 010 fv3_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_rrfs_v1alpha
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_rrfs_v1alpha
 Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -384,13 +384,13 @@ Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.540825
+0:The total amount of wall time                        = 173.120146
 
 Test 011 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_rrfs_v1beta
 Checking test 012 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -455,13 +455,13 @@ Checking test 012 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 169.381538
+0:The total amount of wall time                        = 171.970404
 
 Test 012 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 259.073946
+0:The total amount of wall time                        = 258.782080
 
 Test 013 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -547,26 +547,26 @@ Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 466.975636
+0:The total amount of wall time                        = 465.460526
 
 Test 014 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_debug
 Checking test 015 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.677209
+0:The total amount of wall time                        = 82.401246
 
 Test 015 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/regional_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_regional_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/regional_control_debug
 Checking test 016 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -574,13 +574,13 @@ Checking test 016 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 134.183854
+0:The total amount of wall time                        = 133.370601
 
 Test 016 regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_rrfs_v1alpha_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_rrfs_v1alpha_debug
 Checking test 017 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -645,13 +645,13 @@ Checking test 017 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 110.308916
+0:The total amount of wall time                        = 112.698299
 
 Test 017 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_rrfs_v1beta_debug
 Checking test 018 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -716,13 +716,13 @@ Checking test 018 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 110.422514
+0:The total amount of wall time                        = 112.215863
 
 Test 018 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_gsd_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_gsd_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_gsd_debug
 Checking test 019 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -787,78 +787,78 @@ Checking test 019 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 116.487249
+0:The total amount of wall time                        = 115.840723
 
 Test 019 fv3_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_thompson_debug
 Checking test 020 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 101.685568
+0:The total amount of wall time                        = 101.197349
 
 Test 020 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_thompson_no_aero_debug
 Checking test 021 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 99.808948
+0:The total amount of wall time                        = 97.671214
 
 Test 021 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_rrtmgp_debug
 Checking test 022 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.441882
+0:The total amount of wall time                        = 90.444297
 
 Test 022 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_ugwpv1_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_ugwpv1_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_ugwpv1_debug
 Checking test 023 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 88.739469
+0:The total amount of wall time                        = 88.317064
 
 Test 023 control_ugwpv1_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/control_ras_debug
 Checking test 024 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 84.412968
+0:The total amount of wall time                        = 84.549818
 
 Test 024 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 025 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -923,13 +923,13 @@ Checking test 025 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 112.621419
+0:The total amount of wall time                        = 113.915156
 
 Test 025 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -944,13 +944,13 @@ Checking test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 216.271656
+0:The total amount of wall time                        = 217.968654
 
 Test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/cpld_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/cpld_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/cpld_control
 Checking test 027 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1000,13 +1000,13 @@ Checking test 027 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 118.717689
+0:The total amount of wall time                        = 121.290552
 
 Test 027 cpld_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/GNU/cpld_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_4028/cpld_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/GNU/cpld_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_49928/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1056,11 +1056,11 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 150.621898
+0:The total amount of wall time                        = 150.105733
 
 Test 028 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 14:22:55 MDT 2021
-Elapsed time: 00h:22m:03s. Have a nice day!
+Tue Jun 15 08:42:21 MDT 2021
+Elapsed time: 00h:21m:55s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 11 14:30:54 MDT 2021
+Tue Jun 15 09:03:53 MDT 2021
 Start Regression test
 
-Compile 001 elapsed time 981 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 1030 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-Compile 003 elapsed time 352 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 704 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 005 elapsed time 846 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 006 elapsed time 712 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 007 elapsed time 787 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 728 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 009 elapsed time 257 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 010 elapsed time 227 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 011 elapsed time 233 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 001 elapsed time 988 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 1049 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
+Compile 003 elapsed time 378 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 709 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 005 elapsed time 861 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 006 elapsed time 720 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 007 elapsed time 782 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 731 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 009 elapsed time 260 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 010 elapsed time 229 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 011 elapsed time 234 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
 Compile 012 elapsed time 226 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 013 elapsed time 381 seconds. APP=NG-GODAS-NEMSDATM
-Compile 014 elapsed time 200 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
-Compile 015 elapsed time 395 seconds. APP=NG-GODAS
-Compile 016 elapsed time 202 seconds. APP=NG-GODAS DEBUG=Y
-Compile 017 elapsed time 710 seconds. APP=ATMW SUITES=FV3_GFS_v16
+Compile 013 elapsed time 387 seconds. APP=NG-GODAS-NEMSDATM
+Compile 014 elapsed time 196 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
+Compile 015 elapsed time 402 seconds. APP=NG-GODAS
+Compile 016 elapsed time 201 seconds. APP=NG-GODAS DEBUG=Y
+Compile 017 elapsed time 713 seconds. APP=ATMW SUITES=FV3_GFS_v16
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 93.937132
+0:The total amount of wall time                        = 100.691882
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 52.473608
+0:The total amount of wall time                        = 55.205738
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_decomp
 Checking test 003 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 92.456681
+0:The total amount of wall time                        = 100.704279
 
 Test 003 cpld_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_ca
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_ca
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 95.463566
+0:The total amount of wall time                        = 98.396024
 
 Test 004 cpld_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 391.633615
+0:The total amount of wall time                        = 407.347801
 
 Test 005 cpld_control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_restart_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 279.038817
+0:The total amount of wall time                        = 290.237824
 
 Test 006 cpld_restart_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 859.751263
+0:The total amount of wall time                        = 864.382317
 
 Test 007 cpld_control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_restart_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 468.780316
+0:The total amount of wall time                        = 481.263236
 
 Test 008 cpld_restart_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_bmark_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 846.217766
+0:The total amount of wall time                        = 864.507302
 
 Test 009 cpld_bmark_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_restart_bmark_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 479.296900
+0:The total amount of wall time                        = 478.098157
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16_nsst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_bmark_v16_nsst
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16_nsst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,13 +615,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 850.688044
+0:The total amount of wall time                        = 863.523810
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_bmark_wave_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -666,13 +666,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 916.011819
+0:The total amount of wall time                        = 940.575281
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16_noahmp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_bmark_wave_v16_noahmp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16_noahmp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_bmark_wave_v16_noahmp
 Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -717,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 918.302278
+0:The total amount of wall time                        = 932.690502
 
 Test 013 cpld_bmark_wave_v16_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_wave
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_control_wave
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_wave
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 127.828412
+0:The total amount of wall time                        = 125.861573
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/cpld_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 295.941428
+0:The total amount of wall time                        = 295.978475
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -881,13 +881,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 165.384200
+0:The total amount of wall time                        = 167.565642
 
 Test 016 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -930,13 +930,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.790974
+0:The total amount of wall time                        = 171.638487
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,13 +979,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 352.781102
+0:The total amount of wall time                        = 349.652018
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1024,13 +1024,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 74.876861
+0:The total amount of wall time                        = 74.297031
 
 Test 019 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_CubedSphereGrid
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1057,30 +1057,30 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.983198
+0:The total amount of wall time                        = 140.474299
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 183.040250
+0:The total amount of wall time                        = 183.592879
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 576.707835
+0:The total amount of wall time                        = 586.608765
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1108,13 +1108,13 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1057.443462
+0:The total amount of wall time                        = 1061.396780
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_c384gdas
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384gdas
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1157,13 +1157,13 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 900.926857
+0:The total amount of wall time                        = 915.613777
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1174,13 +1174,13 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 110.775532
+0:The total amount of wall time                        = 112.774729
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_ca
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ca
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_ca
 Checking test 026 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1191,13 +1191,13 @@ Checking test 026 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 109.643810
+0:The total amount of wall time                        = 109.660902
 
 Test 026 control_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_lndp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_lndp
 Checking test 027 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1208,13 +1208,13 @@ Checking test 027 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 112.536618
+0:The total amount of wall time                        = 113.116091
 
 Test 027 control_lndp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_lheatstrg
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_lheatstrg
 Checking test 028 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1225,13 +1225,13 @@ Checking test 028 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 165.641320
+0:The total amount of wall time                        = 167.232122
 
 Test 028 control_lheatstrg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_merra2
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_merra2
 Checking test 029 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1242,13 +1242,13 @@ Checking test 029 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 200.793530
+0:The total amount of wall time                        = 204.257564
 
 Test 029 control_merra2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_rrtmgp
 Checking test 030 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1259,13 +1259,13 @@ Checking test 030 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 269.596715
+0:The total amount of wall time                        = 270.411432
 
 Test 030 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_flake
 Checking test 031 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1276,13 +1276,13 @@ Checking test 031 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 267.682585
+0:The total amount of wall time                        = 269.523863
 
 Test 031 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_ugwpv1
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_ugwpv1
 Checking test 032 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1293,13 +1293,13 @@ Checking test 032 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 222.987632
+0:The total amount of wall time                        = 224.138484
 
 Test 032 control_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_ras
 Checking test 033 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 033 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 198.283569
+0:The total amount of wall time                        = 197.983514
 
 Test 033 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_thompson
 Checking test 034 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1327,13 +1327,13 @@ Checking test 034 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 254.022011
+0:The total amount of wall time                        = 253.657987
 
 Test 034 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_thompson_no_aero
 Checking test 035 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1344,13 +1344,13 @@ Checking test 035 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 243.168450
+0:The total amount of wall time                        = 243.946685
 
 Test 035 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_noahmp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_noahmp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_noahmp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_noahmp
 Checking test 036 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1361,13 +1361,13 @@ Checking test 036 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 192.890813
+0:The total amount of wall time                        = 199.660321
 
 Test 036 control_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_control
 Checking test 037 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1375,25 +1375,25 @@ Checking test 037 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 344.181249
+0:The total amount of wall time                        = 351.707395
 
 Test 037 regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_restart
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_restart
 Checking test 038 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-0:The total amount of wall time                        = 189.186932
+0:The total amount of wall time                        = 192.167570
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_quilt
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_quilt
 Checking test 039 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1404,13 +1404,13 @@ Checking test 039 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 348.028397
+0:The total amount of wall time                        = 346.650869
 
 Test 039 regional_quilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_quilt_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_quilt_2threads
 Checking test 040 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1421,13 +1421,13 @@ Checking test 040 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 930.654222
+0:The total amount of wall time                        = 928.222426
 
 Test 040 regional_quilt_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_quilt_hafs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_hafs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_quilt_hafs
 Checking test 041 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1436,13 +1436,13 @@ Checking test 041 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 347.181242
+0:The total amount of wall time                        = 348.483759
 
 Test 041 regional_quilt_hafs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_quilt_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_quilt_netcdf_parallel
 Checking test 042 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1450,13 +1450,13 @@ Checking test 042 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 348.460514
+0:The total amount of wall time                        = 342.831826
 
 Test 042 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_quilt_RRTMGP
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_quilt_RRTMGP
 Checking test 043 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1467,13 +1467,13 @@ Checking test 043 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 532.028686
+0:The total amount of wall time                        = 495.174042
 
 Test 043 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_gsd
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_gsd
 Checking test 044 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1562,13 +1562,13 @@ Checking test 044 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 195.276501
+0:The total amount of wall time                        = 198.374482
 
 Test 044 fv3_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_rrfs_v1alpha
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_rrfs_v1alpha
 Checking test 045 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1633,13 +1633,13 @@ Checking test 045 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 98.669662
+0:The total amount of wall time                        = 99.241184
 
 Test 045 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rap
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_rap
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rap
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_rap
 Checking test 046 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1704,13 +1704,13 @@ Checking test 046 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 99.292890
+0:The total amount of wall time                        = 99.397361
 
 Test 046 fv3_rap PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_hrrr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_hrrr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_hrrr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_hrrr
 Checking test 047 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1775,13 +1775,13 @@ Checking test 047 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 97.717249
+0:The total amount of wall time                        = 96.989649
 
 Test 047 fv3_hrrr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_rrfs_v1beta
 Checking test 048 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1846,13 +1846,13 @@ Checking test 048 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 97.693710
+0:The total amount of wall time                        = 98.264284
 
 Test 048 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_HAFS_v0_hwrf_thompson
 Checking test 049 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1917,13 +1917,13 @@ Checking test 049 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 195.683917
+0:The total amount of wall time                        = 197.430525
 
 Test 049 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 050 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1938,39 +1938,39 @@ Checking test 050 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 324.275630
+0:The total amount of wall time                        = 325.907360
 
 Test 050 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_debug
 Checking test 051 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.630897
+0:The total amount of wall time                        = 159.313693
 
 Test 051 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_2threads_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_2threads_debug
 Checking test 052 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 271.822759
+0:The total amount of wall time                        = 272.585411
 
 Test 052 control_2threads_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_CubedSphereGrid_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_CubedSphereGrid_debug
 Checking test 053 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1997,169 +1997,169 @@ Checking test 053 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.965830
+0:The total amount of wall time                        = 171.163842
 
 Test 053 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_wrtGauss_netcdf_parallel_debug
 Checking test 054 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 157.984411
+0:The total amount of wall time                        = 161.342758
 
 Test 054 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_stochy_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_stochy_debug
 Checking test 055 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 178.618445
+0:The total amount of wall time                        = 183.263762
 
 Test 055 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_lndp_debug
 Checking test 056 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.569474
+0:The total amount of wall time                        = 163.591104
 
 Test 056 control_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_lheatstrg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_lheatstrg_debug
 Checking test 057 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.992497
+0:The total amount of wall time                        = 155.861617
 
 Test 057 control_lheatstrg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_merra2_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_merra2_debug
 Checking test 058 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 217.399182
+0:The total amount of wall time                        = 206.675800
 
 Test 058 control_merra2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_rrtmgp_debug
 Checking test 059 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.713258
+0:The total amount of wall time                        = 176.528244
 
 Test 059 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_csawmg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_csawmg_debug
 Checking test 060 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 247.973561
+0:The total amount of wall time                        = 251.071404
 
 Test 060 control_csawmg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_csawmgt_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_csawmgt_debug
 Checking test 061 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 278.105251
+0:The total amount of wall time                        = 282.514887
 
 Test 061 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_ugwpv1_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_ugwpv1_debug
 Checking test 062 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.087648
+0:The total amount of wall time                        = 175.083169
 
 Test 062 control_ugwpv1_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_ras_debug
 Checking test 063 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.328442
+0:The total amount of wall time                        = 160.622044
 
 Test 063 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_thompson_debug
 Checking test 064 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.420467
+0:The total amount of wall time                        = 188.727775
 
 Test 064 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_thompson_no_aero_debug
 Checking test 065 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 176.371147
+0:The total amount of wall time                        = 176.533895
 
 Test 065 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/regional_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/regional_control_debug
 Checking test 066 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2167,13 +2167,13 @@ Checking test 066 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 255.375616
+0:The total amount of wall time                        = 255.447857
 
 Test 066 regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_gsd_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_gsd_debug
 Checking test 067 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2238,13 +2238,13 @@ Checking test 067 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 216.820100
+0:The total amount of wall time                        = 218.980159
 
 Test 067 fv3_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_diag3d_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_gsd_diag3d_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_diag3d_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_gsd_diag3d_debug
 Checking test 068 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2309,13 +2309,13 @@ Checking test 068 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 262.351760
+0:The total amount of wall time                        = 262.477880
 
 Test 068 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_rrfs_v1beta_debug
 Checking test 069 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2380,13 +2380,13 @@ Checking test 069 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 232.452892
+0:The total amount of wall time                        = 211.077377
 
 Test 069 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_rrfs_v1alpha_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_rrfs_v1alpha_debug
 Checking test 070 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2451,13 +2451,13 @@ Checking test 070 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 209.550926
+0:The total amount of wall time                        = 212.037248
 
 Test 070 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 071 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2522,13 +2522,13 @@ Checking test 071 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 219.179777
+0:The total amount of wall time                        = 221.462087
 
 Test 071 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2543,73 +2543,73 @@ Checking test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 398.478877
+0:The total amount of wall time                        = 399.722956
 
 Test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_control_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_control_cfsr
 Checking test 073 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 97.741623
+0:The total amount of wall time                        = 98.277115
 
 Test 073 datm_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_restart_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_restart_cfsr
 Checking test 074 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 64.667373
+0:The total amount of wall time                        = 62.381131
 
 Test 074 datm_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_control_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_control_gefs
 Checking test 075 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.269338
+0:The total amount of wall time                        = 96.040408
 
 Test 075 datm_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_bulk_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_bulk_cfsr
 Checking test 076 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.056890
+0:The total amount of wall time                        = 99.138217
 
 Test 076 datm_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_bulk_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_bulk_gefs
 Checking test 077 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.039024
+0:The total amount of wall time                        = 95.707771
 
 Test 077 datm_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_mx025_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_mx025_cfsr
 Checking test 078 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2618,13 +2618,13 @@ Checking test 078 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 371.085265
+0:The total amount of wall time                        = 387.707175
 
 Test 078 datm_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_mx025_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_mx025_gefs
 Checking test 079 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2633,85 +2633,85 @@ Checking test 079 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 385.917838
+0:The total amount of wall time                        = 385.611746
 
 Test 079 datm_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_debug_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_debug_cfsr
 Checking test 080 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 274.713330
+0:The total amount of wall time                        = 276.055539
 
 Test 080 datm_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_control_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_control_cfsr
 Checking test 081 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.207622
+0:The total amount of wall time                        = 165.920627
 
 Test 081 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_restart_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_restart_cfsr
 Checking test 082 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.101512
+0:The total amount of wall time                        = 103.161893
 
 Test 082 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_control_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_control_gefs
 Checking test 083 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.510770
+0:The total amount of wall time                        = 154.291224
 
 Test 083 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_bulk_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_bulk_cfsr
 Checking test 084 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.332767
+0:The total amount of wall time                        = 160.856192
 
 Test 084 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_bulk_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_bulk_gefs
 Checking test 085 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.299257
+0:The total amount of wall time                        = 152.907417
 
 Test 085 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_mx025_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_mx025_cfsr
 Checking test 086 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2720,13 +2720,13 @@ Checking test 086 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 385.542030
+0:The total amount of wall time                        = 390.885803
 
 Test 086 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_mx025_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_mx025_gefs
 Checking test 087 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2735,35 +2735,35 @@ Checking test 087 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 378.139887
+0:The total amount of wall time                        = 382.891709
 
 Test 087 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_multiple_files_cfsr
 Checking test 088 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.328553
+0:The total amount of wall time                        = 166.184515
 
 Test 088 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/datm_cdeps_debug_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/datm_cdeps_debug_cfsr
 Checking test 089 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 452.164162
+0:The total amount of wall time                        = 454.100492
 
 Test 089 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210611/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_57086/control_atmwav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210615/INTEL/control_atmwav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_65130/control_atmwav
 Checking test 090 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2806,11 +2806,11 @@ Checking test 090 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 373.478363
+0:The total amount of wall time                        = 377.114385
 
 Test 090 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 15:25:42 MDT 2021
-Elapsed time: 00h:54m:48s. Have a nice day!
+Tue Jun 15 09:57:34 MDT 2021
+Elapsed time: 00h:53m:42s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,26 +1,26 @@
-Sun Jun 13 12:07:46 EDT 2021
+Tue Jun 15 10:56:19 EDT 2021
 Start Regression test
 
-Compile 001 elapsed time 799 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 777 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-Compile 003 elapsed time 306 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 722 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 005 elapsed time 763 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 006 elapsed time 687 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 007 elapsed time 722 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 722 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 009 elapsed time 297 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 010 elapsed time 262 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 011 elapsed time 287 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 012 elapsed time 259 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 013 elapsed time 326 seconds. APP=NG-GODAS-NEMSDATM
-Compile 014 elapsed time 215 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
-Compile 015 elapsed time 334 seconds. APP=NG-GODAS
-Compile 016 elapsed time 221 seconds. APP=NG-GODAS DEBUG=Y
-Compile 017 elapsed time 717 seconds. APP=ATMW SUITES=FV3_GFS_v16
+Compile 001 elapsed time 777 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 816 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
+Compile 003 elapsed time 308 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 698 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 005 elapsed time 725 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 006 elapsed time 699 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 007 elapsed time 685 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 724 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 009 elapsed time 264 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 010 elapsed time 255 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 011 elapsed time 248 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 012 elapsed time 241 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 013 elapsed time 325 seconds. APP=NG-GODAS-NEMSDATM
+Compile 014 elapsed time 216 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
+Compile 015 elapsed time 323 seconds. APP=NG-GODAS
+Compile 016 elapsed time 214 seconds. APP=NG-GODAS DEBUG=Y
+Compile 017 elapsed time 690 seconds. APP=ATMW SUITES=FV3_GFS_v16
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 101.080954
+The total amount of wall time                        = 95.223374
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 49.072813
+The total amount of wall time                        = 75.030348
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_decomp
 Checking test 003 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 102.000609
+The total amount of wall time                        = 88.277866
 
 Test 003 cpld_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_ca
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 96.565870
+The total amount of wall time                        = 89.382243
 
 Test 004 cpld_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 415.200649
+The total amount of wall time                        = 429.833806
 
 Test 005 cpld_control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_restart_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 315.645639
+The total amount of wall time                        = 306.715854
 
 Test 006 cpld_restart_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 844.510306
+The total amount of wall time                        = 838.311634
 
 Test 007 cpld_control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_restart_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 452.309147
+The total amount of wall time                        = 429.044379
 
 Test 008 cpld_restart_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_bmark_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 824.818633
+The total amount of wall time                        = 823.817969
 
 Test 009 cpld_bmark_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_restart_bmark_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 449.504751
+The total amount of wall time                        = 474.729071
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16_nsst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_bmark_v16_nsst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16_nsst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,13 +615,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 828.321872
+The total amount of wall time                        = 848.128093
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_bmark_wave_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -666,13 +666,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 901.032135
+The total amount of wall time                        = 894.310674
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_bmark_wave_v16_noahmp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16_noahmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_bmark_wave_v16_noahmp
 Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -717,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 900.002378
+The total amount of wall time                        = 895.405802
 
 Test 013 cpld_bmark_wave_v16_noahmp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_control_wave
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 110.153293
+The total amount of wall time                        = 111.767401
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/cpld_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 270.205980
+The total amount of wall time                        = 267.976413
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -881,13 +881,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 166.925356
+The total amount of wall time                        = 165.151251
 
 Test 016 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -930,13 +930,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 171.114560
+The total amount of wall time                        = 170.275094
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,13 +979,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 204.353998
+The total amount of wall time                        = 204.716118
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1024,13 +1024,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 67.564501
+The total amount of wall time                        = 100.547535
 
 Test 019 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1057,13 +1057,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 128.365840
+The total amount of wall time                        = 126.196474
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1074,13 +1074,13 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 495.082855
+The total amount of wall time                        = 290.459546
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 530.447962
+The total amount of wall time                        = 547.840290
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_stochy
 Checking test 023 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1108,13 +1108,13 @@ Checking test 023 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 121.769230
+The total amount of wall time                        = 118.485514
 
 Test 023 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_ca
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_ca
 Checking test 024 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1125,13 +1125,13 @@ Checking test 024 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 118.785984
+The total amount of wall time                        = 117.273092
 
 Test 024 control_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_lndp
 Checking test 025 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1142,13 +1142,13 @@ Checking test 025 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 121.557987
+The total amount of wall time                        = 120.300034
 
 Test 025 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_lheatstrg
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_lheatstrg
 Checking test 026 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1159,13 +1159,13 @@ Checking test 026 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 167.452428
+The total amount of wall time                        = 167.008982
 
 Test 026 control_lheatstrg PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_merra2
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_merra2
 Checking test 027 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1176,13 +1176,13 @@ Checking test 027 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 293.530576
+The total amount of wall time                        = 196.103966
 
 Test 027 control_merra2 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_rrtmgp
 Checking test 028 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1193,13 +1193,13 @@ Checking test 028 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 219.355510
+The total amount of wall time                        = 246.139816
 
 Test 028 control_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_csawmg
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_csawmg
 Checking test 029 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1210,13 +1210,13 @@ Checking test 029 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 355.181751
+The total amount of wall time                        = 297.715195
 
 Test 029 control_csawmg PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_csawmgt
 Checking test 030 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1227,13 +1227,13 @@ Checking test 030 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 369.981780
+The total amount of wall time                        = 356.772632
 
 Test 030 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_flake
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_flake
 Checking test 031 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1244,13 +1244,13 @@ Checking test 031 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 243.848209
+The total amount of wall time                        = 241.597407
 
 Test 031 control_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_ugwpv1
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_ugwpv1
 Checking test 032 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 032 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 200.015097
+The total amount of wall time                        = 198.974182
 
 Test 032 control_ugwpv1 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_ras
 Checking test 033 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1278,13 +1278,13 @@ Checking test 033 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 190.656601
+The total amount of wall time                        = 217.535297
 
 Test 033 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_thompson
 Checking test 034 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1295,13 +1295,13 @@ Checking test 034 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 262.520418
+The total amount of wall time                        = 221.687864
 
 Test 034 control_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_thompson_no_aero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_thompson_no_aero
 Checking test 035 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1312,13 +1312,13 @@ Checking test 035 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 211.666538
+The total amount of wall time                        = 212.157651
 
 Test 035 control_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_noahmp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_noahmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_noahmp
 Checking test 036 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1329,13 +1329,13 @@ Checking test 036 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 190.614716
+The total amount of wall time                        = 197.595127
 
 Test 036 control_noahmp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_control
 Checking test 037 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1343,25 +1343,25 @@ Checking test 037 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 329.772949
+The total amount of wall time                        = 327.941250
 
 Test 037 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_restart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_restart
 Checking test 038 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 176.888434
+The total amount of wall time                        = 182.769017
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_quilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_quilt
 Checking test 039 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 039 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 329.859757
+The total amount of wall time                        = 327.794213
 
 Test 039 regional_quilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_quilt_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_quilt_2threads
 Checking test 040 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1389,13 +1389,13 @@ Checking test 040 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 279.825243
+The total amount of wall time                        = 279.791345
 
 Test 040 regional_quilt_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_quilt_hafs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_quilt_hafs
 Checking test 041 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1404,13 +1404,13 @@ Checking test 041 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 329.507006
+The total amount of wall time                        = 326.894779
 
 Test 041 regional_quilt_hafs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_quilt_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_quilt_netcdf_parallel
 Checking test 042 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1418,13 +1418,13 @@ Checking test 042 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 505.708205
+The total amount of wall time                        = 373.314252
 
 Test 042 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_quilt_RRTMGP
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_quilt_RRTMGP
 Checking test 043 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1435,13 +1435,13 @@ Checking test 043 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 466.846282
+The total amount of wall time                        = 465.765804
 
 Test 043 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_gsd
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_gsd
 Checking test 044 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1530,13 +1530,13 @@ Checking test 044 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 183.432927
+The total amount of wall time                        = 185.947088
 
 Test 044 fv3_gsd PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_rrfs_v1alpha
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_rrfs_v1alpha
 Checking test 045 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1601,13 +1601,13 @@ Checking test 045 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 98.047922
+The total amount of wall time                        = 98.570635
 
 Test 045 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rap
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_rap
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rap
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_rap
 Checking test 046 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1672,13 +1672,13 @@ Checking test 046 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.998173
+The total amount of wall time                        = 91.824229
 
 Test 046 fv3_rap PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_hrrr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_hrrr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_hrrr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_hrrr
 Checking test 047 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1743,13 +1743,13 @@ Checking test 047 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 89.544243
+The total amount of wall time                        = 119.680732
 
 Test 047 fv3_hrrr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_rrfs_v1beta
 Checking test 048 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1814,13 +1814,13 @@ Checking test 048 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 92.950227
+The total amount of wall time                        = 120.281953
 
 Test 048 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_HAFS_v0_hwrf_thompson
 Checking test 049 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1885,13 +1885,13 @@ Checking test 049 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 190.643408
+The total amount of wall time                        = 187.806893
 
 Test 049 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 050 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1906,39 +1906,39 @@ Checking test 050 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 325.484132
+The total amount of wall time                        = 333.330842
 
 Test 050 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_debug
 Checking test 051 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.121847
+The total amount of wall time                        = 146.397291
 
 Test 051 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_2threads_debug
 Checking test 052 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 260.300906
+The total amount of wall time                        = 260.087912
 
 Test 052 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_CubedSphereGrid_debug
 Checking test 053 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1965,169 +1965,169 @@ Checking test 053 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 158.868615
+The total amount of wall time                        = 158.124075
 
 Test 053 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_wrtGauss_netcdf_parallel_debug
 Checking test 054 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 174.974109
+The total amount of wall time                        = 159.266467
 
 Test 054 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_stochy_debug
 Checking test 055 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 175.967663
+The total amount of wall time                        = 167.416292
 
 Test 055 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_lndp_debug
 Checking test 056 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 152.780789
+The total amount of wall time                        = 149.728583
 
 Test 056 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_lheatstrg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_lheatstrg_debug
 Checking test 057 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.862235
+The total amount of wall time                        = 145.530205
 
 Test 057 control_lheatstrg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_merra2_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_merra2_debug
 Checking test 058 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.523284
+The total amount of wall time                        = 191.152244
 
 Test 058 control_merra2_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_rrtmgp_debug
 Checking test 059 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.435423
+The total amount of wall time                        = 165.178993
 
 Test 059 control_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_csawmg_debug
 Checking test 060 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.848377
+The total amount of wall time                        = 271.404182
 
 Test 060 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_csawmgt_debug
 Checking test 061 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 342.990039
+The total amount of wall time                        = 277.689605
 
 Test 061 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_ugwpv1_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_ugwpv1_debug
 Checking test 062 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.258617
+The total amount of wall time                        = 169.034397
 
 Test 062 control_ugwpv1_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_ras_debug
 Checking test 063 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.957048
+The total amount of wall time                        = 147.410897
 
 Test 063 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_thompson_debug
 Checking test 064 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 178.360120
+The total amount of wall time                        = 172.020015
 
 Test 064 control_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_thompson_no_aero_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_thompson_no_aero_debug
 Checking test 065 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 173.027216
+The total amount of wall time                        = 165.908180
 
 Test 065 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/regional_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/regional_control_debug
 Checking test 066 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2135,13 +2135,13 @@ Checking test 066 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 258.421346
+The total amount of wall time                        = 286.597434
 
 Test 066 regional_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_gsd_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_gsd_debug
 Checking test 067 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2206,13 +2206,13 @@ Checking test 067 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 208.077843
+The total amount of wall time                        = 203.935636
 
 Test 067 fv3_gsd_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_diag3d_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_gsd_diag3d_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_diag3d_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_gsd_diag3d_debug
 Checking test 068 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2277,13 +2277,13 @@ Checking test 068 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 245.620788
+The total amount of wall time                        = 238.772944
 
 Test 068 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_rrfs_v1beta_debug
 Checking test 069 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2348,13 +2348,13 @@ Checking test 069 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 202.492774
+The total amount of wall time                        = 198.472923
 
 Test 069 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_rrfs_v1alpha_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_rrfs_v1alpha_debug
 Checking test 070 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2419,13 +2419,13 @@ Checking test 070 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 199.779802
+The total amount of wall time                        = 199.075000
 
 Test 070 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 071 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2490,13 +2490,13 @@ Checking test 071 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 214.116581
+The total amount of wall time                        = 237.491736
 
 Test 071 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2511,73 +2511,73 @@ Checking test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 382.590366
+The total amount of wall time                        = 378.631718
 
 Test 072 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_control_cfsr
 Checking test 073 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 100.801257
+The total amount of wall time                        = 98.531443
 
 Test 073 datm_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_restart_cfsr
 Checking test 074 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 56.211570
+The total amount of wall time                        = 58.452314
 
 Test 074 datm_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_control_gefs
 Checking test 075 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 124.644612
+The total amount of wall time                        = 92.574117
 
 Test 075 datm_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_bulk_cfsr
 Checking test 076 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 129.611810
+The total amount of wall time                        = 93.874249
 
 Test 076 datm_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_bulk_gefs
 Checking test 077 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 119.468375
+The total amount of wall time                        = 128.130016
 
 Test 077 datm_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_mx025_gefs
 Checking test 078 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2586,85 +2586,85 @@ Checking test 078 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 411.514912
+The total amount of wall time                        = 382.548121
 
 Test 078 datm_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_debug_cfsr
 Checking test 079 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 223.443238
+The total amount of wall time                        = 221.225355
 
 Test 079 datm_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_control_cfsr
 Checking test 080 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 152.870842
+The total amount of wall time                        = 149.414539
 
 Test 080 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_restart_cfsr
 Checking test 081 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 119.723769
+The total amount of wall time                        = 86.110684
 
 Test 081 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_control_gefs
 Checking test 082 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 149.037439
+The total amount of wall time                        = 146.014065
 
 Test 082 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_bulk_cfsr
 Checking test 083 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 149.219747
+The total amount of wall time                        = 149.513916
 
 Test 083 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_bulk_gefs
 Checking test 084 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 144.989585
+The total amount of wall time                        = 144.629942
 
 Test 084 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_mx025_gefs
 Checking test 085 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2673,35 +2673,35 @@ Checking test 085 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 407.602551
+The total amount of wall time                        = 392.865413
 
 Test 085 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_multiple_files_cfsr
 Checking test 086 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 150.103062
+The total amount of wall time                        = 150.113018
 
 Test 086 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/datm_cdeps_debug_cfsr
 Checking test 087 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 360.784573
+The total amount of wall time                        = 360.402676
 
 Test 087 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6919/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_37069/control_atmwav
 Checking test 088 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2744,11 +2744,11 @@ Checking test 088 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 349.521371
+The total amount of wall time                        = 372.918257
 
 Test 088 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Jun 13 13:43:31 EDT 2021
-Elapsed time: 01h:35m:46s. Have a nice day!
+Tue Jun 15 12:07:36 EDT 2021
+Elapsed time: 01h:11m:18s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,17 @@
-Fri Jun 11 20:02:19 UTC 2021
+Tue Jun 15 14:41:25 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 178 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras
-Compile 002 elapsed time 177 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
-Compile 003 elapsed time 172 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 004 elapsed time 160 seconds. APP=ATM 32BIT=Y DEBUG=Y
-Compile 005 elapsed time 87 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 006 elapsed time 195 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
-Compile 007 elapsed time 108 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled DEBUG=Y
-Compile 008 elapsed time 92 seconds. APP=NG-GODAS-NEMSDATM
+Compile 001 elapsed time 239 seconds. APP=ATM SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras
+Compile 002 elapsed time 245 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta 32BIT=Y
+Compile 003 elapsed time 211 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 004 elapsed time 256 seconds. APP=ATM 32BIT=Y DEBUG=Y
+Compile 005 elapsed time 112 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 006 elapsed time 245 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled
+Compile 007 elapsed time 227 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled DEBUG=Y
+Compile 008 elapsed time 184 seconds. APP=NG-GODAS-NEMSDATM
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,13 +54,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 831.884345
+  0: The total amount of wall time                        = 1040.748503
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -99,13 +99,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 389.703685
+  0: The total amount of wall time                        = 391.182371
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_stochy
 Checking test 003 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -116,13 +116,13 @@ Checking test 003 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 635.985769
+  0: The total amount of wall time                        = 636.044727
 
 Test 003 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_flake
 Checking test 004 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -133,13 +133,13 @@ Checking test 004 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1418.467823
+  0: The total amount of wall time                        = 1398.555175
 
 Test 004 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_rrtmgp
 Checking test 005 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -150,13 +150,13 @@ Checking test 005 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 873.921772
+  0: The total amount of wall time                        = 881.229090
 
 Test 005 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -167,13 +167,13 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1009.068447
+  0: The total amount of wall time                        = 1036.669333
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,13 +184,13 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 993.423124
+  0: The total amount of wall time                        = 978.803164
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_ugwpv1
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_ugwpv1
 Checking test 008 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -201,13 +201,13 @@ Checking test 008 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 939.673264
+  0: The total amount of wall time                        = 971.502521
 
 Test 008 control_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -218,13 +218,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 814.380189
+  0: The total amount of wall time                        = 844.508867
 
 Test 009 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_gsd
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_gsd
 Checking test 010 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -313,13 +313,13 @@ Checking test 010 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 803.390341
+  0: The total amount of wall time                        = 831.266478
 
 Test 010 fv3_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_rrfs_v1alpha
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_rrfs_v1alpha
 Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -384,13 +384,13 @@ Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 384.528217
+  0: The total amount of wall time                        = 403.100170
 
 Test 011 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_rrfs_v1beta
 Checking test 012 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -455,13 +455,13 @@ Checking test 012 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 402.723381
+  0: The total amount of wall time                        = 376.018096
 
 Test 012 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 601.695309
+  0: The total amount of wall time                        = 612.480185
 
 Test 013 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -547,26 +547,26 @@ Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 445.767068
+ 0: The total amount of wall time                        = 448.476366
 
 Test 014 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_debug
 Checking test 015 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.686803
+  0: The total amount of wall time                        = 144.422674
 
 Test 015 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/regional_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/regional_control_debug
 Checking test 016 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -574,13 +574,13 @@ Checking test 016 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 117.357111
+ 0: The total amount of wall time                        = 125.548068
 
 Test 016 regional_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_rrfs_v1alpha_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_rrfs_v1alpha_debug
 Checking test 017 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -645,13 +645,13 @@ Checking test 017 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.745826
+  0: The total amount of wall time                        = 134.039081
 
 Test 017 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_rrfs_v1beta_debug
 Checking test 018 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -716,13 +716,13 @@ Checking test 018 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 121.907839
+  0: The total amount of wall time                        = 130.987572
 
 Test 018 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_gsd_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_gsd_debug
 Checking test 019 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -787,78 +787,78 @@ Checking test 019 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.055466
+  0: The total amount of wall time                        = 129.480702
 
 Test 019 fv3_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_thompson_debug
 Checking test 020 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 119.590484
+  0: The total amount of wall time                        = 126.168710
 
 Test 020 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_thompson_no_aero_debug
 Checking test 021 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 116.155431
+  0: The total amount of wall time                        = 123.341270
 
 Test 021 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_rrtmgp_debug
 Checking test 022 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 109.564525
+  0: The total amount of wall time                        = 133.554061
 
 Test 022 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_ugwpv1_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_ugwpv1_debug
 Checking test 023 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 106.783381
+  0: The total amount of wall time                        = 119.573343
 
 Test 023 control_ugwpv1_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/control_ras_debug
 Checking test 024 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 103.140078
+  0: The total amount of wall time                        = 108.754096
 
 Test 024 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 025 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -923,13 +923,13 @@ Checking test 025 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.801316
+  0: The total amount of wall time                        = 144.281576
 
 Test 025 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -944,13 +944,13 @@ Checking test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 237.999091
+ 0: The total amount of wall time                        = 245.626458
 
 Test 026 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/cpld_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/cpld_control
 Checking test 027 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1000,13 +1000,13 @@ Checking test 027 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 656.520893
+  0: The total amount of wall time                        = 732.799766
 
 Test 027 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/GNU/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_282206/cpld_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/GNU/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_62510/cpld_debug
 Checking test 028 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1056,11 +1056,11 @@ Checking test 028 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 370.284211
+  0: The total amount of wall time                        = 402.138504
 
 Test 028 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 20:44:40 UTC 2021
-Elapsed time: 00h:42m:21s. Have a nice day!
+Tue Jun 15 16:32:58 UTC 2021
+Elapsed time: 01h:51m:33s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 11 20:32:32 UTC 2021
+Tue Jun 15 15:50:08 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 564 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 595 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-Compile 003 elapsed time 227 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 512 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 005 elapsed time 535 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 006 elapsed time 515 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 007 elapsed time 517 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 519 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 009 elapsed time 204 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 010 elapsed time 163 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 011 elapsed time 190 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 012 elapsed time 193 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 013 elapsed time 187 seconds. APP=NG-GODAS-NEMSDATM
-Compile 014 elapsed time 87 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
-Compile 015 elapsed time 170 seconds. APP=NG-GODAS
-Compile 016 elapsed time 84 seconds. APP=NG-GODAS DEBUG=Y
-Compile 017 elapsed time 549 seconds. APP=ATMW SUITES=FV3_GFS_v16
+Compile 001 elapsed time 579 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 647 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
+Compile 003 elapsed time 204 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 546 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 005 elapsed time 574 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 006 elapsed time 724 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 007 elapsed time 700 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 548 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 009 elapsed time 173 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 010 elapsed time 564 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 011 elapsed time 211 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 012 elapsed time 199 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 013 elapsed time 194 seconds. APP=NG-GODAS-NEMSDATM
+Compile 014 elapsed time 380 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
+Compile 015 elapsed time 225 seconds. APP=NG-GODAS
+Compile 016 elapsed time 97 seconds. APP=NG-GODAS DEBUG=Y
+Compile 017 elapsed time 522 seconds. APP=ATMW SUITES=FV3_GFS_v16
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.942992
+  0: The total amount of wall time                        = 99.162925
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 60.201542
+  0: The total amount of wall time                        = 55.824354
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_decomp
 Checking test 003 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 106.374735
+  0: The total amount of wall time                        = 99.040150
 
 Test 003 cpld_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_ca
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.312468
+  0: The total amount of wall time                        = 96.838727
 
 Test 004 cpld_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 522.330694
+  0: The total amount of wall time                        = 433.081149
 
 Test 005 cpld_control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_restart_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 350.046638
+  0: The total amount of wall time                        = 278.890556
 
 Test 006 cpld_restart_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 782.712614
+  0: The total amount of wall time                        = 806.628911
 
 Test 007 cpld_control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_restart_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 485.290320
+  0: The total amount of wall time                        = 478.801396
 
 Test 008 cpld_restart_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_bmark_v16
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 774.280971
+  0: The total amount of wall time                        = 794.826194
 
 Test 009 cpld_bmark_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_restart_bmark_v16
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 518.059495
+  0: The total amount of wall time                        = 503.636765
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16_nsst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_bmark_v16_nsst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16_nsst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,15 +615,64 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 849.588159
+  0: The total amount of wall time                        = 807.486100
 
 Test 011 cpld_bmark_v16_nsst PASS
 
-Test 012 cpld_bmark_wave_v16 FAIL
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_bmark_wave_v16
+Checking test 012 cpld_bmark_wave_v16 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing 20130401.060000.out_grd.gwes_30m .........OK
+ Comparing 20130401.060000.out_pnt.points .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+
+  0: The total amount of wall time                        = 826.625450
+
+Test 012 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_bmark_wave_v16_noahmp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_bmark_wave_v16_noahmp
 Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -668,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 810.401565
+  0: The total amount of wall time                        = 807.215807
 
 Test 013 cpld_bmark_wave_v16_noahmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_control_wave
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_wave
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -727,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 112.331410
+  0: The total amount of wall time                        = 138.676671
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/cpld_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -783,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 278.443087
+  0: The total amount of wall time                        = 285.409704
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -832,13 +881,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 150.505159
+  0: The total amount of wall time                        = 210.582404
 
 Test 016 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -881,13 +930,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.797818
+  0: The total amount of wall time                        = 184.376068
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -930,13 +979,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 163.035910
+ 0: The total amount of wall time                        = 388.626921
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -975,13 +1024,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 66.425386
+  0: The total amount of wall time                        = 66.292897
 
 Test 019 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1008,13 +1057,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.562955
+  0: The total amount of wall time                        = 212.037627
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1025,13 +1074,13 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 167.310543
+  0: The total amount of wall time                        = 171.651534
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1042,13 +1091,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 478.115406
+  0: The total amount of wall time                        = 491.925523
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1059,13 +1108,13 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 768.229393
+  0: The total amount of wall time                        = 773.243664
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1108,13 +1157,13 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 645.516160
+  0: The total amount of wall time                        = 641.636637
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1125,13 +1174,13 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 108.205678
+  0: The total amount of wall time                        = 145.622969
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_ca
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_ca
 Checking test 026 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1142,13 +1191,13 @@ Checking test 026 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 109.062150
+  0: The total amount of wall time                        = 131.954771
 
 Test 026 control_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_lndp
 Checking test 027 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1159,13 +1208,13 @@ Checking test 027 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 112.908100
+  0: The total amount of wall time                        = 159.289264
 
 Test 027 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_lheatstrg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_lheatstrg
 Checking test 028 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1176,13 +1225,13 @@ Checking test 028 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 154.951744
+  0: The total amount of wall time                        = 191.052890
 
 Test 028 control_lheatstrg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_merra2
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_merra2
 Checking test 029 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1193,13 +1242,13 @@ Checking test 029 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 176.691705
+  0: The total amount of wall time                        = 198.594714
 
 Test 029 control_merra2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_rrtmgp
 Checking test 030 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1210,13 +1259,13 @@ Checking test 030 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 197.353606
+  0: The total amount of wall time                        = 219.071767
 
 Test 030 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_csawmg
 Checking test 031 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1227,13 +1276,13 @@ Checking test 031 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 284.974535
+  0: The total amount of wall time                        = 293.773763
 
 Test 031 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_csawmgt
 Checking test 032 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1244,13 +1293,13 @@ Checking test 032 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 348.002562
+  0: The total amount of wall time                        = 333.252826
 
 Test 032 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_flake
 Checking test 033 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1261,13 +1310,13 @@ Checking test 033 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 243.587268
+  0: The total amount of wall time                        = 247.210876
 
 Test 033 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_ugwpv1
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_ugwpv1
 Checking test 034 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1278,13 +1327,13 @@ Checking test 034 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.984228
+  0: The total amount of wall time                        = 214.332622
 
 Test 034 control_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_ras
 Checking test 035 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1295,13 +1344,13 @@ Checking test 035 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.808762
+  0: The total amount of wall time                        = 189.194967
 
 Test 035 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_thompson
 Checking test 036 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1312,13 +1361,13 @@ Checking test 036 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 259.448954
+  0: The total amount of wall time                        = 223.842511
 
 Test 036 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_thompson_no_aero
 Checking test 037 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1329,13 +1378,13 @@ Checking test 037 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.484046
+  0: The total amount of wall time                        = 218.376349
 
 Test 037 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_noahmp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_noahmp
 Checking test 038 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1346,13 +1395,13 @@ Checking test 038 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.555940
+  0: The total amount of wall time                        = 193.001400
 
 Test 038 control_noahmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_control
 Checking test 039 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1360,25 +1409,25 @@ Checking test 039 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 288.683774
+ 0: The total amount of wall time                        = 292.254209
 
 Test 039 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_restart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_restart
 Checking test 040 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 181.913628
+ 0: The total amount of wall time                        = 169.910136
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_quilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_quilt
 Checking test 041 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1389,13 +1438,13 @@ Checking test 041 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 291.676384
+ 0: The total amount of wall time                        = 317.643346
 
 Test 041 regional_quilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_quilt_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_quilt_2threads
 Checking test 042 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1406,13 +1455,13 @@ Checking test 042 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 216.073093
+ 0: The total amount of wall time                        = 237.127462
 
 Test 042 regional_quilt_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_quilt_hafs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_quilt_hafs
 Checking test 043 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1421,27 +1470,27 @@ Checking test 043 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 289.233014
+ 0: The total amount of wall time                        = 302.833891
 
 Test 043 regional_quilt_hafs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_quilt_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_quilt_netcdf_parallel
 Checking test 044 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 289.628377
+ 0: The total amount of wall time                        = 291.875009
 
 Test 044 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_quilt_RRTMGP
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_quilt_RRTMGP
 Checking test 045 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1452,13 +1501,13 @@ Checking test 045 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 380.668780
+ 0: The total amount of wall time                        = 388.935003
 
 Test 045 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_gsd
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_gsd
 Checking test 046 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1547,13 +1596,13 @@ Checking test 046 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.323028
+  0: The total amount of wall time                        = 176.736737
 
 Test 046 fv3_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_rrfs_v1alpha
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_rrfs_v1alpha
 Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1618,13 +1667,13 @@ Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.753081
+  0: The total amount of wall time                        = 95.083978
 
 Test 047 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rap
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_rap
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rap
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_rap
 Checking test 048 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1689,13 +1738,13 @@ Checking test 048 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.271303
+  0: The total amount of wall time                        = 91.861037
 
 Test 048 fv3_rap PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_hrrr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_hrrr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_hrrr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_hrrr
 Checking test 049 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1760,13 +1809,13 @@ Checking test 049 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.865015
+  0: The total amount of wall time                        = 89.998350
 
 Test 049 fv3_hrrr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_rrfs_v1beta
 Checking test 050 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1831,13 +1880,13 @@ Checking test 050 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 121.785830
+  0: The total amount of wall time                        = 91.546852
 
 Test 050 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_HAFS_v0_hwrf_thompson
 Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1902,13 +1951,13 @@ Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 184.895964
+  0: The total amount of wall time                        = 145.449988
 
 Test 051 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1923,39 +1972,39 @@ Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 347.467468
+ 0: The total amount of wall time                        = 284.905770
 
 Test 052 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_debug
 Checking test 053 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.519783
+  0: The total amount of wall time                        = 157.148488
 
 Test 053 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_2threads_debug
 Checking test 054 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 210.121099
+ 0: The total amount of wall time                        = 228.740856
 
 Test 054 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_CubedSphereGrid_debug
 Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1982,169 +2031,169 @@ Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.083858
+  0: The total amount of wall time                        = 179.053747
 
 Test 055 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_wrtGauss_netcdf_parallel_debug
 Checking test 056 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 147.225750
+  0: The total amount of wall time                        = 180.790800
 
 Test 056 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_stochy_debug
 Checking test 057 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.464307
+  0: The total amount of wall time                        = 182.755404
 
 Test 057 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_lndp_debug
 Checking test 058 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.896023
+  0: The total amount of wall time                        = 191.104590
 
 Test 058 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_lheatstrg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_lheatstrg_debug
 Checking test 059 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 143.881542
+  0: The total amount of wall time                        = 164.493929
 
 Test 059 control_lheatstrg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_merra2_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_merra2_debug
 Checking test 060 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.066068
+  0: The total amount of wall time                        = 221.491137
 
 Test 060 control_merra2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_rrtmgp_debug
 Checking test 061 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.149281
+  0: The total amount of wall time                        = 164.634166
 
 Test 061 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_csawmg_debug
 Checking test 062 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 225.472536
+  0: The total amount of wall time                        = 225.144999
 
 Test 062 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_csawmgt_debug
 Checking test 063 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.571004
+  0: The total amount of wall time                        = 276.292150
 
 Test 063 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_ugwpv1_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_ugwpv1_debug
 Checking test 064 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.671118
+  0: The total amount of wall time                        = 158.254218
 
 Test 064 control_ugwpv1_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_ras_debug
 Checking test 065 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.561140
+  0: The total amount of wall time                        = 194.391392
 
 Test 065 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_thompson_debug
 Checking test 066 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.981078
+  0: The total amount of wall time                        = 175.214172
 
 Test 066 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_thompson_no_aero_debug
 Checking test 067 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.816907
+  0: The total amount of wall time                        = 169.456223
 
 Test 067 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/regional_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/regional_control_debug
 Checking test 068 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2152,13 +2201,13 @@ Checking test 068 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 228.319684
+ 0: The total amount of wall time                        = 225.699454
 
 Test 068 regional_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_gsd_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_gsd_debug
 Checking test 069 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2223,13 +2272,13 @@ Checking test 069 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.233923
+  0: The total amount of wall time                        = 202.591314
 
 Test 069 fv3_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_diag3d_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_gsd_diag3d_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_diag3d_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_gsd_diag3d_debug
 Checking test 070 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2294,13 +2343,13 @@ Checking test 070 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 242.340101
+  0: The total amount of wall time                        = 255.222895
 
 Test 070 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_rrfs_v1beta_debug
 Checking test 071 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2365,13 +2414,13 @@ Checking test 071 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.167413
+  0: The total amount of wall time                        = 214.969619
 
 Test 071 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_rrfs_v1alpha_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_rrfs_v1alpha_debug
 Checking test 072 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2436,13 +2485,13 @@ Checking test 072 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.776128
+  0: The total amount of wall time                        = 190.702313
 
 Test 072 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 073 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2507,13 +2556,13 @@ Checking test 073 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.807874
+  0: The total amount of wall time                        = 257.387535
 
 Test 073 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2528,73 +2577,73 @@ Checking test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 429.795923
+ 0: The total amount of wall time                        = 385.464657
 
 Test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_control_cfsr
 Checking test 075 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 104.774453
+  0: The total amount of wall time                        = 99.098779
 
 Test 075 datm_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_restart_cfsr
 Checking test 076 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 65.625767
+  0: The total amount of wall time                        = 62.769787
 
 Test 076 datm_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_control_gefs
 Checking test 077 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 166.180227
+  0: The total amount of wall time                        = 98.384883
 
 Test 077 datm_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_bulk_cfsr
 Checking test 078 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 134.267450
+  0: The total amount of wall time                        = 98.603895
 
 Test 078 datm_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_bulk_gefs
 Checking test 079 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 123.235772
+  0: The total amount of wall time                        = 93.355212
 
 Test 079 datm_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_mx025_cfsr
 Checking test 080 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2603,13 +2652,13 @@ Checking test 080 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 371.877271
+  0: The total amount of wall time                        = 375.328831
 
 Test 080 datm_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_mx025_gefs
 Checking test 081 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2618,85 +2667,85 @@ Checking test 081 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 366.638447
+  0: The total amount of wall time                        = 349.590375
 
 Test 081 datm_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_debug_cfsr
 Checking test 082 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.401576
+  0: The total amount of wall time                        = 261.227044
 
 Test 082 datm_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_control_cfsr
 Checking test 083 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.669050
+ 0: The total amount of wall time                        = 143.626934
 
 Test 083 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_restart_cfsr
 Checking test 084 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.372930
+ 0: The total amount of wall time                        = 105.550458
 
 Test 084 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_control_gefs
 Checking test 085 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.732586
+ 0: The total amount of wall time                        = 145.324366
 
 Test 085 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_bulk_cfsr
 Checking test 086 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.520568
+ 0: The total amount of wall time                        = 146.727508
 
 Test 086 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_bulk_gefs
 Checking test 087 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.608941
+ 0: The total amount of wall time                        = 143.377239
 
 Test 087 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_mx025_cfsr
 Checking test 088 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2705,13 +2754,13 @@ Checking test 088 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 403.314050
+  0: The total amount of wall time                        = 345.920424
 
 Test 088 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_mx025_gefs
 Checking test 089 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2720,35 +2769,35 @@ Checking test 089 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 418.410395
+  0: The total amount of wall time                        = 343.337640
 
 Test 089 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_multiple_files_cfsr
 Checking test 090 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.600486
+ 0: The total amount of wall time                        = 167.606474
 
 Test 090 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/datm_cdeps_debug_cfsr
 Checking test 091 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 434.273887
+ 0: The total amount of wall time                        = 434.140918
 
 Test 091 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_180294/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_262678/control_atmwav
 Checking test 092 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2791,75 +2840,11 @@ Checking test 092 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.366557
+  0: The total amount of wall time                        = 329.504292
 
 Test 092 control_atmwav PASS
 
-FAILED TESTS: 
-Test cpld_bmark_wave_v16 012 failed failed 
-Test cpld_bmark_wave_v16 012 failed in run_test failed 
-
-REGRESSION TEST FAILED
-Fri Jun 11 21:23:37 UTC 2021
-Elapsed time: 00h:51m:05s. Have a nice day!
-
-
-Fri Jun 11 21:31:22 UTC 2021
-Start Regression test
-
-Compile 001 elapsed time 664 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16
-working dir  = /scratch1/NCEPDEV/stmp2/Minsuk.Ji/FV3_RT/rt_174066/cpld_bmark_wave_v16
-Checking test 001 cpld_bmark_wave_v16 results ....
- Comparing sfcf006.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing 20130401.060000.out_grd.gwes_30m .........OK
- Comparing 20130401.060000.out_pnt.points .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2013-04-01-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
-
-  0: The total amount of wall time                        = 752.228527
-
-Test 001 cpld_bmark_wave_v16 PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 21:58:41 UTC 2021
-Elapsed time: 00h:27m:20s. Have a nice day!
+Tue Jun 15 17:01:16 UTC 2021
+Elapsed time: 01h:11m:08s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,26 +1,26 @@
-Fri Jun 11 21:01:22 GMT 2021
+Tue Jun 15 15:48:36 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 2413 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 2443 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-Compile 003 elapsed time 244 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 2234 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 005 elapsed time 2347 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 006 elapsed time 2235 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 007 elapsed time 2266 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 2286 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 009 elapsed time 231 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 010 elapsed time 200 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 011 elapsed time 214 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 012 elapsed time 205 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 013 elapsed time 254 seconds. APP=NG-GODAS-NEMSDATM
-Compile 014 elapsed time 127 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
-Compile 015 elapsed time 261 seconds. APP=NG-GODAS
-Compile 016 elapsed time 136 seconds. APP=NG-GODAS DEBUG=Y
-Compile 017 elapsed time 2328 seconds. APP=ATMW SUITES=FV3_GFS_v16
+Compile 001 elapsed time 2396 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 2439 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
+Compile 003 elapsed time 239 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 2236 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 005 elapsed time 2329 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 006 elapsed time 2224 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 007 elapsed time 2249 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 2262 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 009 elapsed time 211 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 010 elapsed time 201 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 011 elapsed time 201 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 012 elapsed time 198 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 013 elapsed time 253 seconds. APP=NG-GODAS-NEMSDATM
+Compile 014 elapsed time 132 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
+Compile 015 elapsed time 263 seconds. APP=NG-GODAS
+Compile 016 elapsed time 134 seconds. APP=NG-GODAS DEBUG=Y
+Compile 017 elapsed time 2289 seconds. APP=ATMW SUITES=FV3_GFS_v16
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 127.684304
+The total amount of wall time                        = 126.494311
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 73.334250
+The total amount of wall time                        = 73.203115
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_ca
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_ca
 Checking test 003 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 124.318336
+The total amount of wall time                        = 124.851299
 
 Test 003 cpld_ca PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_control_c192
 Checking test 004 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 524.261521
+The total amount of wall time                        = 530.382723
 
 Test 004 cpld_control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_restart_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_restart_c192
 Checking test 005 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 361.060014
+The total amount of wall time                        = 364.906818
 
 Test 005 cpld_restart_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_control_c384
 Checking test 006 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -353,13 +353,13 @@ Checking test 006 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 609.930605
+The total amount of wall time                        = 617.714689
 
 Test 006 cpld_control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_restart_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_restart_c384
 Checking test 007 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -412,13 +412,13 @@ Checking test 007 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 334.626478
+The total amount of wall time                        = 335.985739
 
 Test 007 cpld_restart_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_bmark_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_bmark_v16
 Checking test 008 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -461,13 +461,13 @@ Checking test 008 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 967.711657
+The total amount of wall time                        = 972.397621
 
 Test 008 cpld_bmark_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_restart_bmark_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_restart_bmark_v16
 Checking test 009 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -510,13 +510,13 @@ Checking test 009 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 532.875933
+The total amount of wall time                        = 521.792085
 
 Test 009 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_v16_nsst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_bmark_v16_nsst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_v16_nsst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_bmark_v16_nsst
 Checking test 010 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -559,13 +559,13 @@ Checking test 010 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 968.117563
+The total amount of wall time                        = 975.628473
 
 Test 010 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_bmark_wave_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_bmark_wave_v16
 Checking test 011 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -610,13 +610,13 @@ Checking test 011 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 1186.914201
+The total amount of wall time                        = 1178.382942
 
 Test 011 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_bmark_wave_v16_noahmp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_bmark_wave_v16_noahmp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_bmark_wave_v16_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_bmark_wave_v16_noahmp
 Checking test 012 cpld_bmark_wave_v16_noahmp results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -661,13 +661,13 @@ Checking test 012 cpld_bmark_wave_v16_noahmp results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 1195.171109
+The total amount of wall time                        = 1182.886806
 
 Test 012 cpld_bmark_wave_v16_noahmp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_control_wave
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_control_wave
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_control_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_control_wave
 Checking test 013 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -720,13 +720,13 @@ Checking test 013 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 1013.453456
+The total amount of wall time                        = 1002.789519
 
 Test 013 cpld_control_wave PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/cpld_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/cpld_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/cpld_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/cpld_debug
 Checking test 014 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 371.522894
+The total amount of wall time                        = 382.972704
 
 Test 014 cpld_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -825,13 +825,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 211.771699
+The total amount of wall time                        = 203.709165
 
 Test 015 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -874,13 +874,13 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 877.521152
+The total amount of wall time                        = 773.745076
 
 Test 016 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -919,13 +919,13 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 86.561007
+The total amount of wall time                        = 86.198261
 
 Test 017 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_CubedSphereGrid
 Checking test 018 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -952,30 +952,30 @@ Checking test 018 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 157.605179
+The total amount of wall time                        = 157.636393
 
 Test 018 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_wrtGauss_netcdf_parallel
 Checking test 019 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 235.490557
+The total amount of wall time                        = 236.367635
 
 Test 019 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_c192
 Checking test 020 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -986,13 +986,13 @@ Checking test 020 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 634.354574
+The total amount of wall time                        = 633.249458
 
 Test 020 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_c384
 Checking test 021 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1003,13 +1003,13 @@ Checking test 021 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 879.245133
+The total amount of wall time                        = 889.399645
 
 Test 021 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_c384gdas
 Checking test 022 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1052,13 +1052,13 @@ Checking test 022 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 766.958580
+The total amount of wall time                        = 772.203179
 
 Test 022 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_stochy
 Checking test 023 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1069,13 +1069,13 @@ Checking test 023 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 145.349338
+The total amount of wall time                        = 144.825438
 
 Test 023 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_ca
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_ca
 Checking test 024 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1086,13 +1086,13 @@ Checking test 024 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 143.782447
+The total amount of wall time                        = 143.971096
 
 Test 024 control_ca PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_lndp
 Checking test 025 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1103,13 +1103,13 @@ Checking test 025 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 150.012042
+The total amount of wall time                        = 149.710975
 
 Test 025 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_lheatstrg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_lheatstrg
 Checking test 026 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1120,13 +1120,13 @@ Checking test 026 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 202.388241
+The total amount of wall time                        = 204.147430
 
 Test 026 control_lheatstrg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_merra2
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_merra2
 Checking test 027 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1137,13 +1137,13 @@ Checking test 027 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 249.414709
+The total amount of wall time                        = 231.856596
 
 Test 027 control_merra2 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_rrtmgp
 Checking test 028 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1154,13 +1154,13 @@ Checking test 028 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 273.877120
+The total amount of wall time                        = 258.528424
 
 Test 028 control_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_csawmg
 Checking test 029 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1171,13 +1171,13 @@ Checking test 029 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 351.563755
+The total amount of wall time                        = 349.011908
 
 Test 029 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_csawmgt
 Checking test 030 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1188,13 +1188,13 @@ Checking test 030 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 432.848054
+The total amount of wall time                        = 423.910103
 
 Test 030 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_flake
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_flake
 Checking test 031 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1205,13 +1205,13 @@ Checking test 031 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 302.682631
+The total amount of wall time                        = 285.531701
 
 Test 031 control_flake PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_ugwpv1
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_ugwpv1
 Checking test 032 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1222,13 +1222,13 @@ Checking test 032 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 273.671330
+The total amount of wall time                        = 251.426302
 
 Test 032 control_ugwpv1 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_ras
 Checking test 033 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1239,13 +1239,13 @@ Checking test 033 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 254.821753
+The total amount of wall time                        = 235.784792
 
 Test 033 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_thompson
 Checking test 034 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,13 +1256,13 @@ Checking test 034 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 274.316072
+The total amount of wall time                        = 271.755237
 
 Test 034 control_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_thompson_no_aero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_thompson_no_aero
 Checking test 035 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,13 +1273,13 @@ Checking test 035 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 265.436458
+The total amount of wall time                        = 262.356967
 
 Test 035 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_noahmp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_noahmp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_noahmp
 Checking test 036 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1290,13 +1290,13 @@ Checking test 036 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 256.348346
+The total amount of wall time                        = 235.728566
 
 Test 036 control_noahmp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_control
 Checking test 037 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1304,25 +1304,25 @@ Checking test 037 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 413.650790
+The total amount of wall time                        = 412.172701
 
 Test 037 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_restart
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_restart
 Checking test 038 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 226.310444
+The total amount of wall time                        = 224.966182
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_quilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_quilt
 Checking test 039 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1333,13 +1333,13 @@ Checking test 039 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 410.457951
+The total amount of wall time                        = 407.745576
 
 Test 039 regional_quilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_quilt_hafs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_quilt_hafs
 Checking test 040 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1348,27 +1348,27 @@ Checking test 040 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 403.730118
+The total amount of wall time                        = 407.098760
 
 Test 040 regional_quilt_hafs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_quilt_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_quilt_netcdf_parallel
 Checking test 041 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 410.030611
+The total amount of wall time                        = 410.854382
 
 Test 041 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_quilt_RRTMGP
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_quilt_RRTMGP
 Checking test 042 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1379,13 +1379,13 @@ Checking test 042 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 530.041081
+The total amount of wall time                        = 526.748271
 
 Test 042 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_gsd
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_gsd
 Checking test 043 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1474,13 +1474,13 @@ Checking test 043 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 235.425128
+The total amount of wall time                        = 235.631374
 
 Test 043 fv3_gsd PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_rrfs_v1alpha
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_rrfs_v1alpha
 Checking test 044 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1545,13 +1545,13 @@ Checking test 044 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 119.856128
+The total amount of wall time                        = 117.839878
 
 Test 044 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_HAFS_v0_hwrf_thompson
 Checking test 045 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1616,13 +1616,13 @@ Checking test 045 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 193.410768
+The total amount of wall time                        = 192.888201
 
 Test 045 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 046 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1637,39 +1637,39 @@ Checking test 046 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 360.401684
+The total amount of wall time                        = 359.660229
 
 Test 046 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_debug
 Checking test 047 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 193.781412
+The total amount of wall time                        = 193.003698
 
 Test 047 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_2threads_debug
 Checking test 048 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 362.246717
+The total amount of wall time                        = 362.671513
 
 Test 048 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_CubedSphereGrid_debug
 Checking test 049 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1696,169 +1696,169 @@ Checking test 049 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 205.374093
+The total amount of wall time                        = 205.801645
 
 Test 049 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_wrtGauss_netcdf_parallel_debug
 Checking test 050 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 196.587976
+The total amount of wall time                        = 194.076163
 
 Test 050 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_stochy_debug
 Checking test 051 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 218.065951
+The total amount of wall time                        = 218.456427
 
 Test 051 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_lndp_debug
 Checking test 052 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 195.353249
+The total amount of wall time                        = 198.993642
 
 Test 052 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_lheatstrg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_lheatstrg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_lheatstrg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_lheatstrg_debug
 Checking test 053 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 190.560983
+The total amount of wall time                        = 192.663373
 
 Test 053 control_lheatstrg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_merra2_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_merra2_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_merra2_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_merra2_debug
 Checking test 054 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 234.196009
+The total amount of wall time                        = 234.967827
 
 Test 054 control_merra2_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_rrtmgp_debug
 Checking test 055 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 216.522963
+The total amount of wall time                        = 215.144608
 
 Test 055 control_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_csawmg_debug
 Checking test 056 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 286.447131
+The total amount of wall time                        = 287.527358
 
 Test 056 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_csawmgt_debug
 Checking test 057 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 329.917380
+The total amount of wall time                        = 328.695435
 
 Test 057 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ugwpv1_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_ugwpv1_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ugwpv1_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_ugwpv1_debug
 Checking test 058 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 205.554246
+The total amount of wall time                        = 208.671865
 
 Test 058 control_ugwpv1_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_ras_debug
 Checking test 059 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 193.608129
+The total amount of wall time                        = 194.749529
 
 Test 059 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_thompson_debug
 Checking test 060 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 226.011667
+The total amount of wall time                        = 227.858968
 
 Test 060 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_thompson_no_aero_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_thompson_no_aero_debug
 Checking test 061 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 216.293943
+The total amount of wall time                        = 218.184129
 
 Test 061 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_regional_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/regional_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_regional_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/regional_control_debug
 Checking test 062 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1866,13 +1866,13 @@ Checking test 062 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 315.057843
+The total amount of wall time                        = 316.525974
 
 Test 062 regional_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_gsd_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_gsd_debug
 Checking test 063 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1937,13 +1937,13 @@ Checking test 063 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 263.297648
+The total amount of wall time                        = 263.427141
 
 Test 063 fv3_gsd_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_gsd_diag3d_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_gsd_diag3d_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_gsd_diag3d_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_gsd_diag3d_debug
 Checking test 064 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2008,13 +2008,13 @@ Checking test 064 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 336.131461
+The total amount of wall time                        = 362.434783
 
 Test 064 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_rrfs_v1beta_debug
 Checking test 065 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2079,13 +2079,13 @@ Checking test 065 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 254.048126
+The total amount of wall time                        = 260.274089
 
 Test 065 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_rrfs_v1alpha_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_rrfs_v1alpha_debug
 Checking test 066 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2150,13 +2150,13 @@ Checking test 066 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 256.175446
+The total amount of wall time                        = 255.156482
 
 Test 066 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 067 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2221,13 +2221,13 @@ Checking test 067 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 267.422133
+The total amount of wall time                        = 269.676327
 
 Test 067 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2242,73 +2242,73 @@ Checking test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 504.174797
+The total amount of wall time                        = 502.043840
 
 Test 068 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_control_cfsr
 Checking test 069 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 130.113400
+The total amount of wall time                        = 134.047998
 
 Test 069 datm_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_restart_cfsr
 Checking test 070 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 80.937507
+The total amount of wall time                        = 85.140826
 
 Test 070 datm_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_control_gefs
 Checking test 071 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 121.784276
+The total amount of wall time                        = 123.816755
 
 Test 071 datm_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_bulk_cfsr
 Checking test 072 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 126.265253
+The total amount of wall time                        = 130.457389
 
 Test 072 datm_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_bulk_gefs
 Checking test 073 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 122.006801
+The total amount of wall time                        = 125.861400
 
 Test 073 datm_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_mx025_cfsr
 Checking test 074 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2317,13 +2317,13 @@ Checking test 074 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 469.019663
+The total amount of wall time                        = 527.381872
 
 Test 074 datm_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_mx025_gefs
 Checking test 075 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2332,85 +2332,85 @@ Checking test 075 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 462.973707
+The total amount of wall time                        = 464.445615
 
 Test 075 datm_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_debug_cfsr
 Checking test 076 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 347.936151
+The total amount of wall time                        = 345.844868
 
 Test 076 datm_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_control_cfsr
 Checking test 077 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 197.348589
+The total amount of wall time                        = 200.210683
 
 Test 077 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_restart_cfsr
 Checking test 078 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 124.693947
+The total amount of wall time                        = 121.889268
 
 Test 078 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_control_gefs
 Checking test 079 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 193.032155
+The total amount of wall time                        = 194.502158
 
 Test 079 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_bulk_cfsr
 Checking test 080 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 198.578222
+The total amount of wall time                        = 200.832217
 
 Test 080 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_bulk_gefs
 Checking test 081 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 193.201428
+The total amount of wall time                        = 193.197814
 
 Test 081 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_mx025_cfsr
 Checking test 082 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2419,13 +2419,13 @@ Checking test 082 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 475.196297
+The total amount of wall time                        = 469.501049
 
 Test 082 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_mx025_gefs
 Checking test 083 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2434,35 +2434,35 @@ Checking test 083 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 457.327438
+The total amount of wall time                        = 457.598105
 
 Test 083 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_multiple_files_cfsr
 Checking test 084 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 197.154046
+The total amount of wall time                        = 200.630088
 
 Test 084 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/datm_cdeps_debug_cfsr
 Checking test 085 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 573.612015
+The total amount of wall time                        = 572.006002
 
 Test 085 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97009/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_158994/control_atmwav
 Checking test 086 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2505,11 +2505,11 @@ Checking test 086 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 429.581800
+The total amount of wall time                        = 429.198918
 
 Test 086 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 12 00:00:22 GMT 2021
-Elapsed time: 02h:59m:00s. Have a nice day!
+Tue Jun 15 18:22:59 GMT 2021
+Elapsed time: 02h:34m:23s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,18 +1,18 @@
-Fri Jun 11 20:32:51 UTC 2021
+Wed Jun 16 14:22:13 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 942 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 002 elapsed time 910 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 003 elapsed time 891 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 004 elapsed time 954 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 005 elapsed time 893 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 006 elapsed time 533 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 007 elapsed time 492 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 008 elapsed time 486 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 009 elapsed time 488 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 001 elapsed time 843 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 002 elapsed time 890 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 003 elapsed time 844 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 004 elapsed time 861 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 005 elapsed time 864 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 006 elapsed time 467 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 007 elapsed time 461 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 008 elapsed time 457 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 009 elapsed time 472 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -55,13 +55,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 192.283245
+The total amount of wall time                        = 185.856815
 
 Test 001 control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_decomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -104,13 +104,13 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 177.214491
+The total amount of wall time                        = 189.238088
 
 Test 002 control_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_restart
 Checking test 003 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -149,13 +149,13 @@ Checking test 003 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 68.250400
+The total amount of wall time                        = 69.728223
 
 Test 003 control_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_CubedSphereGrid
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_CubedSphereGrid
 Checking test 004 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 004 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 157.801051
+The total amount of wall time                        = 140.061614
 
 Test 004 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_wrtGauss_netcdf_parallel
 Checking test 005 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -199,13 +199,13 @@ Checking test 005 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 186.884826
+The total amount of wall time                        = 187.710642
 
 Test 005 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_c192
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_c192
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_c192
 Checking test 006 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -216,13 +216,13 @@ Checking test 006 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 518.152766
+The total amount of wall time                        = 515.778294
 
 Test 006 control_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_stochy
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_stochy
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_stochy
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_stochy
 Checking test 007 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -233,13 +233,13 @@ Checking test 007 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 153.777043
+The total amount of wall time                        = 138.302969
 
 Test 007 control_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ca
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_ca
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ca
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_ca
 Checking test 008 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -250,13 +250,13 @@ Checking test 008 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 149.307691
+The total amount of wall time                        = 138.497308
 
 Test 008 control_ca PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lndp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_lndp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lndp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_lndp
 Checking test 009 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -267,13 +267,13 @@ Checking test 009 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 132.006869
+The total amount of wall time                        = 138.418043
 
 Test 009 control_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lheatstrg
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_lheatstrg
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lheatstrg
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_lheatstrg
 Checking test 010 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -284,13 +284,13 @@ Checking test 010 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 174.335917
+The total amount of wall time                        = 186.734714
 
 Test 010 control_lheatstrg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_merra2
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_merra2
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_merra2
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_merra2
 Checking test 011 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -301,13 +301,13 @@ Checking test 011 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 243.149508
+The total amount of wall time                        = 235.285062
 
 Test 011 control_merra2 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_rrtmgp
 Checking test 012 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -318,13 +318,13 @@ Checking test 012 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 217.697564
+The total amount of wall time                        = 226.104429
 
 Test 012 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmg
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_csawmg
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmg
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_csawmg
 Checking test 013 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -335,13 +335,13 @@ Checking test 013 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 349.406059
+The total amount of wall time                        = 329.655483
 
 Test 013 control_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_csawmgt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_csawmgt
 Checking test 014 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -352,13 +352,13 @@ Checking test 014 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 395.310762
+The total amount of wall time                        = 378.440906
 
 Test 014 control_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_flake
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_flake
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_flake
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_flake
 Checking test 015 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -369,13 +369,13 @@ Checking test 015 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 260.310971
+The total amount of wall time                        = 257.114419
 
 Test 015 control_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ugwpv1
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_ugwpv1
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ugwpv1
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_ugwpv1
 Checking test 016 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -386,13 +386,13 @@ Checking test 016 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 222.802109
+The total amount of wall time                        = 218.815137
 
 Test 016 control_ugwpv1 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ras
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_ras
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ras
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_ras
 Checking test 017 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -403,13 +403,13 @@ Checking test 017 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 197.597841
+The total amount of wall time                        = 208.511472
 
 Test 017 control_ras PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_noahmp
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_noahmp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_noahmp
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_noahmp
 Checking test 018 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -420,13 +420,13 @@ Checking test 018 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 198.919439
+The total amount of wall time                        = 204.091691
 
 Test 018 control_noahmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/regional_control
 Checking test 019 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -434,43 +434,26 @@ Checking test 019 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 339.516625
+The total amount of wall time                        = 347.932899
 
 Test 019 regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_restart
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_restart
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/regional_restart
 Checking test 020 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 212.835189
+The total amount of wall time                        = 213.890071
 
 Test 020 regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_quilt
-Checking test 021 regional_quilt results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF24 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF24 .........OK
-
-The total amount of wall time                        = 326.590777
-
-Test 021 regional_quilt PASS
-
-
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_hafs
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_quilt_hafs
-Checking test 022 regional_quilt_hafs results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt_hafs
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/regional_quilt_hafs
+Checking test 021 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -478,45 +461,28 @@ Checking test 022 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 329.236025
+The total amount of wall time                        = 325.113213
 
-Test 022 regional_quilt_hafs PASS
+Test 021 regional_quilt_hafs PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_quilt_netcdf_parallel
-Checking test 023 regional_quilt_netcdf_parallel results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/regional_quilt_netcdf_parallel
+Checking test 022 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 329.472890
+The total amount of wall time                        = 325.952111
 
-Test 023 regional_quilt_netcdf_parallel PASS
-
-
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_quilt_RRTMGP
-Checking test 024 regional_quilt_RRTMGP results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF24 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF24 .........OK
-
-The total amount of wall time                        = 439.672478
-
-Test 024 regional_quilt_RRTMGP PASS
+Test 022 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_gsd
-Checking test 025 fv3_gsd results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_gsd
+Checking test 023 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -604,14 +570,14 @@ Checking test 025 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 201.802438
+The total amount of wall time                        = 193.294540
 
-Test 025 fv3_gsd PASS
+Test 023 fv3_gsd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1alpha
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_rrfs_v1alpha
-Checking test 026 fv3_rrfs_v1alpha results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1alpha
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_rrfs_v1alpha
+Checking test 024 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -675,14 +641,14 @@ Checking test 026 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 117.290337
+The total amount of wall time                        = 99.783362
 
-Test 026 fv3_rrfs_v1alpha PASS
+Test 024 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rap
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_rap
-Checking test 027 fv3_rap results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rap
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_rap
+Checking test 025 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -746,14 +712,14 @@ Checking test 027 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 112.744847
+The total amount of wall time                        = 99.597662
 
-Test 027 fv3_rap PASS
+Test 025 fv3_rap PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_hrrr
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_hrrr
-Checking test 028 fv3_hrrr results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_hrrr
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_hrrr
+Checking test 026 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -817,14 +783,14 @@ Checking test 028 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 98.864051
+The total amount of wall time                        = 98.155263
 
-Test 028 fv3_hrrr PASS
+Test 026 fv3_hrrr PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_rrfs_v1beta
-Checking test 029 fv3_rrfs_v1beta results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_rrfs_v1beta
+Checking test 027 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -888,14 +854,14 @@ Checking test 029 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.172896
+The total amount of wall time                        = 99.666172
 
-Test 029 fv3_rrfs_v1beta PASS
+Test 027 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_HAFS_v0_hwrf_thompson
-Checking test 030 fv3_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_HAFS_v0_hwrf_thompson
+Checking test 028 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -959,14 +925,14 @@ Checking test 030 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 165.526124
+The total amount of wall time                        = 165.734860
 
-Test 030 fv3_HAFS_v0_hwrf_thompson PASS
+Test 028 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_esg_HAFS_v0_hwrf_thompson
-Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_esg_HAFS_v0_hwrf_thompson
+Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -980,27 +946,27 @@ Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 316.583553
+The total amount of wall time                        = 310.597411
 
-Test 031 fv3_esg_HAFS_v0_hwrf_thompson PASS
+Test 029 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_debug
-Checking test 032 control_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_debug
+Checking test 030 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.086877
+The total amount of wall time                        = 139.913449
 
-Test 032 control_debug PASS
+Test 030 control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_CubedSphereGrid_debug
-Checking test 033 control_CubedSphereGrid_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_CubedSphereGrid_debug
+Checking test 031 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -1026,184 +992,184 @@ Checking test 033 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 150.466232
+The total amount of wall time                        = 149.044031
 
-Test 033 control_CubedSphereGrid_debug PASS
+Test 031 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_wrtGauss_netcdf_parallel_debug
-Checking test 034 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_wrtGauss_netcdf_parallel_debug
+Checking test 032 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.825854
+The total amount of wall time                        = 142.302503
 
-Test 034 control_wrtGauss_netcdf_parallel_debug PASS
+Test 032 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_stochy_debug
-Checking test 035 control_stochy_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_stochy_debug
+Checking test 033 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.665124
+The total amount of wall time                        = 161.202892
 
-Test 035 control_stochy_debug PASS
+Test 033 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_lndp_debug
-Checking test 036 control_lndp_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_lndp_debug
+Checking test 034 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.997100
+The total amount of wall time                        = 146.025895
 
-Test 036 control_lndp_debug PASS
+Test 034 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lheatstrg_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_lheatstrg_debug
-Checking test 037 control_lheatstrg_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lheatstrg_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_lheatstrg_debug
+Checking test 035 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.585679
+The total amount of wall time                        = 139.471184
 
-Test 037 control_lheatstrg_debug PASS
+Test 035 control_lheatstrg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_merra2_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_merra2_debug
-Checking test 038 control_merra2_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_merra2_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_merra2_debug
+Checking test 036 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 207.075346
+The total amount of wall time                        = 196.470866
 
-Test 038 control_merra2_debug PASS
+Test 036 control_merra2_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_rrtmgp_debug
-Checking test 039 control_rrtmgp_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_rrtmgp_debug
+Checking test 037 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.750093
+The total amount of wall time                        = 159.306852
 
-Test 039 control_rrtmgp_debug PASS
+Test 037 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_csawmg_debug
-Checking test 040 control_csawmg_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_csawmg_debug
+Checking test 038 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 238.836872
+The total amount of wall time                        = 243.716213
 
-Test 040 control_csawmg_debug PASS
+Test 038 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_csawmgt_debug
-Checking test 041 control_csawmgt_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_csawmgt_debug
+Checking test 039 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 275.453776
+The total amount of wall time                        = 263.665518
 
-Test 041 control_csawmgt_debug PASS
+Test 039 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ugwpv1_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_ugwpv1_debug
-Checking test 042 control_ugwpv1_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ugwpv1_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_ugwpv1_debug
+Checking test 040 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.765539
+The total amount of wall time                        = 154.627808
 
-Test 042 control_ugwpv1_debug PASS
+Test 040 control_ugwpv1_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_ras_debug
-Checking test 043 control_ras_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_ras_debug
+Checking test 041 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.515503
+The total amount of wall time                        = 141.974624
 
-Test 043 control_ras_debug PASS
+Test 041 control_ras_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_thompson_debug
-Checking test 044 control_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_thompson_debug
+Checking test 042 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.301568
+The total amount of wall time                        = 168.515071
 
-Test 044 control_thompson_debug PASS
+Test 042 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/control_thompson_no_aero_debug
-Checking test 045 control_thompson_no_aero_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/control_thompson_no_aero_debug
+Checking test 043 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.134555
+The total amount of wall time                        = 161.798652
 
-Test 045 control_thompson_no_aero_debug PASS
+Test 043 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_control_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/regional_control_debug
-Checking test 046 regional_control_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_control_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/regional_control_debug
+Checking test 044 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 246.454032
+The total amount of wall time                        = 244.627620
 
-Test 046 regional_control_debug PASS
+Test 044 regional_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_gsd_debug
-Checking test 047 fv3_gsd_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_gsd_debug
+Checking test 045 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1267,14 +1233,14 @@ Checking test 047 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.155999
+The total amount of wall time                        = 197.562643
 
-Test 047 fv3_gsd_debug PASS
+Test 045 fv3_gsd_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd_diag3d_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_gsd_diag3d_debug
-Checking test 048 fv3_gsd_diag3d_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd_diag3d_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_gsd_diag3d_debug
+Checking test 046 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1338,14 +1304,14 @@ Checking test 048 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 265.162494
+The total amount of wall time                        = 268.096767
 
-Test 048 fv3_gsd_diag3d_debug PASS
+Test 046 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_rrfs_v1beta_debug
-Checking test 049 fv3_rrfs_v1beta_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_rrfs_v1beta_debug
+Checking test 047 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1409,14 +1375,14 @@ Checking test 049 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 193.440088
+The total amount of wall time                        = 189.598228
 
-Test 049 fv3_rrfs_v1beta_debug PASS
+Test 047 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_rrfs_v1alpha_debug
-Checking test 050 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_rrfs_v1alpha_debug
+Checking test 048 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1480,14 +1446,14 @@ Checking test 050 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 191.503562
+The total amount of wall time                        = 189.282825
 
-Test 050 fv3_rrfs_v1alpha_debug PASS
+Test 048 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 051 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 049 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1551,14 +1517,14 @@ Checking test 051 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.739822
+The total amount of wall time                        = 197.868589
 
-Test 051 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 049 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_39787/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_12927/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 050 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1572,11 +1538,11 @@ Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 373.221539
+The total amount of wall time                        = 353.709354
 
-Test 052 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 050 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 21:01:07 UTC 2021
-Elapsed time: 00h:28m:16s. Have a nice day!
+Wed Jun 16 14:50:43 UTC 2021
+Elapsed time: 00h:28m:30s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,26 +1,26 @@
-Fri Jun 11 20:48:21 UTC 2021
+Tue Jun 15 16:01:05 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 2173 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
-Compile 002 elapsed time 2496 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
-Compile 003 elapsed time 748 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
-Compile 004 elapsed time 1209 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
-Compile 005 elapsed time 1790 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
-Compile 006 elapsed time 1226 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
-Compile 007 elapsed time 1375 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
-Compile 008 elapsed time 1232 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
-Compile 009 elapsed time 537 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
-Compile 010 elapsed time 360 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
-Compile 011 elapsed time 351 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
-Compile 012 elapsed time 349 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
-Compile 013 elapsed time 932 seconds. APP=NG-GODAS-NEMSDATM
-Compile 014 elapsed time 346 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
-Compile 015 elapsed time 953 seconds. APP=NG-GODAS
-Compile 016 elapsed time 360 seconds. APP=NG-GODAS DEBUG=Y
-Compile 017 elapsed time 1115 seconds. APP=ATMW SUITES=FV3_GFS_v16
+Compile 001 elapsed time 2176 seconds. APP=S2S SUITES=FV3_GFS_2017_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst
+Compile 002 elapsed time 2354 seconds. APP=S2SW SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_noahmp,FV3_GFS_v16_coupled_nsstNoahmp
+Compile 003 elapsed time 717 seconds. APP=S2S DEBUG=Y SUITES=FV3_GFS_2017_coupled,FV3_GFS_2017_satmedmf_coupled,FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled
+Compile 004 elapsed time 1207 seconds. APP=ATM SUITES=FV3_GFS_v16 32BIT=Y
+Compile 005 elapsed time 1533 seconds. APP=ATM SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp
+Compile 006 elapsed time 1170 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y
+Compile 007 elapsed time 1338 seconds. APP=ATM SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y
+Compile 008 elapsed time 1199 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf
+Compile 009 elapsed time 339 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y
+Compile 010 elapsed time 308 seconds. APP=ATM DEBUG=Y SUITES=FV3_GFS_v16_thompson 32BIT=Y
+Compile 011 elapsed time 302 seconds. APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha 32BIT=Y DEBUG=Y
+Compile 012 elapsed time 289 seconds. APP=ATM SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf DEBUG=Y
+Compile 013 elapsed time 905 seconds. APP=NG-GODAS-NEMSDATM
+Compile 014 elapsed time 316 seconds. APP=NG-GODAS-NEMSDATM DEBUG=Y
+Compile 015 elapsed time 970 seconds. APP=NG-GODAS
+Compile 016 elapsed time 504 seconds. APP=NG-GODAS DEBUG=Y
+Compile 017 elapsed time 1108 seconds. APP=ATMW SUITES=FV3_GFS_v16
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 105.905361
+[0] The total amount of wall time                        = 103.651466
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 72.048678
+[0] The total amount of wall time                        = 69.719188
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_decomp
 Checking test 003 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.991014
+[0] The total amount of wall time                        = 101.386813
 
 Test 003 cpld_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_ca
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_ca
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_ca
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 103.288775
+[0] The total amount of wall time                        = 102.940741
 
 Test 004 cpld_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control_c192
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 413.130368
+[0] The total amount of wall time                        = 408.123114
 
 Test 005 cpld_control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_restart_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control_c192
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 315.082287
+[0] The total amount of wall time                        = 312.220157
 
 Test 006 cpld_restart_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control_c384
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 807.466550
+[0] The total amount of wall time                        = 800.307259
 
 Test 007 cpld_control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_restart_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control_c384
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 471.748526
+[0] The total amount of wall time                        = 483.148918
 
 Test 008 cpld_restart_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_bmark_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_bmark_v16
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 832.419305
+[0] The total amount of wall time                        = 829.483874
 
 Test 009 cpld_bmark_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_restart_bmark_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_bmark_v16
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 517.102641
+[0] The total amount of wall time                        = 530.175530
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_bmark_v16_nsst
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_bmark_v16_nsst
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_bmark_v16_nsst
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,13 +615,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 827.195042
+[0] The total amount of wall time                        = 836.196595
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_bmark_wave_v16
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_bmark_wave_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_bmark_wave_v16
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -666,13 +666,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 946.137346
+[0] The total amount of wall time                        = 924.396457
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_bmark_wave_v16_noahmp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_bmark_wave_v16_noahmp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_bmark_wave_v16_noahmp
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_bmark_wave_v16_noahmp
 Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -717,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_noahmp results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 937.861394
+[0] The total amount of wall time                        = 919.130696
 
 Test 013 cpld_bmark_wave_v16_noahmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_control_wave
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_control_wave
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_control_wave
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 127.873752
+[0] The total amount of wall time                        = 126.330894
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/cpld_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/cpld_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/cpld_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 324.213067
+[0] The total amount of wall time                        = 319.922024
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -881,13 +881,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 169.427513
+[0] The total amount of wall time                        = 170.801358
 
 Test 016 control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -930,13 +930,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 174.793241
+[0] The total amount of wall time                        = 173.805529
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,13 +979,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 156.392552
+[0] The total amount of wall time                        = 156.727969
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1024,13 +1024,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 74.324903
+[0] The total amount of wall time                        = 74.666125
 
 Test 019 control_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_CubedSphereGrid
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_CubedSphereGrid
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1057,30 +1057,30 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 134.387828
+[0] The total amount of wall time                        = 134.884179
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 203.550376
+[0] The total amount of wall time                        = 200.855682
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_c192
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_c192
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 544.552564
+[0] The total amount of wall time                        = 551.007997
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_c384
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_c384
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1108,13 +1108,13 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1022.566074
+[0] The total amount of wall time                        = 1025.537661
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_c384gdas
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_c384gdas
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1157,13 +1157,13 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 891.776426
+[0] The total amount of wall time                        = 914.733091
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_stochy
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_stochy
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_stochy
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1174,13 +1174,13 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 120.336609
+[0] The total amount of wall time                        = 120.130661
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ca
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_ca
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ca
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_ca
 Checking test 026 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1191,13 +1191,13 @@ Checking test 026 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 119.327666
+[0] The total amount of wall time                        = 118.581133
 
 Test 026 control_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lndp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_lndp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lndp
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_lndp
 Checking test 027 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1208,13 +1208,13 @@ Checking test 027 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 121.295803
+[0] The total amount of wall time                        = 121.437435
 
 Test 027 control_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lheatstrg
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_lheatstrg
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lheatstrg
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_lheatstrg
 Checking test 028 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1225,13 +1225,13 @@ Checking test 028 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 169.827952
+[0] The total amount of wall time                        = 170.631200
 
 Test 028 control_lheatstrg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_merra2
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_merra2
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_merra2
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_merra2
 Checking test 029 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1242,13 +1242,13 @@ Checking test 029 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 198.376924
+[0] The total amount of wall time                        = 201.374757
 
 Test 029 control_merra2 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_rrtmgp
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_rrtmgp
 Checking test 030 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1259,13 +1259,13 @@ Checking test 030 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 229.088811
+[0] The total amount of wall time                        = 227.763911
 
 Test 030 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_csawmg
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmg
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_csawmg
 Checking test 031 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1276,13 +1276,13 @@ Checking test 031 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 307.328919
+[0] The total amount of wall time                        = 305.550002
 
 Test 031 control_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_csawmgt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmgt
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_csawmgt
 Checking test 032 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1293,13 +1293,13 @@ Checking test 032 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 370.486617
+[0] The total amount of wall time                        = 368.278997
 
 Test 032 control_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_flake
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_flake
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_flake
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_flake
 Checking test 033 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1310,13 +1310,13 @@ Checking test 033 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 249.954293
+[0] The total amount of wall time                        = 251.579068
 
 Test 033 control_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ugwpv1
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_ugwpv1
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ugwpv1
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_ugwpv1
 Checking test 034 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1327,13 +1327,13 @@ Checking test 034 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 209.909336
+[0] The total amount of wall time                        = 207.100881
 
 Test 034 control_ugwpv1 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ras
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_ras
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ras
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_ras
 Checking test 035 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1344,13 +1344,13 @@ Checking test 035 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 198.987828
+[0] The total amount of wall time                        = 196.522706
 
 Test 035 control_ras PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_thompson
 Checking test 036 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1361,13 +1361,13 @@ Checking test 036 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 235.748008
+[0] The total amount of wall time                        = 234.615884
 
 Test 036 control_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_thompson_no_aero
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson_no_aero
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_thompson_no_aero
 Checking test 037 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1378,13 +1378,13 @@ Checking test 037 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 227.248919
+[0] The total amount of wall time                        = 226.158370
 
 Test 037 control_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_noahmp
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_noahmp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_noahmp
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_noahmp
 Checking test 038 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1395,13 +1395,13 @@ Checking test 038 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 198.285700
+[0] The total amount of wall time                        = 197.571483
 
 Test 038 control_noahmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_control
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_control
 Checking test 039 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1409,25 +1409,25 @@ Checking test 039 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 350.625197
+[0] The total amount of wall time                        = 348.993511
 
 Test 039 regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_restart
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_restart
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_restart
 Checking test 040 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-[0] The total amount of wall time                        = 200.256728
+[0] The total amount of wall time                        = 201.040998
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_quilt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_quilt
 Checking test 041 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1438,13 +1438,13 @@ Checking test 041 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 342.552552
+[0] The total amount of wall time                        = 344.643957
 
 Test 041 regional_quilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_quilt_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_quilt_2threads
 Checking test 042 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1455,13 +1455,13 @@ Checking test 042 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 190.434519
+[0] The total amount of wall time                        = 191.281369
 
 Test 042 regional_quilt_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_hafs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_quilt_hafs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt_hafs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_quilt_hafs
 Checking test 043 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1470,27 +1470,27 @@ Checking test 043 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 344.724525
+[0] The total amount of wall time                        = 344.809716
 
 Test 043 regional_quilt_hafs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_quilt_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_quilt_netcdf_parallel
 Checking test 044 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 342.797057
+[0] The total amount of wall time                        = 347.747394
 
 Test 044 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_quilt_RRTMGP
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_quilt_RRTMGP
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_quilt_RRTMGP
 Checking test 045 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1501,13 +1501,13 @@ Checking test 045 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 468.972369
+[0] The total amount of wall time                        = 469.310336
 
 Test 045 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_gsd
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_gsd
 Checking test 046 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,13 +1596,13 @@ Checking test 046 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 200.594914
+[0] The total amount of wall time                        = 199.140277
 
 Test 046 fv3_gsd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1alpha
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_rrfs_v1alpha
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1alpha
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_rrfs_v1alpha
 Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1667,13 +1667,13 @@ Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.873686
+[0] The total amount of wall time                        = 103.759552
 
 Test 047 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rap
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_rap
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rap
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_rap
 Checking test 048 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1738,13 +1738,13 @@ Checking test 048 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.440902
+[0] The total amount of wall time                        = 102.727882
 
 Test 048 fv3_rap PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_hrrr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_hrrr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_hrrr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_hrrr
 Checking test 049 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1809,13 +1809,13 @@ Checking test 049 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 101.306392
+[0] The total amount of wall time                        = 100.987146
 
 Test 049 fv3_hrrr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_rrfs_v1beta
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1beta
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_rrfs_v1beta
 Checking test 050 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1880,13 +1880,13 @@ Checking test 050 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.867953
+[0] The total amount of wall time                        = 103.326231
 
 Test 050 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_HAFS_v0_hwrf_thompson
 Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1951,13 +1951,13 @@ Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 173.539424
+[0] The total amount of wall time                        = 172.175338
 
 Test 051 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1972,39 +1972,39 @@ Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 323.406546
+[0] The total amount of wall time                        = 324.930638
 
 Test 052 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_debug
 Checking test 053 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 169.687772
+[0] The total amount of wall time                        = 168.909657
 
 Test 053 control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_2threads_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_2threads_debug
 Checking test 054 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 157.618943
+[0] The total amount of wall time                        = 155.075363
 
 Test 054 control_2threads_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_CubedSphereGrid_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_CubedSphereGrid_debug
 Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2031,169 +2031,169 @@ Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 184.027971
+[0] The total amount of wall time                        = 182.038575
 
 Test 055 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_wrtGauss_netcdf_parallel_debug
 Checking test 056 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 174.331893
+[0] The total amount of wall time                        = 172.169678
 
 Test 056 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_stochy_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_stochy_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_stochy_debug
 Checking test 057 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 193.239040
+[0] The total amount of wall time                        = 191.454519
 
 Test 057 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_lndp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lndp_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_lndp_debug
 Checking test 058 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 173.703046
+[0] The total amount of wall time                        = 172.680723
 
 Test 058 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_lheatstrg_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_lheatstrg_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_lheatstrg_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_lheatstrg_debug
 Checking test 059 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 169.371377
+[0] The total amount of wall time                        = 168.249868
 
 Test 059 control_lheatstrg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_merra2_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_merra2_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_merra2_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_merra2_debug
 Checking test 060 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 220.956592
+[0] The total amount of wall time                        = 215.498136
 
 Test 060 control_merra2_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_rrtmgp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_rrtmgp_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_rrtmgp_debug
 Checking test 061 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.363102
+[0] The total amount of wall time                        = 189.530585
 
 Test 061 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_csawmg_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmg_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_csawmg_debug
 Checking test 062 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 265.448943
+[0] The total amount of wall time                        = 261.049149
 
 Test 062 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_csawmgt_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_csawmgt_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_csawmgt_debug
 Checking test 063 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 303.358343
+[0] The total amount of wall time                        = 297.412187
 
 Test 063 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ugwpv1_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_ugwpv1_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ugwpv1_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_ugwpv1_debug
 Checking test 064 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 183.252928
+[0] The total amount of wall time                        = 182.402060
 
 Test 064 control_ugwpv1_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_ras_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_ras_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_ras_debug
 Checking test 065 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 171.407010
+[0] The total amount of wall time                        = 169.799323
 
 Test 065 control_ras_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_thompson_debug
 Checking test 066 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 198.135680
+[0] The total amount of wall time                        = 197.499074
 
 Test 066 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_thompson_no_aero_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_thompson_no_aero_debug
 Checking test 067 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.945164
+[0] The total amount of wall time                        = 190.296152
 
 Test 067 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_regional_control_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/regional_control_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_regional_control_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/regional_control_debug
 Checking test 068 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2201,13 +2201,13 @@ Checking test 068 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 279.526447
+[0] The total amount of wall time                        = 277.593111
 
 Test 068 regional_control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_gsd_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_gsd_debug
 Checking test 069 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2272,13 +2272,13 @@ Checking test 069 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 235.546357
+[0] The total amount of wall time                        = 233.965509
 
 Test 069 fv3_gsd_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_gsd_diag3d_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_gsd_diag3d_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_gsd_diag3d_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_gsd_diag3d_debug
 Checking test 070 fv3_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2343,13 +2343,13 @@ Checking test 070 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 293.600415
+[0] The total amount of wall time                        = 302.788932
 
 Test 070 fv3_gsd_diag3d_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_rrfs_v1beta_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_rrfs_v1beta_debug
 Checking test 071 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2414,13 +2414,13 @@ Checking test 071 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 227.083055
+[0] The total amount of wall time                        = 226.023052
 
 Test 071 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_rrfs_v1alpha_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_rrfs_v1alpha_debug
 Checking test 072 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2485,13 +2485,13 @@ Checking test 072 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 227.135010
+[0] The total amount of wall time                        = 226.094388
 
 Test 072 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 073 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2556,13 +2556,13 @@ Checking test 073 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 238.676187
+[0] The total amount of wall time                        = 237.296592
 
 Test 073 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2577,73 +2577,73 @@ Checking test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 434.721293
+[0] The total amount of wall time                        = 434.929051
 
 Test 074 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_control_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_control_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_control_cfsr
 Checking test 075 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 108.986488
+[0] The total amount of wall time                        = 109.365230
 
 Test 075 datm_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_restart_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_control_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_restart_cfsr
 Checking test 076 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 79.015098
+[0] The total amount of wall time                        = 79.842569
 
 Test 076 datm_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_control_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_control_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_control_gefs
 Checking test 077 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 101.711361
+[0] The total amount of wall time                        = 103.703400
 
 Test 077 datm_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_bulk_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_bulk_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_bulk_cfsr
 Checking test 078 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 105.828107
+[0] The total amount of wall time                        = 106.944569
 
 Test 078 datm_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_bulk_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_bulk_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_bulk_gefs
 Checking test 079 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.520573
+[0] The total amount of wall time                        = 102.454078
 
 Test 079 datm_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_mx025_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_mx025_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_mx025_cfsr
 Checking test 080 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2652,13 +2652,13 @@ Checking test 080 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 420.602588
+[0] The total amount of wall time                        = 411.677251
 
 Test 080 datm_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_mx025_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_mx025_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_mx025_gefs
 Checking test 081 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2667,85 +2667,85 @@ Checking test 081 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 413.496130
+[0] The total amount of wall time                        = 395.453309
 
 Test 081 datm_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_debug_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_debug_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_debug_cfsr
 Checking test 082 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 304.221593
+[0] The total amount of wall time                        = 301.264603
 
 Test 082 datm_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_control_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_control_cfsr
 Checking test 083 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 176.132070
+[0] The total amount of wall time                        = 174.130304
 
 Test 083 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_restart_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_restart_cfsr
 Checking test 084 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 121.440894
+[0] The total amount of wall time                        = 118.614689
 
 Test 084 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_control_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_control_gefs
 Checking test 085 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 170.285463
+[0] The total amount of wall time                        = 169.078241
 
 Test 085 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_bulk_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_bulk_cfsr
 Checking test 086 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 177.112216
+[0] The total amount of wall time                        = 175.116908
 
 Test 086 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_bulk_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_bulk_gefs
 Checking test 087 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.851877
+[0] The total amount of wall time                        = 169.815211
 
 Test 087 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_mx025_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_mx025_gefs
 Checking test 088 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2754,35 +2754,35 @@ Checking test 088 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 389.212147
+[0] The total amount of wall time                        = 389.372273
 
 Test 088 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_multiple_files_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_multiple_files_cfsr
 Checking test 089 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.449754
+[0] The total amount of wall time                        = 175.118678
 
 Test 089 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/datm_cdeps_debug_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/datm_cdeps_debug_cfsr
 Checking test 090 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 499.502719
+[0] The total amount of wall time                        = 500.597097
 
 Test 090 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210611/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_189439/control_atmwav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210615/control_atmwav
+working dir  = /gpfs/dell2/emc/modeling/noscrub/Dusan.Jovic/ufs/pr641/ptmp/Dusan.Jovic/FV3_RT/rt_40160/control_atmwav
 Checking test 091 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2825,11 +2825,11 @@ Checking test 091 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 364.324131
+[0] The total amount of wall time                        = 363.984753
 
 Test 091 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 11 21:56:44 UTC 2021
-Elapsed time: 01h:08m:25s. Have a nice day!
+Tue Jun 15 17:12:10 UTC 2021
+Elapsed time: 01h:11m:08s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -71,11 +71,11 @@ RUN     | control_noahmp                                                        
 COMPILE | APP=ATM SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP 32BIT=Y                                       |                                         | fv3 |
 RUN     | regional_control                                                                                                        |                                         | fv3 |
 RUN     | regional_restart                                                                                                        |                                         | fv3 | regional_control
-RUN     | regional_quilt                                                                                                          |                                         | fv3 |
+RUN     | regional_quilt                                                                                                          | - wcoss_cray                            | fv3 |
 RUN     | regional_quilt_2threads                                                                                                 | - wcoss_cray jet.intel                  |     |
 RUN     | regional_quilt_hafs                                                                                                     |                                         | fv3 |
 RUN     | regional_quilt_netcdf_parallel                                                                                          |                                         | fv3 |
-RUN     | regional_quilt_RRTMGP                                                                                                   |                                         | fv3 |
+RUN     | regional_quilt_RRTMGP                                                                                                   | - wcoss_cray                            | fv3 |
 
 # Run multigases test in REPRO mode to avoid numerical instability in the deep atmosphere
 #COMPILE | APP=ATM SUITES=FV3_GFS_v16_fv3wam 32BIT=Y MULTI_GASES=Y REPRO=Y                                                         |                                         | fv3 |

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -413,14 +413,14 @@ if [[ $TESTS_FILE =~ '35d' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20210611
+BL_DATE=20210615
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 else
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}}
 fi
 
-INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20210528}
+INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20210614}
 INPUTDATA_ROOT_WW3=${INPUTDATA_ROOT}/WW3_input_data_20210503
 INPUTDATA_ROOT_BMIC=${INPUTDATA_ROOT_BMIC:-$DISKNM/NEMSfv3gfs/BM_IC-20210212}
 


### PR DESCRIPTION
Ready for review
# PR Checklist
https://github.com/ufs-community/ufs-weather-model/issues/576

Only standalone model (regional configurations) should include a new field in the diag_table:
"gfs_phys",    "pratemax",   "pratemax",    "fv3_history2d",  "all",  .false.,  "none",  2

## Description

This PR adds the hourly maximum precipitation rate in mm/hr for all microphysical schemes and will be used only by regional configurations.  Results for regional configurations will change because pratemax, as noted above, will be added to the diag_table.  Global configurations will not use pratemax, therefore, results would be unchanged.  

### Issue(s) addressed
https://github.com/ufs-community/ufs-weather-model/issues/576

## Testing
Tested on hera with intel. New baseline was created for the regional configuration and a 2nd RT was run to confirm bit identical results.  For global applications, no new baseline was created and results were bit identical.

- [x] hera.intel
- [x] hera.gnu
- [ ] orion.intel - skip, not enough resources on Orion at this moment
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [x] CI

## Dependencies
fv3atm,ccpp/physics
https://github.com/NOAA-EMC/fv3atm/pull/327
https://github.com/NCAR/ccpp-physics/pull/675
