### PR TITLE
fv3atm: fix time dimension in restart files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = fix_zorl_in_fv3gfsio
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
# PR Checklist

- [X] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [X] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

This PR only updates the submodule pointer for fv3atm for the changes described in https://github.com/NOAA-EMC/fv3atm/pull/349.

No new input data required.

New regression test baselines required, because the surface restart files are changed. **No changes to the checksums of the regression test runs (to be confirmed!)**

### Issue(s) addressed

See https://github.com/NOAA-EMC/fv3atm/pull/349

## Testing

(1) On gaea.intel: create new baselines and verify against it - all tests pass.

[rt_gaea_intel_create.log](https://github.com/ufs-community/ufs-weather-model/files/6835285/rt_gaea_intel_create.log)
[rt_gaea_intel_verify.log](https://github.com/ufs-community/ufs-weather-model/files/6835286/rt_gaea_intel_verify.log)

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] CI

## Dependencies

- waiting on https://github.com/NOAA-EMC/fv3atm/pull/349

