### PR TITLE
Update GNU and Intel compiler versions on Cheyenne, don't run control_debug_2threads when creating baselines

### DIFF
--- a/modulefiles/ufs_cheyenne.gnu
+++ b/modulefiles/ufs_cheyenne.gnu
@@ -10,14 +10,14 @@ module load cmake/3.18.2
 
 # load programming environment
 module load ncarenv/1.3
-module load gnu/9.1.0
+module load gnu/10.1.0
 module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
 module load hpc/1.1.0
-module load hpc-gnu/9.1.0
+module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22
 
 module load ufs_common

--- a/modulefiles/ufs_cheyenne.gnu_debug
+++ b/modulefiles/ufs_cheyenne.gnu_debug
@@ -10,14 +10,14 @@ module load cmake/3.18.2
 
 # load programming environment
 module load ncarenv/1.3
-module load gnu/9.1.0
+module load gnu/10.1.0
 module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
 module load hpc/1.1.0
-module load hpc-gnu/9.1.0
+module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22
 
 module load ufs_common_debug

--- a/modulefiles/ufs_cheyenne.intel
+++ b/modulefiles/ufs_cheyenne.intel
@@ -10,14 +10,14 @@ module load cmake/3.18.2
 
 # load programming environment
 module load ncarenv/1.3
-module load intel/19.1.1
+module load intel/2021.2
 module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
 module load hpc/1.1.0
-module load hpc-intel/19.1.1
+module load hpc-intel/2021.2
 module load hpc-mpt/2.22
 
 module load ufs_common

--- a/modulefiles/ufs_cheyenne.intel_debug
+++ b/modulefiles/ufs_cheyenne.intel_debug
@@ -10,14 +10,14 @@ module load cmake/3.18.2
 
 # load programming environment
 module load ncarenv/1.3
-module load intel/19.1.1
+module load intel/2021.2
 module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
 module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
 module load hpc/1.1.0
-module load hpc-intel/19.1.1
+module load hpc-intel/2021.2
 module load hpc-mpt/2.22
 
 module load ufs_common_debug

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -109,7 +109,7 @@ RUN     | fv3_esg_HAFS_v0_hwrf_thompson                                         
 
 COMPILE | APP=ATM DEBUG=Y SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp 32BIT=Y                |           | fv3 |
 RUN     | control_debug                                                                                                           |                                         | fv3 |
-RUN     | control_2threads_debug                                                                                                  | - wcoss_cray                            | fv3 |
+RUN     | control_2threads_debug                                                                                                  | - wcoss_cray                            |     |
 RUN     | control_CubedSphereGrid_debug                                                                                           |                                         | fv3 |
 RUN     | control_wrtGauss_netcdf_parallel_debug                                                                                  |                                         | fv3 |
 RUN     | control_stochy_debug                                                                                                    |                                         | fv3 |


### PR DESCRIPTION
# PR Checklist

- [X] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [X] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

- Update compiler versions for GNU from 9.1.0 to 10.1.0 and Intel from 19.1.1 to 2021.2.0 (=20.2.0) on Cheyenne.
- Fix bug in `tests/rt.conf`, `control_debug_2threads` should not be run when baselines are created.

### Issue(s) addressed

Fixes https://github.com/ufs-community/ufs-weather-model/issues/671

## Testing

### Preliminary testing:

I created new baselines with Intel 2021.2.0 using `rt.conf` and GNU 10.1.0 using `rt_gnu.conf` on Cheyenne, then verified against those baselines.

With GNU: all tests pass

[rt_cheyenne_gnu_create.log](https://github.com/ufs-community/ufs-weather-model/files/6729400/rt_cheyenne_gnu_create.log)
[rt_cheyenne_gnu_verify.log](https://github.com/ufs-community/ufs-weather-model/files/6729401/rt_cheyenne_gnu_verify.log)

With Intel: all tests pass

[rt_cheyenne_intel_create.log](https://github.com/ufs-community/ufs-weather-model/files/6730163/rt_cheyenne_intel_create.log)
[rt_cheyenne_intel_verify.log](https://github.com/ufs-community/ufs-weather-model/files/6730164/rt_cheyenne_intel_verify.log)

### Final regression testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] CI

## Dependencies

If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
