### PR TITLE
Wrapper PR for: Thompson inner loop, Thompson subcycling bugfix, remove snet from noah lsm, fix time dimension in restart files, rt.sh bugfix for PBS, and more!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = thompson_inner_loop_subcycling_bugfix_noah_bugfix
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = thompson_inner_loop_subcycling_bugfix_noah_bugfix
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,14 +1,14 @@
-Wed Jul 21 11:28:07 MDT 2021
+Thu Jul 22 14:30:56 MDT 2021
 Start Regression test
 
 Compile 001 elapsed time 349 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 341 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 313 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 378 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 154 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 002 elapsed time 334 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 308 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 376 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 158 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -51,13 +51,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 288.664523
+0:The total amount of wall time                        = 280.428439
 
 Test 001 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -96,13 +96,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 136.737587
+0:The total amount of wall time                        = 138.148047
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_stochy
 Checking test 003 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -113,13 +113,13 @@ Checking test 003 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 189.861446
+0:The total amount of wall time                        = 186.595035
 
 Test 003 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_flake
 Checking test 004 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -130,13 +130,13 @@ Checking test 004 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 349.965359
+0:The total amount of wall time                        = 347.561894
 
 Test 004 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_rrtmgp
 Checking test 005 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -147,13 +147,13 @@ Checking test 005 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 361.485166
+0:The total amount of wall time                        = 339.854798
 
 Test 005 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -164,13 +164,13 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 359.177116
+0:The total amount of wall time                        = 362.362791
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -181,13 +181,13 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 340.443045
+0:The total amount of wall time                        = 346.628558
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_ugwpv1
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_ugwpv1
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_ugwpv1
 Checking test 008 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -198,13 +198,13 @@ Checking test 008 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 310.217576
+0:The total amount of wall time                        = 299.381856
 
 Test 008 control_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -215,13 +215,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 295.298170
+0:The total amount of wall time                        = 288.142734
 
 Test 009 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_gsd
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_gsd
 Checking test 010 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -310,13 +310,13 @@ Checking test 010 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 445.961441
+0:The total amount of wall time                        = 441.049561
 
 Test 010 fv3_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_rrfs_v1alpha
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_rrfs_v1alpha
 Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -381,13 +381,13 @@ Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 165.352583
+0:The total amount of wall time                        = 161.531594
 
 Test 011 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_rrfs_v1beta
 Checking test 012 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -452,13 +452,13 @@ Checking test 012 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 164.610461
+0:The total amount of wall time                        = 162.964181
 
 Test 012 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -523,13 +523,13 @@ Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 247.421502
+0:The total amount of wall time                        = 248.713126
 
 Test 013 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -544,39 +544,39 @@ Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 453.607012
+0:The total amount of wall time                        = 452.907096
 
 Test 014 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_debug
 Checking test 015 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.603588
+0:The total amount of wall time                        = 82.188013
 
 Test 015 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_diag_debug
 Checking test 016 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.339895
+0:The total amount of wall time                        = 89.722477
 
 Test 016 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/regional_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_regional_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/regional_control_debug
 Checking test 017 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -584,13 +584,13 @@ Checking test 017 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 129.531923
+0:The total amount of wall time                        = 128.575471
 
 Test 017 regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_rrfs_v1alpha_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_rrfs_v1alpha_debug
 Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -655,13 +655,13 @@ Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 106.769837
+0:The total amount of wall time                        = 105.256527
 
 Test 018 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_rrfs_v1beta_debug
 Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -726,13 +726,13 @@ Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 107.389229
+0:The total amount of wall time                        = 105.469062
 
 Test 019 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_gsd_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_gsd_debug
 Checking test 020 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -797,13 +797,13 @@ Checking test 020 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 136.469360
+0:The total amount of wall time                        = 134.708454
 
 Test 020 fv3_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_gsd_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_gsd_diag_debug
 Checking test 021 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -830,92 +830,105 @@ Checking test 021 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 310.545969
+0:The total amount of wall time                        = 287.338736
 
 Test 021 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_thompson_debug
 Checking test 022 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 98.414440
+0:The total amount of wall time                        = 96.245173
 
 Test 022 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_thompson_no_aero_debug
 Checking test 023 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.422534
+0:The total amount of wall time                        = 93.056922
 
 Test 023 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_thompson_extdiag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_debug_extdiag
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_thompson_extdiag_debug
 Checking test 024 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 104.100541
+0:The total amount of wall time                        = 101.918689
 
 Test 024 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_rrtmgp_debug
 Checking test 025 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.640310
+0:The total amount of wall time                        = 91.018153
 
 Test 025 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_ugwpv1_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_ugwpv1_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_ugwpv1_debug
 Checking test 026 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.992901
+0:The total amount of wall time                        = 88.409908
 
 Test 026 control_ugwpv1_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_ras_debug
 Checking test 027 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.401682
+0:The total amount of wall time                        = 111.665452
 
 Test 027 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/control_noahmp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/control_noahmp_debug
+Checking test 028 control_noahmp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 83.150475
+
+Test 028 control_noahmp_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 029 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -979,14 +992,14 @@ Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 108.422330
+0:The total amount of wall time                        = 107.185342
 
-Test 028 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 029 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_69430/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_6965/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1000,11 +1013,11 @@ Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 245.138285
+0:The total amount of wall time                        = 213.335283
 
-Test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 12:26:03 MDT 2021
-Elapsed time: 00h:57m:57s. Have a nice day!
+Thu Jul 22 14:49:59 MDT 2021
+Elapsed time: 00h:19m:03s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,26 +1,26 @@
-Wed Jul 21 12:47:42 MDT 2021
+Thu Jul 22 14:49:50 MDT 2021
 Start Regression test
 
-Compile 001 elapsed time 958 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1051 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 316 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 704 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 878 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 733 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 816 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 247 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 211 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 217 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 954 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1046 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 291 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 690 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 879 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 731 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 805 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 704 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 223 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 196 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 013 elapsed time 351 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 171 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 375 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 168 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 692 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 161 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 364 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 160 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 713 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 95.313975
+0:The total amount of wall time                        = 96.695244
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 56.180870
+0:The total amount of wall time                        = 52.925791
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 256.809857
+0:The total amount of wall time                        = 255.244187
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 92.546660
+0:The total amount of wall time                        = 90.567994
 
 Test 004 cpld_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_ca
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_ca
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.866511
+0:The total amount of wall time                        = 94.351955
 
 Test 005 cpld_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 406.610585
+0:The total amount of wall time                        = 406.191641
 
 Test 006 cpld_control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_restart_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 283.493590
+0:The total amount of wall time                        = 282.018166
 
 Test 007 cpld_restart_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 878.783987
+0:The total amount of wall time                        = 869.999356
 
 Test 008 cpld_control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_restart_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 454.172165
+0:The total amount of wall time                        = 465.193019
 
 Test 009 cpld_restart_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_bmark_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 664.102305
+0:The total amount of wall time                        = 649.410449
 
 Test 010 cpld_bmark_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_restart_bmark_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 396.712124
+0:The total amount of wall time                        = 386.246736
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16_nsst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_bmark_v16_nsst
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16_nsst
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 690.466279
+0:The total amount of wall time                        = 684.501969
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_bmark_wave_v16
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 803.597854
+0:The total amount of wall time                        = 776.457950
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_wave
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_control_wave
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_wave
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -781,13 +781,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 125.050364
+0:The total amount of wall time                        = 121.750669
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/cpld_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -837,13 +837,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 286.801341
+0:The total amount of wall time                        = 286.767945
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -886,13 +886,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.893855
+0:The total amount of wall time                        = 166.334629
 
 Test 016 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -935,13 +935,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.218269
+0:The total amount of wall time                        = 169.597821
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -984,13 +984,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 348.299385
+0:The total amount of wall time                        = 347.476566
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1029,13 +1029,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 76.414040
+0:The total amount of wall time                        = 73.783653
 
 Test 019 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_CubedSphereGrid
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1062,30 +1062,30 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 143.121793
+0:The total amount of wall time                        = 140.694561
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 187.811537
+0:The total amount of wall time                        = 184.600610
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c192
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1096,13 +1096,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 583.702342
+0:The total amount of wall time                        = 573.389666
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1113,13 +1113,13 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1066.817231
+0:The total amount of wall time                        = 1057.465959
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_c384gdas
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384gdas
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1162,13 +1162,13 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 914.227416
+0:The total amount of wall time                        = 905.002767
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1179,26 +1179,26 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 113.995173
+0:The total amount of wall time                        = 112.604179
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_stochy_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_stochy_restart
 Checking test 026 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 58.196252
+0:The total amount of wall time                        = 56.769182
 
 Test 026 control_stochy_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_ca
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ca
 Checking test 027 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1209,13 +1209,13 @@ Checking test 027 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 111.530769
+0:The total amount of wall time                        = 111.206039
 
 Test 027 control_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_lndp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1226,13 +1226,13 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 115.385076
+0:The total amount of wall time                        = 114.784004
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_lheatstrg
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_lheatstrg
 Checking test 029 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1243,13 +1243,13 @@ Checking test 029 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 169.460603
+0:The total amount of wall time                        = 166.742217
 
 Test 029 control_lheatstrg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lseaspray
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_lseaspray
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lseaspray
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_lseaspray
 Checking test 030 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1260,13 +1260,13 @@ Checking test 030 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 179.188491
+0:The total amount of wall time                        = 176.063682
 
 Test 030 control_lseaspray PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_merra2
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_merra2
 Checking test 031 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1277,13 +1277,13 @@ Checking test 031 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 213.610424
+0:The total amount of wall time                        = 203.243568
 
 Test 031 control_merra2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_rrtmgp
 Checking test 032 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1294,14 +1294,14 @@ Checking test 032 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 269.280938
+0:The total amount of wall time                        = 274.877950
 
 Test 032 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_csawmg
-Checking test 033 control_csawmg results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_csawmgt
+Checking test 033 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1311,14 +1311,14 @@ Checking test 033 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 347.075330
+0:The total amount of wall time                        = 416.480922
 
-Test 033 control_csawmg PASS
+Test 033 control_csawmgt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_csawmgt
-Checking test 034 control_csawmgt results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_flake
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_flake
+Checking test 034 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1328,14 +1328,14 @@ Checking test 034 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 423.991823
+0:The total amount of wall time                        = 267.120448
 
-Test 034 control_csawmgt PASS
+Test 034 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_flake
-Checking test 035 control_flake results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ugwpv1
+Checking test 035 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1345,14 +1345,14 @@ Checking test 035 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 268.933216
+0:The total amount of wall time                        = 223.359071
 
-Test 035 control_flake PASS
+Test 035 control_ugwpv1 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_ugwpv1
-Checking test 036 control_ugwpv1 results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ras
+Checking test 036 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1362,14 +1362,14 @@ Checking test 036 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 227.636559
+0:The total amount of wall time                        = 205.850026
 
-Test 036 control_ugwpv1 PASS
+Test 036 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_ras
-Checking test 037 control_ras results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_thompson
+Checking test 037 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1379,14 +1379,14 @@ Checking test 037 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 207.467982
+0:The total amount of wall time                        = 257.696601
 
-Test 037 control_ras PASS
+Test 037 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_thompson
-Checking test 038 control_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_thompson_no_aero
+Checking test 038 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1396,14 +1396,14 @@ Checking test 038 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 256.633088
+0:The total amount of wall time                        = 246.559328
 
-Test 038 control_thompson PASS
+Test 038 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_thompson_no_aero
-Checking test 039 control_thompson_no_aero results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_noahmp
+Checking test 039 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1413,57 +1413,40 @@ Checking test 039 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 238.858353
+0:The total amount of wall time                        = 202.288915
 
-Test 039 control_thompson_no_aero PASS
-
-
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_noahmp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_noahmp
-Checking test 040 control_noahmp results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-0:The total amount of wall time                        = 202.247221
-
-Test 040 control_noahmp PASS
+Test 039 control_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_control
-Checking test 041 regional_control results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_control
+Checking test 040 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 352.130394
+0:The total amount of wall time                        = 353.515029
 
-Test 041 regional_control PASS
+Test 040 regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_restart
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_restart
-Checking test 042 regional_restart results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_restart
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_restart
+Checking test 041 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-0:The total amount of wall time                        = 193.915322
+0:The total amount of wall time                        = 193.141944
 
-Test 042 regional_restart PASS
+Test 041 regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_quilt
-Checking test 043 regional_quilt results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_quilt
+Checking test 042 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1473,14 +1456,14 @@ Checking test 043 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 344.371443
+0:The total amount of wall time                        = 348.962677
 
-Test 043 regional_quilt PASS
+Test 042 regional_quilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_quilt_2threads
-Checking test 044 regional_quilt_2threads results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_quilt_2threads
+Checking test 043 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1490,14 +1473,14 @@ Checking test 044 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 935.106087
+0:The total amount of wall time                        = 925.437387
 
-Test 044 regional_quilt_2threads PASS
+Test 043 regional_quilt_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_quilt_hafs
-Checking test 045 regional_quilt_hafs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_hafs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_quilt_hafs
+Checking test 044 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1505,28 +1488,28 @@ Checking test 045 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 346.638672
+0:The total amount of wall time                        = 344.329387
 
-Test 045 regional_quilt_hafs PASS
+Test 044 regional_quilt_hafs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_quilt_netcdf_parallel
-Checking test 046 regional_quilt_netcdf_parallel results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_quilt_netcdf_parallel
+Checking test 045 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 350.579582
+0:The total amount of wall time                        = 347.014607
 
-Test 046 regional_quilt_netcdf_parallel PASS
+Test 045 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_quilt_RRTMGP
-Checking test 047 regional_quilt_RRTMGP results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_quilt_RRTMGP
+Checking test 046 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1536,14 +1519,14 @@ Checking test 047 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 531.828916
+0:The total amount of wall time                        = 530.053393
 
-Test 047 regional_quilt_RRTMGP PASS
+Test 046 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_gsd
-Checking test 048 fv3_gsd results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_gsd
+Checking test 047 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1631,14 +1614,14 @@ Checking test 048 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 262.679897
+0:The total amount of wall time                        = 256.480630
 
-Test 048 fv3_gsd PASS
+Test 047 fv3_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_rrfs_v1alpha
-Checking test 049 fv3_rrfs_v1alpha results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_rrfs_v1alpha
+Checking test 048 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1702,14 +1685,14 @@ Checking test 049 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 104.701249
+0:The total amount of wall time                        = 100.453340
 
-Test 049 fv3_rrfs_v1alpha PASS
+Test 048 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rap
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_rap
-Checking test 050 fv3_rap results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rap
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_rap
+Checking test 049 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1773,14 +1756,14 @@ Checking test 050 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 103.304748
+0:The total amount of wall time                        = 100.432394
 
-Test 050 fv3_rap PASS
+Test 049 fv3_rap PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_hrrr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_hrrr
-Checking test 051 fv3_hrrr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_hrrr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_hrrr
+Checking test 050 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1844,14 +1827,14 @@ Checking test 051 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 102.466607
+0:The total amount of wall time                        = 98.491560
 
-Test 051 fv3_hrrr PASS
+Test 050 fv3_hrrr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_rrfs_v1beta
-Checking test 052 fv3_rrfs_v1beta results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_rrfs_v1beta
+Checking test 051 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1915,14 +1898,14 @@ Checking test 052 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 102.687128
+0:The total amount of wall time                        = 100.273750
 
-Test 052 fv3_rrfs_v1beta PASS
+Test 051 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_HAFS_v0_hwrf_thompson
-Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_HAFS_v0_hwrf_thompson
+Checking test 052 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1986,14 +1969,14 @@ Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 200.076689
+0:The total amount of wall time                        = 197.388448
 
-Test 053 fv3_HAFS_v0_hwrf_thompson PASS
+Test 052 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_esg_HAFS_v0_hwrf_thompson
-Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_esg_HAFS_v0_hwrf_thompson
+Checking test 053 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2007,40 +1990,40 @@ Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 342.251222
+0:The total amount of wall time                        = 339.931568
 
-Test 054 fv3_esg_HAFS_v0_hwrf_thompson PASS
+Test 053 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_debug
-Checking test 055 control_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_debug
+Checking test 054 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 156.289478
+0:The total amount of wall time                        = 153.957811
 
-Test 055 control_debug PASS
+Test 054 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_2threads_debug
-Checking test 056 control_2threads_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_2threads_debug
+Checking test 055 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 272.027920
+0:The total amount of wall time                        = 271.291449
 
-Test 056 control_2threads_debug PASS
+Test 055 control_2threads_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_CubedSphereGrid_debug
-Checking test 057 control_CubedSphereGrid_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_CubedSphereGrid_debug
+Checking test 056 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2066,210 +2049,236 @@ Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 169.180135
+0:The total amount of wall time                        = 169.020775
 
-Test 057 control_CubedSphereGrid_debug PASS
+Test 056 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_wrtGauss_netcdf_parallel_debug
-Checking test 058 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_wrtGauss_netcdf_parallel_debug
+Checking test 057 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 158.982960
+0:The total amount of wall time                        = 156.628920
 
-Test 058 control_wrtGauss_netcdf_parallel_debug PASS
+Test 057 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_stochy_debug
-Checking test 059 control_stochy_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_stochy_debug
+Checking test 058 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 177.850558
+0:The total amount of wall time                        = 176.528926
 
-Test 059 control_stochy_debug PASS
+Test 058 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ca_debug
+Checking test 059 control_ca_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 155.459098
+
+Test 059 control_ca_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_lndp_debug
 Checking test 060 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 159.750712
+0:The total amount of wall time                        = 158.641244
 
 Test 060 control_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_lheatstrg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_lheatstrg_debug
 Checking test 061 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.099905
+0:The total amount of wall time                        = 154.337451
 
 Test 061 control_lheatstrg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_merra2_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_merra2_debug
 Checking test 062 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 231.199595
+0:The total amount of wall time                        = 227.384009
 
 Test 062 control_merra2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_rrtmgp_debug
 Checking test 063 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 177.087181
+0:The total amount of wall time                        = 176.315077
 
 Test 063 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_csawmg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_csawmg_debug
 Checking test 064 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 271.013588
+0:The total amount of wall time                        = 267.551029
 
 Test 064 control_csawmg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_csawmgt_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_csawmgt_debug
 Checking test 065 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 301.292890
+0:The total amount of wall time                        = 298.999481
 
 Test 065 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_ugwpv1_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ugwpv1_debug
 Checking test 066 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 169.673863
+0:The total amount of wall time                        = 167.299324
 
 Test 066 control_ugwpv1_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_ras_debug
 Checking test 067 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 161.966966
+0:The total amount of wall time                        = 160.925072
 
 Test 067 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_diag_debug
-Checking test 068 control_diag_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_noahmp_debug
+Checking test 068 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 165.790387
+0:The total amount of wall time                        = 154.240542
 
-Test 068 control_diag_debug PASS
+Test 068 control_noahmp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_thompson_debug
-Checking test 069 control_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_diag_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_diag_debug
+Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 181.650131
+0:The total amount of wall time                        = 164.308648
 
-Test 069 control_thompson_debug PASS
+Test 069 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_thompson_no_aero_debug
-Checking test 070 control_thompson_no_aero_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_thompson_debug
+Checking test 070 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.569011
+0:The total amount of wall time                        = 180.066547
 
-Test 070 control_thompson_no_aero_debug PASS
+Test 070 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_thompson_extdiag_debug
-Checking test 071 control_thompson_extdiag_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_thompson_no_aero_debug
+Checking test 071 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 193.202833
+0:The total amount of wall time                        = 174.415914
 
-Test 071 control_thompson_extdiag_debug PASS
+Test 071 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/regional_control_debug
-Checking test 072 regional_control_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug_extdiag
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_thompson_extdiag_debug
+Checking test 072 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 190.071295
+
+Test 072 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/regional_control_debug
+Checking test 073 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 255.240581
+0:The total amount of wall time                        = 254.109541
 
-Test 072 regional_control_debug PASS
+Test 073 regional_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_gsd_debug
-Checking test 073 fv3_gsd_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_gsd_debug
+Checking test 074 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2333,14 +2342,14 @@ Checking test 073 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 263.454020
+0:The total amount of wall time                        = 261.892092
 
-Test 073 fv3_gsd_debug PASS
+Test 074 fv3_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_gsd_diag_debug
-Checking test 074 fv3_gsd_diag_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_diag_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_gsd_diag_debug
+Checking test 075 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2366,14 +2375,14 @@ Checking test 074 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 413.942909
+0:The total amount of wall time                        = 412.241638
 
-Test 074 fv3_gsd_diag_debug PASS
+Test 075 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_rrfs_v1beta_debug
-Checking test 075 fv3_rrfs_v1beta_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_rrfs_v1beta_debug
+Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2437,14 +2446,14 @@ Checking test 075 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 207.993525
+0:The total amount of wall time                        = 212.150657
 
-Test 075 fv3_rrfs_v1beta_debug PASS
+Test 076 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_rrfs_v1alpha_debug
-Checking test 076 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_rrfs_v1alpha_debug
+Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2508,14 +2517,14 @@ Checking test 076 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.619894
+0:The total amount of wall time                        = 207.487762
 
-Test 076 fv3_rrfs_v1alpha_debug PASS
+Test 077 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 077 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2579,14 +2588,14 @@ Checking test 077 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 220.348812
+0:The total amount of wall time                        = 217.591590
 
-Test 077 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 078 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 078 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2600,86 +2609,86 @@ Checking test 078 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 400.090237
+0:The total amount of wall time                        = 398.880504
 
-Test 078 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_control_cfsr
-Checking test 079 datm_control_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_control_cfsr
+Checking test 080 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 103.729952
+0:The total amount of wall time                        = 100.690993
 
-Test 079 datm_control_cfsr PASS
+Test 080 datm_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_restart_cfsr
-Checking test 080 datm_restart_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_restart_cfsr
+Checking test 081 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 63.949200
+0:The total amount of wall time                        = 63.074286
 
-Test 080 datm_restart_cfsr PASS
+Test 081 datm_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_control_gefs
-Checking test 081 datm_control_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_control_gefs
+Checking test 082 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 97.334914
+0:The total amount of wall time                        = 94.786118
 
-Test 081 datm_control_gefs PASS
+Test 082 datm_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_iau_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_control_iau_gefs
-Checking test 082 datm_control_iau_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_iau_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_control_iau_gefs
+Checking test 083 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.614728
+0:The total amount of wall time                        = 96.784791
 
-Test 082 datm_control_iau_gefs PASS
+Test 083 datm_control_iau_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_bulk_cfsr
-Checking test 083 datm_bulk_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_bulk_cfsr
+Checking test 084 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 100.378084
+0:The total amount of wall time                        = 97.686745
 
-Test 083 datm_bulk_cfsr PASS
+Test 084 datm_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_bulk_gefs
-Checking test 084 datm_bulk_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_bulk_gefs
+Checking test 085 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 91.778776
+0:The total amount of wall time                        = 94.961319
 
-Test 084 datm_bulk_gefs PASS
+Test 085 datm_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_mx025_cfsr
-Checking test 085 datm_mx025_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_mx025_cfsr
+Checking test 086 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2687,14 +2696,14 @@ Checking test 085 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 358.709000
+0:The total amount of wall time                        = 353.871449
 
-Test 085 datm_mx025_cfsr PASS
+Test 086 datm_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_mx025_gefs
-Checking test 086 datm_mx025_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_mx025_gefs
+Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2702,86 +2711,86 @@ Checking test 086 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 354.885915
+0:The total amount of wall time                        = 348.459054
 
-Test 086 datm_mx025_gefs PASS
+Test 087 datm_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_debug_cfsr
-Checking test 087 datm_debug_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_debug_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_debug_cfsr
+Checking test 088 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 267.747758
+0:The total amount of wall time                        = 265.637951
 
-Test 087 datm_debug_cfsr PASS
+Test 088 datm_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_control_cfsr
-Checking test 088 datm_cdeps_control_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_control_cfsr
+Checking test 089 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.521291
+0:The total amount of wall time                        = 159.281422
 
-Test 088 datm_cdeps_control_cfsr PASS
+Test 089 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_restart_cfsr
-Checking test 089 datm_cdeps_restart_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_restart_cfsr
+Checking test 090 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 103.870316
+0:The total amount of wall time                        = 100.059122
 
-Test 089 datm_cdeps_restart_cfsr PASS
+Test 090 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_control_gefs
-Checking test 090 datm_cdeps_control_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_control_gefs
+Checking test 091 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.173709
+0:The total amount of wall time                        = 157.961030
 
-Test 090 datm_cdeps_control_gefs PASS
+Test 091 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_bulk_cfsr
-Checking test 091 datm_cdeps_bulk_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_bulk_cfsr
+Checking test 092 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.958442
+0:The total amount of wall time                        = 166.654277
 
-Test 091 datm_cdeps_bulk_cfsr PASS
+Test 092 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_bulk_gefs
-Checking test 092 datm_cdeps_bulk_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_bulk_gefs
+Checking test 093 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.970700
+0:The total amount of wall time                        = 158.603461
 
-Test 092 datm_cdeps_bulk_gefs PASS
+Test 093 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_mx025_cfsr
-Checking test 093 datm_cdeps_mx025_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_mx025_cfsr
+Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2789,14 +2798,14 @@ Checking test 093 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 354.217153
+0:The total amount of wall time                        = 348.350952
 
-Test 093 datm_cdeps_mx025_cfsr PASS
+Test 094 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_mx025_gefs
-Checking test 094 datm_cdeps_mx025_gefs results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_mx025_gefs
+Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2804,36 +2813,36 @@ Checking test 094 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 352.888902
+0:The total amount of wall time                        = 346.298167
 
-Test 094 datm_cdeps_mx025_gefs PASS
+Test 095 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_multiple_files_cfsr
-Checking test 095 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_multiple_files_cfsr
+Checking test 096 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.768590
+0:The total amount of wall time                        = 164.897256
 
-Test 095 datm_cdeps_multiple_files_cfsr PASS
+Test 096 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/datm_cdeps_debug_cfsr
-Checking test 096 datm_cdeps_debug_cfsr results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/datm_cdeps_debug_cfsr
+Checking test 097 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 450.262430
+0:The total amount of wall time                        = 448.640908
 
-Test 096 datm_cdeps_debug_cfsr PASS
+Test 097 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_3200/control_atmwav
-Checking test 097 control_atmwav results ....
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atmwav
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_71256/control_atmwav
+Checking test 098 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2875,11 +2884,11 @@ Checking test 097 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 366.290831
+0:The total amount of wall time                        = 368.310798
 
-Test 097 control_atmwav PASS
+Test 098 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 13:56:49 MDT 2021
-Elapsed time: 01h:09m:08s. Have a nice day!
+Thu Jul 22 16:19:40 MDT 2021
+Elapsed time: 01h:29m:51s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,26 +1,26 @@
-Wed Jul 21 16:09:47 EDT 2021
+Thu Jul 22 18:03:55 EDT 2021
 Start Regression test
 
-Compile 001 elapsed time 765 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 807 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 273 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 685 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 717 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 668 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 679 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 690 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 776 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 830 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 286 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 708 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 735 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 694 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 718 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 739 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 009 elapsed time 260 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 241 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 249 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 240 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 312 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 196 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 317 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 174 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 651 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 010 elapsed time 247 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 272 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 277 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 321 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 193 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 316 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 208 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 702 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 90.793555
+The total amount of wall time                        = 97.791515
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 82.002506
+The total amount of wall time                        = 79.774334
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 117.594255
+The total amount of wall time                        = 154.007601
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 90.835475
+The total amount of wall time                        = 121.615974
 
 Test 004 cpld_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_ca
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 119.284602
+The total amount of wall time                        = 120.918097
 
 Test 005 cpld_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 435.204577
+The total amount of wall time                        = 436.077970
 
 Test 006 cpld_control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_restart_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 272.269156
+The total amount of wall time                        = 320.654277
 
 Test 007 cpld_restart_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 846.619389
+The total amount of wall time                        = 876.315390
 
 Test 008 cpld_control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_restart_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 443.180023
+The total amount of wall time                        = 443.059895
 
 Test 009 cpld_restart_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_bmark_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 648.853560
+The total amount of wall time                        = 696.174931
 
 Test 010 cpld_bmark_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_restart_bmark_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 388.476836
+The total amount of wall time                        = 391.360384
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16_nsst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_bmark_v16_nsst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16_nsst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 655.878553
+The total amount of wall time                        = 702.260316
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_bmark_wave_v16
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 728.311176
+The total amount of wall time                        = 747.200918
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_bmark_wave_v16_p7b
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16_p7b
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 883.256930
+The total amount of wall time                        = 873.496506
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_control_wave
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 126.764917
+The total amount of wall time                        = 107.667907
 
 Test 015 cpld_control_wave PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/cpld_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 262.698757
+The total amount of wall time                        = 274.636405
 
 Test 016 cpld_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 194.989387
+The total amount of wall time                        = 194.599873
 
 Test 017 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -986,13 +986,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 195.291414
+The total amount of wall time                        = 197.175412
 
 Test 018 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1035,13 +1035,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.799195
+The total amount of wall time                        = 226.486547
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1080,13 +1080,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.259278
+The total amount of wall time                        = 96.427440
 
 Test 020 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,13 +1113,13 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 153.057072
+The total amount of wall time                        = 154.987529
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1130,13 +1130,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 282.776810
+The total amount of wall time                        = 231.635895
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1147,13 +1147,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 546.656206
+The total amount of wall time                        = 527.067484
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_stochy
 Checking test 024 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1164,26 +1164,26 @@ Checking test 024 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 135.725294
+The total amount of wall time                        = 157.622132
 
 Test 024 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_stochy_restart
 Checking test 025 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 90.189764
+The total amount of wall time                        = 60.426717
 
 Test 025 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_ca
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ca
 Checking test 026 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1194,13 +1194,13 @@ Checking test 026 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 117.297919
+The total amount of wall time                        = 146.103170
 
 Test 026 control_ca PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_lndp
 Checking test 027 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1211,13 +1211,13 @@ Checking test 027 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 142.316901
+The total amount of wall time                        = 144.903145
 
 Test 027 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_lheatstrg
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_lheatstrg
 Checking test 028 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1228,13 +1228,13 @@ Checking test 028 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 162.755501
+The total amount of wall time                        = 167.582813
 
 Test 028 control_lheatstrg PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lseaspray
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_lseaspray
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lseaspray
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_lseaspray
 Checking test 029 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1245,13 +1245,13 @@ Checking test 029 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 170.989327
+The total amount of wall time                        = 175.019174
 
 Test 029 control_lseaspray PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_merra2
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_merra2
 Checking test 030 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1262,13 +1262,13 @@ Checking test 030 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 193.880977
+The total amount of wall time                        = 319.915418
 
 Test 030 control_merra2 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_rrtmgp
 Checking test 031 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1279,13 +1279,13 @@ Checking test 031 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 247.304547
+The total amount of wall time                        = 248.414675
 
 Test 031 control_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_csawmg
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_csawmg
 Checking test 032 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1296,13 +1296,13 @@ Checking test 032 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 296.448599
+The total amount of wall time                        = 374.543263
 
 Test 032 control_csawmg PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_csawmgt
 Checking test 033 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1313,13 +1313,13 @@ Checking test 033 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 353.884987
+The total amount of wall time                        = 421.883497
 
 Test 033 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_flake
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_flake
 Checking test 034 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1330,13 +1330,13 @@ Checking test 034 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 254.611074
+The total amount of wall time                        = 269.114763
 
 Test 034 control_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_ugwpv1
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ugwpv1
 Checking test 035 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1347,13 +1347,13 @@ Checking test 035 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 223.298655
+The total amount of wall time                        = 227.241559
 
 Test 035 control_ugwpv1 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ras
 Checking test 036 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1364,13 +1364,13 @@ Checking test 036 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 221.040595
+The total amount of wall time                        = 198.775500
 
 Test 036 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_thompson
 Checking test 037 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,13 +1381,13 @@ Checking test 037 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 246.394896
+The total amount of wall time                        = 227.204343
 
 Test 037 control_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_thompson_no_aero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_thompson_no_aero
 Checking test 038 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1398,13 +1398,13 @@ Checking test 038 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 236.917563
+The total amount of wall time                        = 236.397057
 
 Test 038 control_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_noahmp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_noahmp
 Checking test 039 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1415,13 +1415,13 @@ Checking test 039 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 217.019907
+The total amount of wall time                        = 217.173352
 
 Test 039 control_noahmp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_control
 Checking test 040 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1429,25 +1429,25 @@ Checking test 040 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 326.559205
+The total amount of wall time                        = 329.947732
 
 Test 040 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_restart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_restart
 Checking test 041 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 181.959402
+The total amount of wall time                        = 176.405155
 
 Test 041 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_quilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_quilt
 Checking test 042 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1458,13 +1458,13 @@ Checking test 042 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 325.775191
+The total amount of wall time                        = 329.129951
 
 Test 042 regional_quilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_quilt_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_quilt_2threads
 Checking test 043 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1475,13 +1475,13 @@ Checking test 043 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 280.454705
+The total amount of wall time                        = 285.946832
 
 Test 043 regional_quilt_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_quilt_hafs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_quilt_hafs
 Checking test 044 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1490,13 +1490,13 @@ Checking test 044 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 325.297921
+The total amount of wall time                        = 328.366526
 
 Test 044 regional_quilt_hafs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_quilt_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_quilt_netcdf_parallel
 Checking test 045 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1504,13 +1504,13 @@ Checking test 045 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 335.698959
+The total amount of wall time                        = 335.908626
 
 Test 045 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_quilt_RRTMGP
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_quilt_RRTMGP
 Checking test 046 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1521,13 +1521,13 @@ Checking test 046 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 463.818389
+The total amount of wall time                        = 467.657501
 
 Test 046 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_gsd
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_gsd
 Checking test 047 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1616,13 +1616,13 @@ Checking test 047 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 264.029480
+The total amount of wall time                        = 264.139685
 
 Test 047 fv3_gsd PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_rrfs_v1alpha
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_rrfs_v1alpha
 Checking test 048 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1687,13 +1687,13 @@ Checking test 048 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 123.301514
+The total amount of wall time                        = 115.624710
 
 Test 048 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rap
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_rap
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rap
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_rap
 Checking test 049 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1758,13 +1758,13 @@ Checking test 049 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 118.699288
+The total amount of wall time                        = 123.757455
 
 Test 049 fv3_rap PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_hrrr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_hrrr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_hrrr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_hrrr
 Checking test 050 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1829,13 +1829,13 @@ Checking test 050 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 91.301074
+The total amount of wall time                        = 117.886982
 
 Test 050 fv3_hrrr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_rrfs_v1beta
 Checking test 051 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1900,13 +1900,13 @@ Checking test 051 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 92.521660
+The total amount of wall time                        = 120.109346
 
 Test 051 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1971,13 +1971,13 @@ Checking test 052 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 162.280164
+The total amount of wall time                        = 193.940070
 
 Test 052 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 053 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1992,39 +1992,39 @@ Checking test 053 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 327.665419
+The total amount of wall time                        = 323.088767
 
 Test 053 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_debug
 Checking test 054 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.266177
+The total amount of wall time                        = 147.266418
 
 Test 054 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_2threads_debug
 Checking test 055 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 259.713146
+The total amount of wall time                        = 262.162554
 
 Test 055 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_CubedSphereGrid_debug
 Checking test 056 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2051,210 +2051,236 @@ Checking test 056 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 155.123242
+The total amount of wall time                        = 157.238483
 
 Test 056 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_wrtGauss_netcdf_parallel_debug
 Checking test 057 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.000376
+The total amount of wall time                        = 151.258727
 
 Test 057 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_stochy_debug
 Checking test 058 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.235123
+The total amount of wall time                        = 171.535721
 
 Test 058 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_lndp_debug
-Checking test 059 control_lndp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ca_debug
+Checking test 059 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 151.316028
+The total amount of wall time                        = 148.955987
 
-Test 059 control_lndp_debug PASS
+Test 059 control_ca_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_lheatstrg_debug
-Checking test 060 control_lheatstrg_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_lndp_debug
+Checking test 060 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.205213
+The total amount of wall time                        = 150.811015
 
-Test 060 control_lheatstrg_debug PASS
+Test 060 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_merra2_debug
-Checking test 061 control_merra2_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_lheatstrg_debug
+Checking test 061 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 221.297296
+The total amount of wall time                        = 147.778203
 
-Test 061 control_merra2_debug PASS
+Test 061 control_lheatstrg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_rrtmgp_debug
-Checking test 062 control_rrtmgp_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_merra2_debug
+Checking test 062 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.180284
+The total amount of wall time                        = 245.737344
 
-Test 062 control_rrtmgp_debug PASS
+Test 062 control_merra2_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_csawmg_debug
-Checking test 063 control_csawmg_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_rrtmgp_debug
+Checking test 063 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 257.734990
+The total amount of wall time                        = 168.387581
 
-Test 063 control_csawmg_debug PASS
+Test 063 control_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_csawmgt_debug
-Checking test 064 control_csawmgt_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_csawmg_debug
+Checking test 064 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.527170
+The total amount of wall time                        = 289.901091
 
-Test 064 control_csawmgt_debug PASS
+Test 064 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_ugwpv1_debug
-Checking test 065 control_ugwpv1_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_csawmgt_debug
+Checking test 065 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.214644
+The total amount of wall time                        = 322.485044
 
-Test 065 control_ugwpv1_debug PASS
+Test 065 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_ras_debug
-Checking test 066 control_ras_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ugwpv1_debug
+Checking test 066 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 151.457921
+The total amount of wall time                        = 159.990347
 
-Test 066 control_ras_debug PASS
+Test 066 control_ugwpv1_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_diag_debug
-Checking test 067 control_diag_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_ras_debug
+Checking test 067 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 154.199945
+The total amount of wall time                        = 153.385479
 
-Test 067 control_diag_debug PASS
+Test 067 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_thompson_debug
-Checking test 068 control_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_noahmp_debug
+Checking test 068 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 174.056356
+The total amount of wall time                        = 146.909382
 
-Test 068 control_thompson_debug PASS
+Test 068 control_noahmp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_thompson_no_aero_debug
-Checking test 069 control_thompson_no_aero_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_diag_debug
+Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.557188
+The total amount of wall time                        = 156.773606
 
-Test 069 control_thompson_no_aero_debug PASS
+Test 069 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_thompson_extdiag_debug
-Checking test 070 control_thompson_extdiag_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_thompson_debug
+Checking test 070 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 183.500207
+The total amount of wall time                        = 208.534574
 
-Test 070 control_thompson_extdiag_debug PASS
+Test 070 control_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/regional_control_debug
-Checking test 071 regional_control_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_thompson_no_aero_debug
+Checking test 071 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+The total amount of wall time                        = 168.872899
+
+Test 071 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug_extdiag
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_thompson_extdiag_debug
+Checking test 072 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+The total amount of wall time                        = 182.305212
+
+Test 072 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/regional_control_debug
+Checking test 073 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 255.168398
+The total amount of wall time                        = 261.067298
 
-Test 071 regional_control_debug PASS
+Test 073 regional_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_gsd_debug
-Checking test 072 fv3_gsd_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_gsd_debug
+Checking test 074 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2318,14 +2344,14 @@ Checking test 072 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 250.745468
+The total amount of wall time                        = 253.440184
 
-Test 072 fv3_gsd_debug PASS
+Test 074 fv3_gsd_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_gsd_diag_debug
-Checking test 073 fv3_gsd_diag_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_gsd_diag_debug
+Checking test 075 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2351,14 +2377,14 @@ Checking test 073 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 342.051324
+The total amount of wall time                        = 345.554561
 
-Test 073 fv3_gsd_diag_debug PASS
+Test 075 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_rrfs_v1beta_debug
-Checking test 074 fv3_rrfs_v1beta_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_rrfs_v1beta_debug
+Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2422,14 +2448,14 @@ Checking test 074 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.071981
+The total amount of wall time                        = 199.819494
 
-Test 074 fv3_rrfs_v1beta_debug PASS
+Test 076 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_rrfs_v1alpha_debug
-Checking test 075 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_rrfs_v1alpha_debug
+Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2493,14 +2519,14 @@ Checking test 075 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 196.722859
+The total amount of wall time                        = 199.999174
 
-Test 075 fv3_rrfs_v1alpha_debug PASS
+Test 077 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 076 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2564,14 +2590,14 @@ Checking test 076 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 210.445618
+The total amount of wall time                        = 214.607536
 
-Test 076 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 078 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2585,86 +2611,86 @@ Checking test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 376.196141
+The total amount of wall time                        = 382.378806
 
-Test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_control_cfsr
-Checking test 078 datm_control_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_control_cfsr
+Checking test 080 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 126.098392
+The total amount of wall time                        = 99.527097
 
-Test 078 datm_control_cfsr PASS
+Test 080 datm_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_restart_cfsr
-Checking test 079 datm_restart_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_restart_cfsr
+Checking test 081 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 58.163937
+The total amount of wall time                        = 56.084118
 
-Test 079 datm_restart_cfsr PASS
+Test 081 datm_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_control_gefs
-Checking test 080 datm_control_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_control_gefs
+Checking test 082 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 90.484736
+The total amount of wall time                        = 91.307803
 
-Test 080 datm_control_gefs PASS
+Test 082 datm_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_control_iau_gefs
-Checking test 081 datm_control_iau_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_control_iau_gefs
+Checking test 083 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 122.738321
+The total amount of wall time                        = 128.369194
 
-Test 081 datm_control_iau_gefs PASS
+Test 083 datm_control_iau_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_bulk_cfsr
-Checking test 082 datm_bulk_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_bulk_cfsr
+Checking test 084 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 123.707196
+The total amount of wall time                        = 92.218684
 
-Test 082 datm_bulk_cfsr PASS
+Test 084 datm_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_bulk_gefs
-Checking test 083 datm_bulk_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_bulk_gefs
+Checking test 085 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 120.350239
+The total amount of wall time                        = 96.020827
 
-Test 083 datm_bulk_gefs PASS
+Test 085 datm_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_mx025_gefs
-Checking test 084 datm_mx025_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_mx025_gefs
+Checking test 086 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2672,86 +2698,86 @@ Checking test 084 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 373.102947
+The total amount of wall time                        = 386.366464
 
-Test 084 datm_mx025_gefs PASS
+Test 086 datm_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_debug_cfsr
-Checking test 085 datm_debug_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_debug_cfsr
+Checking test 087 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 248.902171
+The total amount of wall time                        = 249.143454
 
-Test 085 datm_debug_cfsr PASS
+Test 087 datm_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_control_cfsr
-Checking test 086 datm_cdeps_control_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_control_cfsr
+Checking test 088 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 146.713389
+The total amount of wall time                        = 151.598830
 
-Test 086 datm_cdeps_control_cfsr PASS
+Test 088 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_restart_cfsr
-Checking test 087 datm_cdeps_restart_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_restart_cfsr
+Checking test 089 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 85.010442
+The total amount of wall time                        = 85.811437
 
-Test 087 datm_cdeps_restart_cfsr PASS
+Test 089 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_control_gefs
-Checking test 088 datm_cdeps_control_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_control_gefs
+Checking test 090 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 144.602043
+The total amount of wall time                        = 145.363103
 
-Test 088 datm_cdeps_control_gefs PASS
+Test 090 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_bulk_cfsr
-Checking test 089 datm_cdeps_bulk_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_bulk_cfsr
+Checking test 091 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 146.948610
+The total amount of wall time                        = 148.221402
 
-Test 089 datm_cdeps_bulk_cfsr PASS
+Test 091 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_bulk_gefs
-Checking test 090 datm_cdeps_bulk_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_bulk_gefs
+Checking test 092 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.768510
+The total amount of wall time                        = 150.460832
 
-Test 090 datm_cdeps_bulk_gefs PASS
+Test 092 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_mx025_cfsr
-Checking test 091 datm_cdeps_mx025_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_mx025_cfsr
+Checking test 093 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2759,14 +2785,14 @@ Checking test 091 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 341.898054
+The total amount of wall time                        = 380.214522
 
-Test 091 datm_cdeps_mx025_cfsr PASS
+Test 093 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_mx025_gefs
-Checking test 092 datm_cdeps_mx025_gefs results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_mx025_gefs
+Checking test 094 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2774,36 +2800,36 @@ Checking test 092 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 333.044854
+The total amount of wall time                        = 374.120171
 
-Test 092 datm_cdeps_mx025_gefs PASS
+Test 094 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_multiple_files_cfsr
-Checking test 093 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_multiple_files_cfsr
+Checking test 095 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 149.974749
+The total amount of wall time                        = 149.486148
 
-Test 093 datm_cdeps_multiple_files_cfsr PASS
+Test 095 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/datm_cdeps_debug_cfsr
-Checking test 094 datm_cdeps_debug_cfsr results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/datm_cdeps_debug_cfsr
+Checking test 096 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 359.311694
+The total amount of wall time                        = 359.604617
 
-Test 094 datm_cdeps_debug_cfsr PASS
+Test 096 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_39563/control_atmwav
-Checking test 095 control_atmwav results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_43529/control_atmwav
+Checking test 097 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2845,11 +2871,11 @@ Checking test 095 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 370.555721
+The total amount of wall time                        = 346.150274
 
-Test 095 control_atmwav PASS
+Test 097 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 17:22:03 EDT 2021
-Elapsed time: 01h:12m:17s. Have a nice day!
+Thu Jul 22 19:23:10 EDT 2021
+Elapsed time: 01h:19m:16s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,17 @@
-Wed Jul 21 17:40:53 UTC 2021
+Thu Jul 22 22:56:30 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 175 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 168 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 88 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 192 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 103 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 008 elapsed time 91 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 171 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 174 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 101 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 208 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 115 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 008 elapsed time 93 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -54,13 +54,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 829.224435
+  0: The total amount of wall time                        = 835.959688
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -99,13 +99,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 398.323547
+  0: The total amount of wall time                        = 389.352918
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_stochy
 Checking test 003 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -116,13 +116,13 @@ Checking test 003 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 650.337158
+  0: The total amount of wall time                        = 661.327502
 
 Test 003 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_flake
 Checking test 004 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -133,13 +133,13 @@ Checking test 004 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1406.972290
+  0: The total amount of wall time                        = 1444.686295
 
 Test 004 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_rrtmgp
 Checking test 005 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -150,13 +150,13 @@ Checking test 005 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 883.715624
+  0: The total amount of wall time                        = 893.622980
 
 Test 005 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -167,13 +167,13 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1014.536264
+  0: The total amount of wall time                        = 1002.468084
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,13 +184,13 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 990.780897
+  0: The total amount of wall time                        = 976.809236
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_ugwpv1
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_ugwpv1
 Checking test 008 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -201,13 +201,13 @@ Checking test 008 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 968.177483
+  0: The total amount of wall time                        = 954.401742
 
 Test 008 control_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -218,13 +218,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 846.938389
+  0: The total amount of wall time                        = 846.444664
 
 Test 009 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_gsd
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_gsd
 Checking test 010 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -313,13 +313,13 @@ Checking test 010 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1069.184592
+  0: The total amount of wall time                        = 1094.190304
 
 Test 010 fv3_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_rrfs_v1alpha
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_rrfs_v1alpha
 Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -384,13 +384,13 @@ Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 391.549801
+  0: The total amount of wall time                        = 370.467741
 
 Test 011 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_rrfs_v1beta
 Checking test 012 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -455,13 +455,13 @@ Checking test 012 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 401.113458
+  0: The total amount of wall time                        = 416.730222
 
 Test 012 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 613.915080
+  0: The total amount of wall time                        = 663.329903
 
 Test 013 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -547,39 +547,39 @@ Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 443.030741
+ 0: The total amount of wall time                        = 439.047987
 
 Test 014 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_debug
 Checking test 015 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 103.561851
+  0: The total amount of wall time                        = 98.556780
 
 Test 015 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_diag_debug
 Checking test 016 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 121.681305
+  0: The total amount of wall time                        = 123.130491
 
 Test 016 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/regional_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/regional_control_debug
 Checking test 017 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -587,13 +587,13 @@ Checking test 017 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 117.463082
+ 0: The total amount of wall time                        = 117.417147
 
 Test 017 regional_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_rrfs_v1alpha_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_rrfs_v1alpha_debug
 Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -658,13 +658,13 @@ Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.595187
+  0: The total amount of wall time                        = 120.559047
 
 Test 018 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_rrfs_v1beta_debug
 Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -729,13 +729,13 @@ Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.609600
+  0: The total amount of wall time                        = 116.754043
 
 Test 019 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_gsd_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_gsd_debug
 Checking test 020 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -800,13 +800,13 @@ Checking test 020 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 149.260047
+  0: The total amount of wall time                        = 148.622483
 
 Test 020 fv3_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_gsd_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_gsd_diag_debug
 Checking test 021 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -833,92 +833,105 @@ Checking test 021 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 385.657740
+  0: The total amount of wall time                        = 490.046757
 
 Test 021 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_thompson_debug
 Checking test 022 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 113.436140
+  0: The total amount of wall time                        = 112.064121
 
 Test 022 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_thompson_no_aero_debug
 Checking test 023 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.577611
+  0: The total amount of wall time                        = 107.806017
 
 Test 023 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_thompson_extdiag_debug
 Checking test 024 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 130.433914
+  0: The total amount of wall time                        = 133.013124
 
 Test 024 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_rrtmgp_debug
 Checking test 025 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 109.531926
+  0: The total amount of wall time                        = 108.624810
 
 Test 025 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_ugwpv1_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_ugwpv1_debug
 Checking test 026 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.440516
+  0: The total amount of wall time                        = 103.433339
 
 Test 026 control_ugwpv1_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_ras_debug
 Checking test 027 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 102.110197
+  0: The total amount of wall time                        = 100.895252
 
 Test 027 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/control_noahmp_debug
+Checking test 028 control_noahmp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 99.790149
+
+Test 028 control_noahmp_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 029 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -982,14 +995,14 @@ Checking test 028 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.265705
+  0: The total amount of wall time                        = 131.583475
 
-Test 028 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 029 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1003,14 +1016,14 @@ Checking test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 232.284475
+ 0: The total amount of wall time                        = 238.728382
 
-Test 029 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/cpld_control
-Checking test 030 cpld_control results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/cpld_control
+Checking test 031 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
  Comparing sfcf024.tile3.nc .........OK
@@ -1059,14 +1072,14 @@ Checking test 030 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 619.994007
+  0: The total amount of wall time                        = 655.822575
 
-Test 030 cpld_control PASS
+Test 031 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/GNU/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_158991/cpld_debug
-Checking test 031 cpld_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/GNU/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_79849/cpld_debug
+Checking test 032 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
  Comparing sfcf006.tile3.nc .........OK
@@ -1115,11 +1128,11 @@ Checking test 031 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 332.689682
+  0: The total amount of wall time                        = 343.269946
 
-Test 031 cpld_debug PASS
+Test 032 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 18:19:44 UTC 2021
-Elapsed time: 00h:38m:51s. Have a nice day!
+Fri Jul 23 00:52:03 UTC 2021
+Elapsed time: 01h:55m:35s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,27 +1,27 @@
-Wed Jul 21 18:14:52 UTC 2021
+Thu Jul 22 22:56:54 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 1111 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 689 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 194 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 654 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 561 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 652 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 568 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 946 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 678 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 917 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 600 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 256 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 96 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 289 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 119 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 558 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 546 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 593 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 596 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 200 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 544 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 563 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 546 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 620 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 545 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 346 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 172 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 225 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 164 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 92 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 173 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 94 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 548 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 552 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -71,13 +71,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 86.409284
+  0: The total amount of wall time                        = 90.093706
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -127,13 +127,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 118.573876
+  0: The total amount of wall time                        = 51.282227
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -183,13 +183,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 93.244852
+  0: The total amount of wall time                        = 95.081341
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -239,13 +239,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.679306
+  0: The total amount of wall time                        = 97.511039
 
 Test 004 cpld_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_ca
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_ca
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -295,13 +295,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 83.199362
+  0: The total amount of wall time                        = 99.952831
 
 Test 005 cpld_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -351,13 +351,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 371.662103
+  0: The total amount of wall time                        = 378.313028
 
 Test 006 cpld_control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_restart_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -407,13 +407,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 273.271970
+  0: The total amount of wall time                        = 256.616022
 
 Test 007 cpld_restart_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -466,13 +466,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 762.118474
+  0: The total amount of wall time                        = 810.399102
 
 Test 008 cpld_control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_restart_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -525,13 +525,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 416.934428
+  0: The total amount of wall time                        = 443.605160
 
 Test 009 cpld_restart_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_bmark_v16
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -574,13 +574,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 626.075965
+  0: The total amount of wall time                        = 644.315613
 
 Test 010 cpld_bmark_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_restart_bmark_v16
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -623,13 +623,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 341.216413
+  0: The total amount of wall time                        = 362.528984
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16_nsst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_bmark_v16_nsst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16_nsst
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -672,13 +672,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 627.797961
+  0: The total amount of wall time                        = 639.569394
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_bmark_wave_v16
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -723,13 +723,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 617.487073
+  0: The total amount of wall time                        = 658.242252
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_bmark_wave_v16_p7b
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16_p7b
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -774,13 +774,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 663.975934
+  0: The total amount of wall time                        = 685.760030
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_control_wave
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_wave
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -833,13 +833,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 97.178157
+  0: The total amount of wall time                        = 97.896195
 
 Test 015 cpld_control_wave PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/cpld_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -889,13 +889,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 266.140143
+  0: The total amount of wall time                        = 272.208579
 
 Test 016 cpld_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -938,13 +938,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 152.588903
+  0: The total amount of wall time                        = 152.953453
 
 Test 017 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -987,13 +987,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.112466
+  0: The total amount of wall time                        = 153.350939
 
 Test 018 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1036,13 +1036,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 161.578307
+ 0: The total amount of wall time                        = 170.853759
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1081,13 +1081,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 62.207952
+  0: The total amount of wall time                        = 83.173164
 
 Test 020 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1114,13 +1114,13 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 114.690361
+  0: The total amount of wall time                        = 123.603735
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1131,13 +1131,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.295703
+  0: The total amount of wall time                        = 169.501191
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1148,13 +1148,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 454.122716
+  0: The total amount of wall time                        = 484.922151
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1165,13 +1165,13 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 770.652533
+  0: The total amount of wall time                        = 794.927510
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1214,13 +1214,13 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 643.854590
+  0: The total amount of wall time                        = 649.705696
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1231,26 +1231,26 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 105.511727
+  0: The total amount of wall time                        = 107.887611
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 54.441246
+  0: The total amount of wall time                        = 56.358005
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_ca
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ca
 Checking test 028 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1261,13 +1261,13 @@ Checking test 028 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 103.299263
+  0: The total amount of wall time                        = 111.439805
 
 Test 028 control_ca PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1278,13 +1278,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 107.101044
+  0: The total amount of wall time                        = 107.106352
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_lheatstrg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_lheatstrg
 Checking test 030 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1295,13 +1295,13 @@ Checking test 030 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 149.874497
+  0: The total amount of wall time                        = 148.349462
 
 Test 030 control_lheatstrg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lseaspray
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_lseaspray
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lseaspray
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_lseaspray
 Checking test 031 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1312,13 +1312,13 @@ Checking test 031 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 155.067124
+  0: The total amount of wall time                        = 160.997505
 
 Test 031 control_lseaspray PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_merra2
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_merra2
 Checking test 032 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1329,13 +1329,13 @@ Checking test 032 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 175.853405
+  0: The total amount of wall time                        = 177.907949
 
 Test 032 control_merra2 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_rrtmgp
 Checking test 033 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1346,13 +1346,13 @@ Checking test 033 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.602437
+  0: The total amount of wall time                        = 203.511937
 
 Test 033 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_csawmg
 Checking test 034 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1363,13 +1363,13 @@ Checking test 034 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 262.369438
+  0: The total amount of wall time                        = 330.768174
 
 Test 034 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_csawmgt
 Checking test 035 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1380,13 +1380,13 @@ Checking test 035 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 314.482109
+  0: The total amount of wall time                        = 572.961135
 
 Test 035 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_flake
 Checking test 036 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1397,13 +1397,13 @@ Checking test 036 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 223.679508
+  0: The total amount of wall time                        = 226.455887
 
 Test 036 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_ugwpv1
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ugwpv1
 Checking test 037 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1414,13 +1414,13 @@ Checking test 037 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.715067
+  0: The total amount of wall time                        = 302.039440
 
 Test 037 control_ugwpv1 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ras
 Checking test 038 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1431,13 +1431,13 @@ Checking test 038 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 174.842136
+  0: The total amount of wall time                        = 182.615288
 
 Test 038 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_thompson
 Checking test 039 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1448,13 +1448,13 @@ Checking test 039 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.470942
+  0: The total amount of wall time                        = 479.423553
 
 Test 039 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_thompson_no_aero
 Checking test 040 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1465,13 +1465,13 @@ Checking test 040 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 192.590829
+  0: The total amount of wall time                        = 378.933519
 
 Test 040 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_noahmp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_noahmp
 Checking test 041 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1482,13 +1482,13 @@ Checking test 041 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 173.383563
+  0: The total amount of wall time                        = 177.386177
 
 Test 041 control_noahmp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_control
 Checking test 042 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1496,25 +1496,25 @@ Checking test 042 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 284.368584
+ 0: The total amount of wall time                        = 334.525800
 
 Test 042 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_restart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_restart
 Checking test 043 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 163.497572
+ 0: The total amount of wall time                        = 157.296800
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_quilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_quilt
 Checking test 044 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1525,13 +1525,13 @@ Checking test 044 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 292.070479
+ 0: The total amount of wall time                        = 290.078325
 
 Test 044 regional_quilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_quilt_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_quilt_2threads
 Checking test 045 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1542,13 +1542,13 @@ Checking test 045 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 208.756097
+ 0: The total amount of wall time                        = 206.977451
 
 Test 045 regional_quilt_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_quilt_hafs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_quilt_hafs
 Checking test 046 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1557,27 +1557,27 @@ Checking test 046 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 291.250940
+ 0: The total amount of wall time                        = 289.867688
 
 Test 046 regional_quilt_hafs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_quilt_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_quilt_netcdf_parallel
 Checking test 047 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 294.948635
+ 0: The total amount of wall time                        = 291.226881
 
 Test 047 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_quilt_RRTMGP
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_quilt_RRTMGP
 Checking test 048 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1588,13 +1588,13 @@ Checking test 048 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 386.570898
+ 0: The total amount of wall time                        = 424.495087
 
 Test 048 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_gsd
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_gsd
 Checking test 049 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1683,13 +1683,13 @@ Checking test 049 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 218.094701
+  0: The total amount of wall time                        = 216.178223
 
 Test 049 fv3_gsd PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_rrfs_v1alpha
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_rrfs_v1alpha
 Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1754,13 +1754,13 @@ Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.728927
+  0: The total amount of wall time                        = 86.509878
 
 Test 050 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rap
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_rap
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rap
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_rap
 Checking test 051 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1825,13 +1825,13 @@ Checking test 051 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 85.029884
+  0: The total amount of wall time                        = 87.044001
 
 Test 051 fv3_rap PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_hrrr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_hrrr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_hrrr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_hrrr
 Checking test 052 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1896,13 +1896,13 @@ Checking test 052 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.524581
+  0: The total amount of wall time                        = 84.453483
 
 Test 052 fv3_hrrr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_rrfs_v1beta
 Checking test 053 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1967,13 +1967,13 @@ Checking test 053 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.276147
+  0: The total amount of wall time                        = 85.835024
 
 Test 053 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_HAFS_v0_hwrf_thompson
 Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2038,13 +2038,13 @@ Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.369808
+  0: The total amount of wall time                        = 153.865466
 
 Test 054 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2059,39 +2059,39 @@ Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 287.974899
+ 0: The total amount of wall time                        = 291.705953
 
 Test 055 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_debug
 Checking test 056 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 140.627271
+  0: The total amount of wall time                        = 141.768448
 
 Test 056 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_2threads_debug
 Checking test 057 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 215.867601
+ 0: The total amount of wall time                        = 209.094448
 
 Test 057 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_CubedSphereGrid_debug
 Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2118,210 +2118,236 @@ Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.666194
+  0: The total amount of wall time                        = 153.856758
 
 Test 058 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_wrtGauss_netcdf_parallel_debug
 Checking test 059 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 146.516088
+  0: The total amount of wall time                        = 147.132325
 
 Test 059 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_stochy_debug
 Checking test 060 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.940748
+  0: The total amount of wall time                        = 159.306207
 
 Test 060 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_lndp_debug
-Checking test 061 control_lndp_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ca_debug
+Checking test 061 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.845717
+  0: The total amount of wall time                        = 141.621586
 
-Test 061 control_lndp_debug PASS
+Test 061 control_ca_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_lheatstrg_debug
-Checking test 062 control_lheatstrg_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_lndp_debug
+Checking test 062 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 147.302257
+  0: The total amount of wall time                        = 141.830894
 
-Test 062 control_lheatstrg_debug PASS
+Test 062 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_merra2_debug
-Checking test 063 control_merra2_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_lheatstrg_debug
+Checking test 063 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.022629
+  0: The total amount of wall time                        = 140.691062
 
-Test 063 control_merra2_debug PASS
+Test 063 control_lheatstrg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_rrtmgp_debug
-Checking test 064 control_rrtmgp_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_merra2_debug
+Checking test 064 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.052486
+  0: The total amount of wall time                        = 190.318169
 
-Test 064 control_rrtmgp_debug PASS
+Test 064 control_merra2_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_csawmg_debug
-Checking test 065 control_csawmg_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_rrtmgp_debug
+Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.043352
+  0: The total amount of wall time                        = 164.039140
 
-Test 065 control_csawmg_debug PASS
+Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_csawmgt_debug
-Checking test 066 control_csawmgt_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_csawmg_debug
+Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.967074
+  0: The total amount of wall time                        = 226.658209
 
-Test 066 control_csawmgt_debug PASS
+Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_ugwpv1_debug
-Checking test 067 control_ugwpv1_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_csawmgt_debug
+Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.122202
+  0: The total amount of wall time                        = 257.990350
 
-Test 067 control_ugwpv1_debug PASS
+Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_ras_debug
-Checking test 068 control_ras_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ugwpv1_debug
+Checking test 068 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.153855
+  0: The total amount of wall time                        = 150.207016
 
-Test 068 control_ras_debug PASS
+Test 068 control_ugwpv1_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_diag_debug
-Checking test 069 control_diag_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_ras_debug
+Checking test 069 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.651077
+  0: The total amount of wall time                        = 143.460360
 
-Test 069 control_diag_debug PASS
+Test 069 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_thompson_debug
-Checking test 070 control_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_noahmp_debug
+Checking test 070 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.175927
+  0: The total amount of wall time                        = 142.430461
 
-Test 070 control_thompson_debug PASS
+Test 070 control_noahmp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_thompson_no_aero_debug
-Checking test 071 control_thompson_no_aero_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_diag_debug
+Checking test 071 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.724775
+  0: The total amount of wall time                        = 156.222309
 
-Test 071 control_thompson_no_aero_debug PASS
+Test 071 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_thompson_extdiag_debug
-Checking test 072 control_thompson_extdiag_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_thompson_debug
+Checking test 072 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.249751
+  0: The total amount of wall time                        = 166.611552
 
-Test 072 control_thompson_extdiag_debug PASS
+Test 072 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/regional_control_debug
-Checking test 073 regional_control_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_thompson_no_aero_debug
+Checking test 073 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 163.976837
+
+Test 073 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_thompson_extdiag_debug
+Checking test 074 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 178.109130
+
+Test 074 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/regional_control_debug
+Checking test 075 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 228.439880
+ 0: The total amount of wall time                        = 228.084787
 
-Test 073 regional_control_debug PASS
+Test 075 regional_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_gsd_debug
-Checking test 074 fv3_gsd_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_gsd_debug
+Checking test 076 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2385,14 +2411,14 @@ Checking test 074 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 241.592855
+  0: The total amount of wall time                        = 241.470569
 
-Test 074 fv3_gsd_debug PASS
+Test 076 fv3_gsd_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_gsd_diag_debug
-Checking test 075 fv3_gsd_diag_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_gsd_diag_debug
+Checking test 077 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2418,14 +2444,14 @@ Checking test 075 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 616.090963
+  0: The total amount of wall time                        = 580.054912
 
-Test 075 fv3_gsd_diag_debug PASS
+Test 077 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_rrfs_v1beta_debug
-Checking test 076 fv3_rrfs_v1beta_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_rrfs_v1beta_debug
+Checking test 078 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2489,14 +2515,14 @@ Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.062124
+  0: The total amount of wall time                        = 184.668762
 
-Test 076 fv3_rrfs_v1beta_debug PASS
+Test 078 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_rrfs_v1alpha_debug
-Checking test 077 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_rrfs_v1alpha_debug
+Checking test 079 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2560,14 +2586,14 @@ Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.394071
+  0: The total amount of wall time                        = 187.073215
 
-Test 077 fv3_rrfs_v1alpha_debug PASS
+Test 079 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 080 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2631,14 +2657,14 @@ Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.122898
+  0: The total amount of wall time                        = 209.522062
 
-Test 078 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 080 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2652,86 +2678,86 @@ Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 388.844798
+ 0: The total amount of wall time                        = 387.168434
 
-Test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_control_cfsr
-Checking test 080 datm_control_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_control_cfsr
+Checking test 082 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 96.245251
+  0: The total amount of wall time                        = 144.549123
 
-Test 080 datm_control_cfsr PASS
+Test 082 datm_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_restart_cfsr
-Checking test 081 datm_restart_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_restart_cfsr
+Checking test 083 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 86.728312
+  0: The total amount of wall time                        = 61.557097
 
-Test 081 datm_restart_cfsr PASS
+Test 083 datm_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_control_gefs
-Checking test 082 datm_control_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_control_gefs
+Checking test 084 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 89.649959
+  0: The total amount of wall time                        = 168.279619
 
-Test 082 datm_control_gefs PASS
+Test 084 datm_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_control_iau_gefs
-Checking test 083 datm_control_iau_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_control_iau_gefs
+Checking test 085 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 90.937932
+  0: The total amount of wall time                        = 155.771180
 
-Test 083 datm_control_iau_gefs PASS
+Test 085 datm_control_iau_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_bulk_cfsr
-Checking test 084 datm_bulk_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_bulk_cfsr
+Checking test 086 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.124788
+  0: The total amount of wall time                        = 101.368518
 
-Test 084 datm_bulk_cfsr PASS
+Test 086 datm_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_bulk_gefs
-Checking test 085 datm_bulk_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_bulk_gefs
+Checking test 087 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.104187
+  0: The total amount of wall time                        = 88.889613
 
-Test 085 datm_bulk_gefs PASS
+Test 087 datm_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_mx025_cfsr
-Checking test 086 datm_mx025_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_mx025_cfsr
+Checking test 088 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2739,14 +2765,14 @@ Checking test 086 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 335.668818
+  0: The total amount of wall time                        = 329.572969
 
-Test 086 datm_mx025_cfsr PASS
+Test 088 datm_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_mx025_gefs
-Checking test 087 datm_mx025_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_mx025_gefs
+Checking test 089 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2754,86 +2780,86 @@ Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 323.093826
+  0: The total amount of wall time                        = 356.736333
 
-Test 087 datm_mx025_gefs PASS
+Test 089 datm_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_debug_cfsr
-Checking test 088 datm_debug_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_debug_cfsr
+Checking test 090 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 252.664615
+  0: The total amount of wall time                        = 260.768794
 
-Test 088 datm_debug_cfsr PASS
+Test 090 datm_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_control_cfsr
-Checking test 089 datm_cdeps_control_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_control_cfsr
+Checking test 091 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.058171
+ 0: The total amount of wall time                        = 165.647498
 
-Test 089 datm_cdeps_control_cfsr PASS
+Test 091 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_restart_cfsr
-Checking test 090 datm_cdeps_restart_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_restart_cfsr
+Checking test 092 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 104.311936
+ 0: The total amount of wall time                        = 95.294649
 
-Test 090 datm_cdeps_restart_cfsr PASS
+Test 092 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_control_gefs
-Checking test 091 datm_cdeps_control_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_control_gefs
+Checking test 093 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.094388
+ 0: The total amount of wall time                        = 145.865748
 
-Test 091 datm_cdeps_control_gefs PASS
+Test 093 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_bulk_cfsr
-Checking test 092 datm_cdeps_bulk_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_bulk_cfsr
+Checking test 094 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.686307
+ 0: The total amount of wall time                        = 150.242635
 
-Test 092 datm_cdeps_bulk_cfsr PASS
+Test 094 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_bulk_gefs
-Checking test 093 datm_cdeps_bulk_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_bulk_gefs
+Checking test 095 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.663064
+ 0: The total amount of wall time                        = 142.543045
 
-Test 093 datm_cdeps_bulk_gefs PASS
+Test 095 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_mx025_cfsr
-Checking test 094 datm_cdeps_mx025_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_mx025_cfsr
+Checking test 096 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2841,14 +2867,14 @@ Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 314.885622
+  0: The total amount of wall time                        = 316.709594
 
-Test 094 datm_cdeps_mx025_cfsr PASS
+Test 096 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_mx025_gefs
-Checking test 095 datm_cdeps_mx025_gefs results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_mx025_gefs
+Checking test 097 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2856,36 +2882,36 @@ Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 311.587792
+  0: The total amount of wall time                        = 306.307591
 
-Test 095 datm_cdeps_mx025_gefs PASS
+Test 097 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_multiple_files_cfsr
-Checking test 096 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_multiple_files_cfsr
+Checking test 098 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.147155
+ 0: The total amount of wall time                        = 148.597601
 
-Test 096 datm_cdeps_multiple_files_cfsr PASS
+Test 098 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/datm_cdeps_debug_cfsr
-Checking test 097 datm_cdeps_debug_cfsr results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/datm_cdeps_debug_cfsr
+Checking test 099 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 447.214829
+ 0: The total amount of wall time                        = 439.794446
 
-Test 097 datm_cdeps_debug_cfsr PASS
+Test 099 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_atmwav
-Checking test 098 control_atmwav results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_atmwav
+Checking test 100 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2927,14 +2953,14 @@ Checking test 098 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.185102
+  0: The total amount of wall time                        = 325.711706
 
-Test 098 control_atmwav PASS
+Test 100 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_85434/control_atm_aerosols
-Checking test 099 control_atm_aerosols results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_191100/control_atm_aerosols
+Checking test 101 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2980,11 +3006,11 @@ Checking test 099 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 309.909398
+  0: The total amount of wall time                        = 352.743859
 
-Test 099 control_atm_aerosols PASS
+Test 101 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 19:24:13 UTC 2021
-Elapsed time: 01h:09m:22s. Have a nice day!
+Fri Jul 23 02:56:40 UTC 2021
+Elapsed time: 03h:59m:46s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,26 +1,26 @@
-Thu Jul 22 01:01:23 GMT 2021
+Fri Jul 23 00:33:36 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 2481 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 2531 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 270 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 2279 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 2393 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 2307 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 007 elapsed time 2314 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 2326 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 216 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 191 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 220 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 219 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 266 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 014 elapsed time 138 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 268 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 016 elapsed time 137 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 2329 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 2495 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2535 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 240 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 2294 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 2459 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 2284 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 007 elapsed time 2311 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 2329 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 211 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 209 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 211 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 211 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 253 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 014 elapsed time 142 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 265 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 016 elapsed time 140 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 2334 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 125.912509
+  0: The total amount of wall time                        = 125.568667
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 70.889662
+  0: The total amount of wall time                        = 74.914012
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 621.614741
+  0: The total amount of wall time                        = 562.112629
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_ca
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 119.979887
+  0: The total amount of wall time                        = 121.075214
 
 Test 004 cpld_ca PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 533.521886
+  0: The total amount of wall time                        = 523.697502
 
 Test 005 cpld_control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_restart_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 364.125394
+  0: The total amount of wall time                        = 363.830553
 
 Test 006 cpld_restart_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 633.496962
+  0: The total amount of wall time                        = 606.501456
 
 Test 007 cpld_control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_restart_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 347.625085
+  0: The total amount of wall time                        = 337.618974
 
 Test 008 cpld_restart_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_bmark_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 809.641321
+  0: The total amount of wall time                        = 813.944561
 
 Test 009 cpld_bmark_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_restart_bmark_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 447.281105
+  0: The total amount of wall time                        = 452.908312
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16_nsst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_bmark_v16_nsst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16_nsst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,13 +615,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 792.084408
+  0: The total amount of wall time                        = 804.555224
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_bmark_wave_v16
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -666,13 +666,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1040.488072
+  0: The total amount of wall time                        = 1041.712789
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_bmark_wave_v16_p7b
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16_p7b
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_bmark_wave_v16_p7b
 Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -717,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1095.189017
+  0: The total amount of wall time                        = 1092.495596
 
 Test 013 cpld_bmark_wave_v16_p7b PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_wave
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_control_wave
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 991.119483
+  0: The total amount of wall time                        = 994.564279
 
 Test 014 cpld_control_wave PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/cpld_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 357.620322
+  0: The total amount of wall time                        = 364.597433
 
 Test 015 cpld_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -881,13 +881,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.121687
+  0: The total amount of wall time                        = 204.851352
 
 Test 016 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -930,13 +930,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.972554
+  0: The total amount of wall time                        = 208.658339
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,13 +979,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 810.013024
+ 0: The total amount of wall time                        = 818.281285
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1024,13 +1024,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 85.677232
+  0: The total amount of wall time                        = 87.173722
 
 Test 019 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1057,13 +1057,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 184.189061
+  0: The total amount of wall time                        = 160.278729
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1074,13 +1074,13 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 241.674328
+  0: The total amount of wall time                        = 237.930339
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_c192
 Checking test 022 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1091,13 +1091,13 @@ Checking test 022 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 655.063742
+  0: The total amount of wall time                        = 640.414840
 
 Test 022 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_c384
 Checking test 023 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1108,13 +1108,13 @@ Checking test 023 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 895.619530
+  0: The total amount of wall time                        = 908.992124
 
 Test 023 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_c384gdas
 Checking test 024 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1157,13 +1157,13 @@ Checking test 024 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 772.173121
+  0: The total amount of wall time                        = 773.938376
 
 Test 024 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1174,26 +1174,26 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 146.269323
+  0: The total amount of wall time                        = 152.047278
 
 Test 025 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_stochy_restart
 Checking test 026 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.426816
+  0: The total amount of wall time                        = 75.818348
 
 Test 026 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_ca
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ca
 Checking test 027 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1204,13 +1204,13 @@ Checking test 027 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 152.232541
+  0: The total amount of wall time                        = 144.948517
 
 Test 027 control_ca PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1221,13 +1221,13 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 151.137568
+  0: The total amount of wall time                        = 151.501303
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_lheatstrg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_lheatstrg
 Checking test 029 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1238,13 +1238,13 @@ Checking test 029 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 217.745282
+  0: The total amount of wall time                        = 207.815259
 
 Test 029 control_lheatstrg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lseaspray
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_lseaspray
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lseaspray
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_lseaspray
 Checking test 030 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,13 +1255,13 @@ Checking test 030 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 227.485494
+  0: The total amount of wall time                        = 214.110807
 
 Test 030 control_lseaspray PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_merra2
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_merra2
 Checking test 031 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1272,13 +1272,13 @@ Checking test 031 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 235.882732
+  0: The total amount of wall time                        = 241.720546
 
 Test 031 control_merra2 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_rrtmgp
 Checking test 032 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1289,13 +1289,13 @@ Checking test 032 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 264.202545
+  0: The total amount of wall time                        = 265.138575
 
 Test 032 control_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_csawmgt
 Checking test 033 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1306,13 +1306,13 @@ Checking test 033 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 426.301176
+  0: The total amount of wall time                        = 429.939925
 
 Test 033 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_flake
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_flake
 Checking test 034 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1323,13 +1323,13 @@ Checking test 034 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 293.974048
+  0: The total amount of wall time                        = 295.113031
 
 Test 034 control_flake PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_ugwpv1
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ugwpv1
 Checking test 035 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1340,13 +1340,13 @@ Checking test 035 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 255.937578
+  0: The total amount of wall time                        = 255.354037
 
 Test 035 control_ugwpv1 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ras
 Checking test 036 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1357,13 +1357,13 @@ Checking test 036 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 243.085051
+  0: The total amount of wall time                        = 245.481477
 
 Test 036 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_thompson
 Checking test 037 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1374,13 +1374,13 @@ Checking test 037 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 272.870891
+  0: The total amount of wall time                        = 276.645323
 
 Test 037 control_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_thompson_no_aero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_thompson_no_aero
 Checking test 038 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1391,13 +1391,13 @@ Checking test 038 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 264.524572
+  0: The total amount of wall time                        = 267.903609
 
 Test 038 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_noahmp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_noahmp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_noahmp
 Checking test 039 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1408,13 +1408,13 @@ Checking test 039 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 243.853316
+  0: The total amount of wall time                        = 242.643151
 
 Test 039 control_noahmp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_control
 Checking test 040 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1422,25 +1422,25 @@ Checking test 040 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 438.612828
+ 0: The total amount of wall time                        = 417.022067
 
 Test 040 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_restart
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_restart
 Checking test 041 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 224.279048
+ 0: The total amount of wall time                        = 227.842595
 
 Test 041 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_quilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_quilt
 Checking test 042 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1451,13 +1451,13 @@ Checking test 042 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 411.449408
+ 0: The total amount of wall time                        = 410.377684
 
 Test 042 regional_quilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_quilt_hafs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_quilt_hafs
 Checking test 043 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1466,27 +1466,27 @@ Checking test 043 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 407.832710
+ 0: The total amount of wall time                        = 414.431889
 
 Test 043 regional_quilt_hafs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_quilt_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_quilt_netcdf_parallel
 Checking test 044 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 410.431158
+ 0: The total amount of wall time                        = 411.989167
 
 Test 044 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_quilt_RRTMGP
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_quilt_RRTMGP
 Checking test 045 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1497,13 +1497,13 @@ Checking test 045 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 527.693633
+ 0: The total amount of wall time                        = 531.356715
 
 Test 045 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_gsd
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_gsd
 Checking test 046 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1592,13 +1592,13 @@ Checking test 046 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.850523
+  0: The total amount of wall time                        = 309.777153
 
 Test 046 fv3_gsd PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_rrfs_v1alpha
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_rrfs_v1alpha
 Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1663,13 +1663,13 @@ Checking test 047 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.390996
+  0: The total amount of wall time                        = 121.675103
 
 Test 047 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rap
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_rap
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rap
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_rap
 Checking test 048 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1734,13 +1734,13 @@ Checking test 048 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.270843
+  0: The total amount of wall time                        = 119.242113
 
 Test 048 fv3_rap PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_hrrr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_hrrr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_hrrr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_hrrr
 Checking test 049 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1805,13 +1805,13 @@ Checking test 049 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 121.009256
+  0: The total amount of wall time                        = 119.192923
 
 Test 049 fv3_hrrr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_rrfs_v1beta
 Checking test 050 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1876,13 +1876,13 @@ Checking test 050 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.570539
+  0: The total amount of wall time                        = 121.289966
 
 Test 050 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_HAFS_v0_hwrf_thompson
 Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1947,13 +1947,13 @@ Checking test 051 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.552700
+  0: The total amount of wall time                        = 199.504368
 
 Test 051 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1968,39 +1968,39 @@ Checking test 052 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 365.141930
+ 0: The total amount of wall time                        = 369.838951
 
 Test 052 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_debug
 Checking test 053 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.341400
+  0: The total amount of wall time                        = 189.738968
 
 Test 053 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_2threads_debug
 Checking test 054 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 362.487040
+ 0: The total amount of wall time                        = 364.189575
 
 Test 054 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_CubedSphereGrid_debug
 Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2027,210 +2027,236 @@ Checking test 055 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.807226
+  0: The total amount of wall time                        = 204.366685
 
 Test 055 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_wrtGauss_netcdf_parallel_debug
 Checking test 056 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.468959
+  0: The total amount of wall time                        = 191.149012
 
 Test 056 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_stochy_debug
 Checking test 057 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 217.476367
+  0: The total amount of wall time                        = 216.639170
 
 Test 057 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_lndp_debug
-Checking test 058 control_lndp_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ca_debug
+Checking test 058 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.822529
+  0: The total amount of wall time                        = 189.794457
 
-Test 058 control_lndp_debug PASS
+Test 058 control_ca_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_lheatstrg_debug
-Checking test 059 control_lheatstrg_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_lndp_debug
+Checking test 059 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.321787
+  0: The total amount of wall time                        = 193.923532
 
-Test 059 control_lheatstrg_debug PASS
+Test 059 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_merra2_debug
-Checking test 060 control_merra2_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_lheatstrg_debug
+Checking test 060 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.040506
+  0: The total amount of wall time                        = 188.198719
 
-Test 060 control_merra2_debug PASS
+Test 060 control_lheatstrg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_rrtmgp_debug
-Checking test 061 control_rrtmgp_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_merra2_debug
+Checking test 061 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.211998
+  0: The total amount of wall time                        = 260.703777
 
-Test 061 control_rrtmgp_debug PASS
+Test 061 control_merra2_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_csawmg_debug
-Checking test 062 control_csawmg_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_rrtmgp_debug
+Checking test 062 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 312.156088
+  0: The total amount of wall time                        = 212.640130
 
-Test 062 control_csawmg_debug PASS
+Test 062 control_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_csawmgt_debug
-Checking test 063 control_csawmgt_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_csawmg_debug
+Checking test 063 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.225316
+  0: The total amount of wall time                        = 311.641350
 
-Test 063 control_csawmgt_debug PASS
+Test 063 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_ugwpv1_debug
-Checking test 064 control_ugwpv1_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_csawmgt_debug
+Checking test 064 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.318273
+  0: The total amount of wall time                        = 351.725522
 
-Test 064 control_ugwpv1_debug PASS
+Test 064 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_ras_debug
-Checking test 065 control_ras_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ugwpv1_debug
+Checking test 065 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.738698
+  0: The total amount of wall time                        = 205.830045
 
-Test 065 control_ras_debug PASS
+Test 065 control_ugwpv1_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_diag_debug
-Checking test 066 control_diag_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_ras_debug
+Checking test 066 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.747011
+  0: The total amount of wall time                        = 195.202996
 
-Test 066 control_diag_debug PASS
+Test 066 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_thompson_debug
-Checking test 067 control_thompson_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_noahmp_debug
+Checking test 067 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 224.644354
+  0: The total amount of wall time                        = 190.630983
 
-Test 067 control_thompson_debug PASS
+Test 067 control_noahmp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_thompson_no_aero_debug
-Checking test 068 control_thompson_no_aero_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_diag_debug
+Checking test 068 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 213.866129
+  0: The total amount of wall time                        = 200.428323
 
-Test 068 control_thompson_no_aero_debug PASS
+Test 068 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_thompson_extdiag_debug
-Checking test 069 control_thompson_extdiag_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_thompson_debug
+Checking test 069 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 236.424833
+  0: The total amount of wall time                        = 223.154968
 
-Test 069 control_thompson_extdiag_debug PASS
+Test 069 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/regional_control_debug
-Checking test 070 regional_control_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_thompson_no_aero_debug
+Checking test 070 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 214.757735
+
+Test 070 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_thompson_extdiag_debug
+Checking test 071 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 233.825568
+
+Test 071 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/regional_control_debug
+Checking test 072 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 318.295604
+ 0: The total amount of wall time                        = 317.398615
 
-Test 070 regional_control_debug PASS
+Test 072 regional_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_gsd_debug
-Checking test 071 fv3_gsd_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_gsd_debug
+Checking test 073 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2294,14 +2320,14 @@ Checking test 071 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 334.683220
+  0: The total amount of wall time                        = 321.175764
 
-Test 071 fv3_gsd_debug PASS
+Test 073 fv3_gsd_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_gsd_diag_debug
-Checking test 072 fv3_gsd_diag_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_gsd_diag_debug
+Checking test 074 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2327,14 +2353,14 @@ Checking test 072 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 557.341440
+  0: The total amount of wall time                        = 570.229862
 
-Test 072 fv3_gsd_diag_debug PASS
+Test 074 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_rrfs_v1beta_debug
-Checking test 073 fv3_rrfs_v1beta_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_rrfs_v1beta_debug
+Checking test 075 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2398,14 +2424,14 @@ Checking test 073 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.715249
+  0: The total amount of wall time                        = 251.968973
 
-Test 073 fv3_rrfs_v1beta_debug PASS
+Test 075 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_rrfs_v1alpha_debug
-Checking test 074 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_rrfs_v1alpha_debug
+Checking test 076 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2469,14 +2495,14 @@ Checking test 074 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.333693
+  0: The total amount of wall time                        = 253.562890
 
-Test 074 fv3_rrfs_v1alpha_debug PASS
+Test 076 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 075 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 077 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2540,14 +2566,14 @@ Checking test 075 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 272.496965
+  0: The total amount of wall time                        = 264.259451
 
-Test 075 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 077 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 076 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 078 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2561,86 +2587,86 @@ Checking test 076 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 501.443496
+ 0: The total amount of wall time                        = 505.880301
 
-Test 076 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 078 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_control_cfsr
-Checking test 077 datm_control_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_control_cfsr
+Checking test 079 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 128.595775
+  0: The total amount of wall time                        = 129.580550
 
-Test 077 datm_control_cfsr PASS
+Test 079 datm_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_restart_cfsr
-Checking test 078 datm_restart_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_restart_cfsr
+Checking test 080 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 81.090660
+  0: The total amount of wall time                        = 78.251078
 
-Test 078 datm_restart_cfsr PASS
+Test 080 datm_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_control_gefs
-Checking test 079 datm_control_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_control_gefs
+Checking test 081 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 119.424116
+  0: The total amount of wall time                        = 123.271937
 
-Test 079 datm_control_gefs PASS
+Test 081 datm_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_control_iau_gefs
-Checking test 080 datm_control_iau_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_control_iau_gefs
+Checking test 082 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 126.303977
+  0: The total amount of wall time                        = 122.045366
 
-Test 080 datm_control_iau_gefs PASS
+Test 082 datm_control_iau_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_bulk_cfsr
-Checking test 081 datm_bulk_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_bulk_cfsr
+Checking test 083 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 125.294371
+  0: The total amount of wall time                        = 123.361223
 
-Test 081 datm_bulk_cfsr PASS
+Test 083 datm_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_bulk_gefs
-Checking test 082 datm_bulk_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_bulk_gefs
+Checking test 084 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 122.327586
+  0: The total amount of wall time                        = 124.050227
 
-Test 082 datm_bulk_gefs PASS
+Test 084 datm_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_mx025_cfsr
-Checking test 083 datm_mx025_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_mx025_cfsr
+Checking test 085 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2648,14 +2674,14 @@ Checking test 083 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 417.573151
+  0: The total amount of wall time                        = 422.232482
 
-Test 083 datm_mx025_cfsr PASS
+Test 085 datm_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_mx025_gefs
-Checking test 084 datm_mx025_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_mx025_gefs
+Checking test 086 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2663,86 +2689,86 @@ Checking test 084 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 417.683228
+  0: The total amount of wall time                        = 413.644923
 
-Test 084 datm_mx025_gefs PASS
+Test 086 datm_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_debug_cfsr
-Checking test 085 datm_debug_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_debug_cfsr
+Checking test 087 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 342.643271
+  0: The total amount of wall time                        = 337.939867
 
-Test 085 datm_debug_cfsr PASS
+Test 087 datm_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_control_cfsr
-Checking test 086 datm_cdeps_control_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_control_cfsr
+Checking test 088 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.327942
+ 0: The total amount of wall time                        = 198.037771
 
-Test 086 datm_cdeps_control_cfsr PASS
+Test 088 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_restart_cfsr
-Checking test 087 datm_cdeps_restart_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_restart_cfsr
+Checking test 089 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 121.884730
+ 0: The total amount of wall time                        = 119.963840
 
-Test 087 datm_cdeps_restart_cfsr PASS
+Test 089 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_control_gefs
-Checking test 088 datm_cdeps_control_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_control_gefs
+Checking test 090 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.801921
+ 0: The total amount of wall time                        = 196.459221
 
-Test 088 datm_cdeps_control_gefs PASS
+Test 090 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_bulk_cfsr
-Checking test 089 datm_cdeps_bulk_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_bulk_cfsr
+Checking test 091 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.548124
+ 0: The total amount of wall time                        = 200.421952
 
-Test 089 datm_cdeps_bulk_cfsr PASS
+Test 091 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_bulk_gefs
-Checking test 090 datm_cdeps_bulk_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_bulk_gefs
+Checking test 092 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.752069
+ 0: The total amount of wall time                        = 196.561477
 
-Test 090 datm_cdeps_bulk_gefs PASS
+Test 092 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_mx025_cfsr
-Checking test 091 datm_cdeps_mx025_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_mx025_cfsr
+Checking test 093 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2750,14 +2776,14 @@ Checking test 091 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 426.273633
+  0: The total amount of wall time                        = 435.362856
 
-Test 091 datm_cdeps_mx025_cfsr PASS
+Test 093 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_mx025_gefs
-Checking test 092 datm_cdeps_mx025_gefs results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_mx025_gefs
+Checking test 094 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2765,36 +2791,36 @@ Checking test 092 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 420.326956
+  0: The total amount of wall time                        = 432.274876
 
-Test 092 datm_cdeps_mx025_gefs PASS
+Test 094 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_multiple_files_cfsr
-Checking test 093 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_multiple_files_cfsr
+Checking test 095 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 202.414343
+ 0: The total amount of wall time                        = 196.116287
 
-Test 093 datm_cdeps_multiple_files_cfsr PASS
+Test 095 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/datm_cdeps_debug_cfsr
-Checking test 094 datm_cdeps_debug_cfsr results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/datm_cdeps_debug_cfsr
+Checking test 096 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 569.333721
+ 0: The total amount of wall time                        = 569.172402
 
-Test 094 datm_cdeps_debug_cfsr PASS
+Test 096 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_233851/control_atmwav
-Checking test 095 control_atmwav results ....
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_148408/control_atmwav
+Checking test 097 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2836,11 +2862,11 @@ Checking test 095 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 424.118454
+  0: The total amount of wall time                        = 441.634495
 
-Test 095 control_atmwav PASS
+Test 097 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jul 22 03:09:49 GMT 2021
-Elapsed time: 02h:08m:27s. Have a nice day!
+Fri Jul 23 02:55:09 GMT 2021
+Elapsed time: 02h:21m:33s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,26 +1,26 @@
-Wed Jul 21 14:38:35 CDT 2021
+Thu Jul 22 19:01:18 CDT 2021
 Start Regression test
 
-Compile 001 elapsed time 630 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 654 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 224 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 531 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 594 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 537 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 543 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 548 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 259 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 144 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 138 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 144 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 206 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 124 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 187 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 94 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 562 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 627 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 665 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 238 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 530 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 571 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 541 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 542 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 156 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 174 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 158 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 133 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 182 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 109 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 208 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 99 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 589 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 103.264808
+  0: The total amount of wall time                        = 113.808292
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 78.111879
+  0: The total amount of wall time                        = 80.751295
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 130.385696
+  0: The total amount of wall time                        = 129.457342
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 120.569628
+  0: The total amount of wall time                        = 113.043714
 
 Test 004 cpld_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_ca
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_ca
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 102.483444
+  0: The total amount of wall time                        = 108.289422
 
 Test 005 cpld_ca PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 380.172886
+  0: The total amount of wall time                        = 417.250578
 
 Test 006 cpld_control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_restart_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 373.442460
+  0: The total amount of wall time                        = 278.215811
 
 Test 007 cpld_restart_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 871.887885
+  0: The total amount of wall time                        = 787.822421
 
 Test 008 cpld_control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_restart_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 426.819432
+  0: The total amount of wall time                        = 430.509278
 
 Test 009 cpld_restart_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_bmark_v16
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 771.529906
+  0: The total amount of wall time                        = 665.889730
 
 Test 010 cpld_bmark_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_restart_bmark_v16
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 357.236985
+  0: The total amount of wall time                        = 375.638323
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_v16_nsst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_bmark_v16_nsst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_v16_nsst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 745.729452
+  0: The total amount of wall time                        = 691.696078
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_bmark_wave_v16
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 787.802304
+  0: The total amount of wall time                        = 701.381590
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_bmark_wave_v16_p7b
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_bmark_wave_v16_p7b
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 859.448660
+  0: The total amount of wall time                        = 842.972188
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_control_wave
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_control_wave
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_control_wave
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 128.050839
+  0: The total amount of wall time                        = 127.605014
 
 Test 015 cpld_control_wave PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/cpld_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/cpld_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/cpld_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 303.953286
+  0: The total amount of wall time                        = 321.917332
 
 Test 016 cpld_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.615542
+  0: The total amount of wall time                        = 180.338957
 
 Test 017 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -986,13 +986,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.395484
+  0: The total amount of wall time                        = 175.280892
 
 Test 018 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1035,13 +1035,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 171.704745
+ 0: The total amount of wall time                        = 178.454279
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1080,13 +1080,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 69.681070
+  0: The total amount of wall time                        = 73.832910
 
 Test 020 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,13 +1113,13 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.199657
+  0: The total amount of wall time                        = 142.144385
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1130,13 +1130,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 200.970489
+  0: The total amount of wall time                        = 249.744961
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1147,13 +1147,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 475.486261
+  0: The total amount of wall time                        = 498.551851
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1164,13 +1164,13 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 787.548076
+  0: The total amount of wall time                        = 786.352762
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1213,13 +1213,13 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 659.001879
+  0: The total amount of wall time                        = 732.677998
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1230,26 +1230,26 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 115.275656
+  0: The total amount of wall time                        = 127.622484
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 65.165282
+  0: The total amount of wall time                        = 65.610117
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_ca
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ca
 Checking test 028 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1260,13 +1260,13 @@ Checking test 028 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.272952
+  0: The total amount of wall time                        = 126.902689
 
 Test 028 control_ca PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1277,13 +1277,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.621050
+  0: The total amount of wall time                        = 129.437717
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_lheatstrg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_lheatstrg
 Checking test 030 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1294,13 +1294,13 @@ Checking test 030 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 168.317535
+  0: The total amount of wall time                        = 171.910881
 
 Test 030 control_lheatstrg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lseaspray
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_lseaspray
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lseaspray
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_lseaspray
 Checking test 031 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1311,13 +1311,13 @@ Checking test 031 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 168.766812
+  0: The total amount of wall time                        = 181.073212
 
 Test 031 control_lseaspray PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_merra2
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_merra2
 Checking test 032 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1328,13 +1328,13 @@ Checking test 032 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 289.031746
+  0: The total amount of wall time                        = 292.318596
 
 Test 032 control_merra2 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_rrtmgp
 Checking test 033 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1345,13 +1345,13 @@ Checking test 033 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 208.106191
+  0: The total amount of wall time                        = 217.315479
 
 Test 033 control_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_csawmg
 Checking test 034 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1362,13 +1362,13 @@ Checking test 034 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 344.223832
+  0: The total amount of wall time                        = 361.071588
 
 Test 034 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_csawmgt
 Checking test 035 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1379,13 +1379,13 @@ Checking test 035 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 420.448204
+  0: The total amount of wall time                        = 416.814328
 
 Test 035 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_flake
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_flake
 Checking test 036 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1396,13 +1396,13 @@ Checking test 036 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 230.970208
+  0: The total amount of wall time                        = 247.215367
 
 Test 036 control_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_ugwpv1
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ugwpv1
 Checking test 037 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1413,13 +1413,13 @@ Checking test 037 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 194.695966
+  0: The total amount of wall time                        = 199.341240
 
 Test 037 control_ugwpv1 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ras
 Checking test 038 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1430,13 +1430,13 @@ Checking test 038 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.073579
+  0: The total amount of wall time                        = 192.715354
 
 Test 038 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_thompson
 Checking test 039 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1447,13 +1447,13 @@ Checking test 039 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 219.791204
+  0: The total amount of wall time                        = 214.047791
 
 Test 039 control_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_thompson_no_aero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_thompson_no_aero
 Checking test 040 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1464,13 +1464,13 @@ Checking test 040 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 208.320083
+  0: The total amount of wall time                        = 206.110116
 
 Test 040 control_thompson_no_aero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_noahmp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_noahmp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_noahmp
 Checking test 041 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1481,13 +1481,13 @@ Checking test 041 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.214796
+  0: The total amount of wall time                        = 184.177191
 
 Test 041 control_noahmp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_control
 Checking test 042 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1495,25 +1495,25 @@ Checking test 042 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 330.832120
+ 0: The total amount of wall time                        = 299.099386
 
 Test 042 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_restart
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_restart
 Checking test 043 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 195.399537
+ 0: The total amount of wall time                        = 172.234426
 
 Test 043 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_quilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_quilt
 Checking test 044 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1524,13 +1524,13 @@ Checking test 044 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 328.871839
+ 0: The total amount of wall time                        = 312.467283
 
 Test 044 regional_quilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_quilt_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_quilt_2threads
 Checking test 045 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1541,13 +1541,13 @@ Checking test 045 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 285.975781
+ 0: The total amount of wall time                        = 227.562559
 
 Test 045 regional_quilt_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_quilt_hafs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_hafs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_quilt_hafs
 Checking test 046 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1556,27 +1556,27 @@ Checking test 046 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 340.100786
+ 0: The total amount of wall time                        = 310.954341
 
 Test 046 regional_quilt_hafs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_quilt_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_quilt_netcdf_parallel
 Checking test 047 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 455.061215
+ 0: The total amount of wall time                        = 312.397311
 
 Test 047 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_quilt_RRTMGP
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_quilt_RRTMGP
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_quilt_RRTMGP
 Checking test 048 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1587,13 +1587,13 @@ Checking test 048 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 532.855402
+ 0: The total amount of wall time                        = 397.982983
 
 Test 048 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_gsd
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_gsd
 Checking test 049 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1682,13 +1682,13 @@ Checking test 049 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 360.983940
+  0: The total amount of wall time                        = 262.443464
 
 Test 049 fv3_gsd PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_rrfs_v1alpha
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_rrfs_v1alpha
 Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1753,13 +1753,13 @@ Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 192.643812
+  0: The total amount of wall time                        = 115.296565
 
 Test 050 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rap
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_rap
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rap
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_rap
 Checking test 051 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1824,13 +1824,13 @@ Checking test 051 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 150.337927
+  0: The total amount of wall time                        = 99.202618
 
 Test 051 fv3_rap PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_hrrr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_hrrr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_hrrr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_hrrr
 Checking test 052 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1895,13 +1895,13 @@ Checking test 052 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.096200
+  0: The total amount of wall time                        = 96.215639
 
 Test 052 fv3_hrrr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_rrfs_v1beta
 Checking test 053 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1966,13 +1966,13 @@ Checking test 053 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.201882
+  0: The total amount of wall time                        = 120.925048
 
 Test 053 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_HAFS_v0_hwrf_thompson
 Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2037,13 +2037,13 @@ Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 198.527271
+  0: The total amount of wall time                        = 154.080766
 
 Test 054 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2058,39 +2058,39 @@ Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 332.195180
+ 0: The total amount of wall time                        = 289.400607
 
 Test 055 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_debug
 Checking test 056 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.045071
+  0: The total amount of wall time                        = 162.917663
 
 Test 056 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_2threads_debug
 Checking test 057 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 229.915197
+ 0: The total amount of wall time                        = 233.702374
 
 Test 057 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_CubedSphereGrid_debug
 Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2117,210 +2117,236 @@ Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.254727
+  0: The total amount of wall time                        = 172.346544
 
 Test 058 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_wrtGauss_netcdf_parallel_debug
 Checking test 059 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.509352
+  0: The total amount of wall time                        = 161.553995
 
 Test 059 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_stochy_debug
 Checking test 060 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.010879
+  0: The total amount of wall time                        = 186.717081
 
 Test 060 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_lndp_debug
-Checking test 061 control_lndp_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ca_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ca_debug
+Checking test 061 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.297018
+  0: The total amount of wall time                        = 170.488766
 
-Test 061 control_lndp_debug PASS
+Test 061 control_ca_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_lheatstrg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_lheatstrg_debug
-Checking test 062 control_lheatstrg_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_lndp_debug
+Checking test 062 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.728767
+  0: The total amount of wall time                        = 172.598220
 
-Test 062 control_lheatstrg_debug PASS
+Test 062 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_merra2_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_merra2_debug
-Checking test 063 control_merra2_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_lheatstrg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_lheatstrg_debug
+Checking test 063 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 246.961692
+  0: The total amount of wall time                        = 166.766925
 
-Test 063 control_merra2_debug PASS
+Test 063 control_lheatstrg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_rrtmgp_debug
-Checking test 064 control_rrtmgp_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_merra2_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_merra2_debug
+Checking test 064 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 198.783287
+  0: The total amount of wall time                        = 268.013813
 
-Test 064 control_rrtmgp_debug PASS
+Test 064 control_merra2_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_csawmg_debug
-Checking test 065 control_csawmg_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_rrtmgp_debug
+Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.274449
+  0: The total amount of wall time                        = 182.213917
 
-Test 065 control_csawmg_debug PASS
+Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_csawmgt_debug
-Checking test 066 control_csawmgt_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_csawmg_debug
+Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 319.332031
+  0: The total amount of wall time                        = 290.952797
 
-Test 066 control_csawmgt_debug PASS
+Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ugwpv1_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_ugwpv1_debug
-Checking test 067 control_ugwpv1_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_csawmgt_debug
+Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.399018
+  0: The total amount of wall time                        = 418.047443
 
-Test 067 control_ugwpv1_debug PASS
+Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_ras_debug
-Checking test 068 control_ras_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ugwpv1_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ugwpv1_debug
+Checking test 068 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.969996
+  0: The total amount of wall time                        = 169.254751
 
-Test 068 control_ras_debug PASS
+Test 068 control_ugwpv1_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_diag_debug
-Checking test 069 control_diag_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_ras_debug
+Checking test 069 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.203562
+  0: The total amount of wall time                        = 173.096766
 
-Test 069 control_diag_debug PASS
+Test 069 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_thompson_debug
-Checking test 070 control_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_noahmp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_noahmp_debug
+Checking test 070 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.870670
+  0: The total amount of wall time                        = 159.898538
 
-Test 070 control_thompson_debug PASS
+Test 070 control_noahmp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_thompson_no_aero_debug
-Checking test 071 control_thompson_no_aero_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_diag_debug
+Checking test 071 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 184.454969
+  0: The total amount of wall time                        = 177.604660
 
-Test 071 control_thompson_no_aero_debug PASS
+Test 071 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_thompson_extdiag_debug
-Checking test 072 control_thompson_extdiag_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_thompson_debug
+Checking test 072 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.755576
+  0: The total amount of wall time                        = 228.702363
 
-Test 072 control_thompson_extdiag_debug PASS
+Test 072 control_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_regional_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/regional_control_debug
-Checking test 073 regional_control_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_thompson_no_aero_debug
+Checking test 073 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 226.559831
+
+Test 073 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_thompson_debug_extdiag
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_thompson_extdiag_debug
+Checking test 074 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 208.469993
+
+Test 074 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_regional_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/regional_control_debug
+Checking test 075 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 243.518108
+ 0: The total amount of wall time                        = 247.169607
 
-Test 073 regional_control_debug PASS
+Test 075 regional_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_gsd_debug
-Checking test 074 fv3_gsd_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_gsd_debug
+Checking test 076 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2384,14 +2410,14 @@ Checking test 074 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.025007
+  0: The total amount of wall time                        = 286.378857
 
-Test 074 fv3_gsd_debug PASS
+Test 076 fv3_gsd_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_gsd_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_gsd_diag_debug
-Checking test 075 fv3_gsd_diag_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_gsd_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_gsd_diag_debug
+Checking test 077 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2417,14 +2443,14 @@ Checking test 075 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 504.615518
+  0: The total amount of wall time                        = 569.226823
 
-Test 075 fv3_gsd_diag_debug PASS
+Test 077 fv3_gsd_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_rrfs_v1beta_debug
-Checking test 076 fv3_rrfs_v1beta_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_rrfs_v1beta_debug
+Checking test 078 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2488,14 +2514,14 @@ Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 209.502924
+  0: The total amount of wall time                        = 227.594874
 
-Test 076 fv3_rrfs_v1beta_debug PASS
+Test 078 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_rrfs_v1alpha_debug
-Checking test 077 fv3_rrfs_v1alpha_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/fv3_rrfs_v1alpha_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_rrfs_v1alpha_debug
+Checking test 079 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2559,14 +2585,14 @@ Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 216.080847
+  0: The total amount of wall time                        = 214.260717
 
-Test 077 fv3_rrfs_v1alpha_debug PASS
+Test 079 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 080 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2630,14 +2656,14 @@ Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.681372
+  0: The total amount of wall time                        = 219.339938
 
-Test 078 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 080 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2651,86 +2677,86 @@ Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 408.848512
+ 0: The total amount of wall time                        = 410.257275
 
-Test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_control_cfsr
-Checking test 080 datm_control_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_control_cfsr
+Checking test 082 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 120.365121
+  0: The total amount of wall time                        = 103.130363
 
-Test 080 datm_control_cfsr PASS
+Test 082 datm_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_restart_cfsr
-Checking test 081 datm_restart_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_restart_cfsr
+Checking test 083 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 112.711058
+  0: The total amount of wall time                        = 76.140407
 
-Test 081 datm_restart_cfsr PASS
+Test 083 datm_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_control_gefs
-Checking test 082 datm_control_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_control_gefs
+Checking test 084 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 114.774618
+  0: The total amount of wall time                        = 93.399982
 
-Test 082 datm_control_gefs PASS
+Test 084 datm_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_control_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_control_iau_gefs
-Checking test 083 datm_control_iau_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_control_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_control_iau_gefs
+Checking test 085 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 119.625501
+  0: The total amount of wall time                        = 103.183793
 
-Test 083 datm_control_iau_gefs PASS
+Test 085 datm_control_iau_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_bulk_cfsr
-Checking test 084 datm_bulk_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_bulk_cfsr
+Checking test 086 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 115.521960
+  0: The total amount of wall time                        = 99.296777
 
-Test 084 datm_bulk_cfsr PASS
+Test 086 datm_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_bulk_gefs
-Checking test 085 datm_bulk_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_bulk_gefs
+Checking test 087 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 108.709127
+  0: The total amount of wall time                        = 95.242405
 
-Test 085 datm_bulk_gefs PASS
+Test 087 datm_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_mx025_cfsr
-Checking test 086 datm_mx025_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_mx025_cfsr
+Checking test 088 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2738,14 +2764,14 @@ Checking test 086 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 381.193739
+  0: The total amount of wall time                        = 357.045619
 
-Test 086 datm_mx025_cfsr PASS
+Test 088 datm_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_mx025_gefs
-Checking test 087 datm_mx025_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_mx025_gefs
+Checking test 089 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2753,86 +2779,86 @@ Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 421.351262
+  0: The total amount of wall time                        = 371.937879
 
-Test 087 datm_mx025_gefs PASS
+Test 089 datm_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_debug_cfsr
-Checking test 088 datm_debug_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_debug_cfsr
+Checking test 090 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 311.107050
+  0: The total amount of wall time                        = 276.096886
 
-Test 088 datm_debug_cfsr PASS
+Test 090 datm_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_control_cfsr
-Checking test 089 datm_cdeps_control_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_control_cfsr
+Checking test 091 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 245.917695
+ 0: The total amount of wall time                        = 149.715057
 
-Test 089 datm_cdeps_control_cfsr PASS
+Test 091 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_restart_cfsr
-Checking test 090 datm_cdeps_restart_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_restart_cfsr
+Checking test 092 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 113.051171
+ 0: The total amount of wall time                        = 99.077514
 
-Test 090 datm_cdeps_restart_cfsr PASS
+Test 092 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_control_gefs
-Checking test 091 datm_cdeps_control_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_control_gefs
+Checking test 093 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 215.186242
+ 0: The total amount of wall time                        = 181.517265
 
-Test 091 datm_cdeps_control_gefs PASS
+Test 093 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_bulk_cfsr
-Checking test 092 datm_cdeps_bulk_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_bulk_cfsr
+Checking test 094 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 158.886891
+ 0: The total amount of wall time                        = 157.938668
 
-Test 092 datm_cdeps_bulk_cfsr PASS
+Test 094 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_bulk_gefs
-Checking test 093 datm_cdeps_bulk_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_bulk_gefs
+Checking test 095 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 162.867330
+ 0: The total amount of wall time                        = 158.271964
 
-Test 093 datm_cdeps_bulk_gefs PASS
+Test 095 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_mx025_cfsr
-Checking test 094 datm_cdeps_mx025_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_mx025_cfsr
+Checking test 096 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2840,14 +2866,14 @@ Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 372.307944
+  0: The total amount of wall time                        = 359.269182
 
-Test 094 datm_cdeps_mx025_cfsr PASS
+Test 096 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_mx025_gefs
-Checking test 095 datm_cdeps_mx025_gefs results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_mx025_gefs
+Checking test 097 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2855,36 +2881,36 @@ Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 375.854552
+  0: The total amount of wall time                        = 347.637986
 
-Test 095 datm_cdeps_mx025_gefs PASS
+Test 097 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_multiple_files_cfsr
-Checking test 096 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_multiple_files_cfsr
+Checking test 098 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 173.117299
+ 0: The total amount of wall time                        = 151.764776
 
-Test 096 datm_cdeps_multiple_files_cfsr PASS
+Test 098 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/datm_cdeps_debug_cfsr
-Checking test 097 datm_cdeps_debug_cfsr results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/datm_cdeps_debug_cfsr
+Checking test 099 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 460.091156
+ 0: The total amount of wall time                        = 462.037806
 
-Test 097 datm_cdeps_debug_cfsr PASS
+Test 099 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210721/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_204378/control_atmwav
-Checking test 098 control_atmwav results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_5023/control_atmwav
+Checking test 100 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2926,11 +2952,11 @@ Checking test 098 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 349.301078
+  0: The total amount of wall time                        = 351.727314
 
-Test 098 control_atmwav PASS
+Test 100 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 21 15:37:00 CDT 2021
-Elapsed time: 00h:58m:26s. Have a nice day!
+Thu Jul 22 20:00:43 CDT 2021
+Elapsed time: 00h:59m:25s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,18 +1,18 @@
-Mon Jul 19 19:51:53 UTC 2021
+Thu Jul 22 23:15:36 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 888 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 955 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 914 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 856 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 914 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 516 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 447 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 515 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 517 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 943 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 970 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 908 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 986 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 923 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 565 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 528 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 549 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 569 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -55,13 +55,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.307156
+The total amount of wall time                        = 183.720726
 
 Test 001 control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_decomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -104,13 +104,13 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 191.909602
+The total amount of wall time                        = 185.949391
 
 Test 002 control_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_restart
 Checking test 003 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -149,13 +149,13 @@ Checking test 003 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 69.964622
+The total amount of wall time                        = 71.454259
 
 Test 003 control_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_CubedSphereGrid
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_CubedSphereGrid
 Checking test 004 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 004 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 137.348759
+The total amount of wall time                        = 135.783356
 
 Test 004 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_wrtGauss_netcdf_parallel
 Checking test 005 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -199,13 +199,13 @@ Checking test 005 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 203.677581
+The total amount of wall time                        = 194.643584
 
 Test 005 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_c192
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_c192
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_c192
 Checking test 006 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -216,13 +216,13 @@ Checking test 006 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 528.189283
+The total amount of wall time                        = 526.751061
 
 Test 006 control_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_stochy
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_stochy
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_stochy
 Checking test 007 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -233,14 +233,27 @@ Checking test 007 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 143.578206
+The total amount of wall time                        = 139.614336
 
 Test 007 control_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ca
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_ca
-Checking test 008 control_ca results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_stochy_restart
+Checking test 008 control_stochy_restart results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+The total amount of wall time                        = 67.126396
+
+Test 008 control_stochy_restart PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ca
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ca
+Checking test 009 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -250,14 +263,14 @@ Checking test 008 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 136.540588
+The total amount of wall time                        = 130.065140
 
-Test 008 control_ca PASS
+Test 009 control_ca PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lndp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_lndp
-Checking test 009 control_lndp results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lndp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_lndp
+Checking test 010 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -267,14 +280,14 @@ Checking test 009 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 141.652923
+The total amount of wall time                        = 133.917888
 
-Test 009 control_lndp PASS
+Test 010 control_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lheatstrg
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_lheatstrg
-Checking test 010 control_lheatstrg results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lheatstrg
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_lheatstrg
+Checking test 011 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -284,14 +297,14 @@ Checking test 010 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 193.934583
+The total amount of wall time                        = 177.741348
 
-Test 010 control_lheatstrg PASS
+Test 011 control_lheatstrg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lseaspray
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_lseaspray
-Checking test 011 control_lseaspray results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lseaspray
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_lseaspray
+Checking test 012 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -301,14 +314,14 @@ Checking test 011 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 196.773250
+The total amount of wall time                        = 210.470685
 
-Test 011 control_lseaspray PASS
+Test 012 control_lseaspray PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_merra2
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_merra2
-Checking test 012 control_merra2 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_merra2
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_merra2
+Checking test 013 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -318,14 +331,14 @@ Checking test 012 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 262.974077
+The total amount of wall time                        = 261.183305
 
-Test 012 control_merra2 PASS
+Test 013 control_merra2 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_rrtmgp
-Checking test 013 control_rrtmgp results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_rrtmgp
+Checking test 014 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -335,14 +348,14 @@ Checking test 013 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 230.980458
+The total amount of wall time                        = 224.768330
 
-Test 013 control_rrtmgp PASS
+Test 014 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmg
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_csawmg
-Checking test 014 control_csawmg results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmg
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_csawmg
+Checking test 015 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -352,14 +365,14 @@ Checking test 014 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 355.861137
+The total amount of wall time                        = 347.572773
 
-Test 014 control_csawmg PASS
+Test 015 control_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_csawmgt
-Checking test 015 control_csawmgt results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_csawmgt
+Checking test 016 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -369,14 +382,14 @@ Checking test 015 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 409.196049
+The total amount of wall time                        = 421.468690
 
-Test 015 control_csawmgt PASS
+Test 016 control_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_flake
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_flake
-Checking test 016 control_flake results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_flake
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_flake
+Checking test 017 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -386,14 +399,14 @@ Checking test 016 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 240.716301
+The total amount of wall time                        = 243.823209
 
-Test 016 control_flake PASS
+Test 017 control_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ugwpv1
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_ugwpv1
-Checking test 017 control_ugwpv1 results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ugwpv1
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ugwpv1
+Checking test 018 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -403,14 +416,14 @@ Checking test 017 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 212.885834
+The total amount of wall time                        = 225.736272
 
-Test 017 control_ugwpv1 PASS
+Test 018 control_ugwpv1 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ras
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_ras
-Checking test 018 control_ras results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ras
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ras
+Checking test 019 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -420,14 +433,14 @@ Checking test 018 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 214.352907
+The total amount of wall time                        = 207.948820
 
-Test 018 control_ras PASS
+Test 019 control_ras PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_noahmp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_noahmp
-Checking test 019 control_noahmp results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_noahmp
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_noahmp
+Checking test 020 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -437,40 +450,40 @@ Checking test 019 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 204.913117
+The total amount of wall time                        = 204.978478
 
-Test 019 control_noahmp PASS
+Test 020 control_noahmp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_control
-Checking test 020 regional_control results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_control
+Checking test 021 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 350.603432
+The total amount of wall time                        = 374.910143
 
-Test 020 regional_control PASS
+Test 021 regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_restart
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_restart
-Checking test 021 regional_restart results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_restart
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_restart
+Checking test 022 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 214.235607
+The total amount of wall time                        = 240.023446
 
-Test 021 regional_restart PASS
+Test 022 regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_quilt
-Checking test 022 regional_quilt results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_quilt
+Checking test 023 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -480,14 +493,14 @@ Checking test 022 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 338.310198
+The total amount of wall time                        = 341.679019
 
-Test 022 regional_quilt PASS
+Test 023 regional_quilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_hafs
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_quilt_hafs
-Checking test 023 regional_quilt_hafs results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_hafs
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_quilt_hafs
+Checking test 024 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -495,28 +508,28 @@ Checking test 023 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 337.220459
+The total amount of wall time                        = 339.947850
 
-Test 023 regional_quilt_hafs PASS
+Test 024 regional_quilt_hafs PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_quilt_netcdf_parallel
-Checking test 024 regional_quilt_netcdf_parallel results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_quilt_netcdf_parallel
+Checking test 025 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 339.561289
+The total amount of wall time                        = 344.193705
 
-Test 024 regional_quilt_netcdf_parallel PASS
+Test 025 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_quilt_RRTMGP
-Checking test 025 regional_quilt_RRTMGP results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_RRTMGP
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_quilt_RRTMGP
+Checking test 026 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -526,14 +539,14 @@ Checking test 025 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 447.742347
+The total amount of wall time                        = 450.139905
 
-Test 025 regional_quilt_RRTMGP PASS
+Test 026 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_gsd
-Checking test 026 fv3_gsd results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_gsd
+Checking test 027 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -621,14 +634,14 @@ Checking test 026 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.868950
+The total amount of wall time                        = 250.082101
 
-Test 026 fv3_gsd PASS
+Test 027 fv3_gsd PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1alpha
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_rrfs_v1alpha
-Checking test 027 fv3_rrfs_v1alpha results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1alpha
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_rrfs_v1alpha
+Checking test 028 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -692,14 +705,14 @@ Checking test 027 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 106.197658
+The total amount of wall time                        = 110.915241
 
-Test 027 fv3_rrfs_v1alpha PASS
+Test 028 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rap
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_rap
-Checking test 028 fv3_rap results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rap
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_rap
+Checking test 029 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -763,14 +776,14 @@ Checking test 028 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 109.545381
+The total amount of wall time                        = 105.145098
 
-Test 028 fv3_rap PASS
+Test 029 fv3_rap PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_hrrr
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_hrrr
-Checking test 029 fv3_hrrr results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_hrrr
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_hrrr
+Checking test 030 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -834,14 +847,14 @@ Checking test 029 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 104.577062
+The total amount of wall time                        = 107.134542
 
-Test 029 fv3_hrrr PASS
+Test 030 fv3_hrrr PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_rrfs_v1beta
-Checking test 030 fv3_rrfs_v1beta results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_rrfs_v1beta
+Checking test 031 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -905,14 +918,14 @@ Checking test 030 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 106.634954
+The total amount of wall time                        = 107.198188
 
-Test 030 fv3_rrfs_v1beta PASS
+Test 031 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_HAFS_v0_hwrf_thompson
-Checking test 031 fv3_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_HAFS_v0_hwrf_thompson
+Checking test 032 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -976,14 +989,14 @@ Checking test 031 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 169.718400
+The total amount of wall time                        = 165.695025
 
-Test 031 fv3_HAFS_v0_hwrf_thompson PASS
+Test 032 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_esg_HAFS_v0_hwrf_thompson
-Checking test 032 fv3_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_esg_HAFS_v0_hwrf_thompson
+Checking test 033 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -997,27 +1010,27 @@ Checking test 032 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 349.549997
+The total amount of wall time                        = 335.543787
 
-Test 032 fv3_esg_HAFS_v0_hwrf_thompson PASS
+Test 033 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_debug
-Checking test 033 control_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_debug
+Checking test 034 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 143.812712
+The total amount of wall time                        = 139.899478
 
-Test 033 control_debug PASS
+Test 034 control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_CubedSphereGrid_debug
-Checking test 034 control_CubedSphereGrid_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_CubedSphereGrid_debug
+Checking test 035 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -1043,197 +1056,236 @@ Checking test 034 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 148.332126
+The total amount of wall time                        = 148.759109
 
-Test 034 control_CubedSphereGrid_debug PASS
+Test 035 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_wrtGauss_netcdf_parallel_debug
-Checking test 035 control_wrtGauss_netcdf_parallel_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_wrtGauss_netcdf_parallel_debug
+Checking test 036 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 143.217415
+The total amount of wall time                        = 141.109317
 
-Test 035 control_wrtGauss_netcdf_parallel_debug PASS
+Test 036 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_stochy_debug
-Checking test 036 control_stochy_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_stochy_debug
+Checking test 037 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.822744
+The total amount of wall time                        = 160.753097
 
-Test 036 control_stochy_debug PASS
+Test 037 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_lndp_debug
-Checking test 037 control_lndp_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ca_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ca_debug
+Checking test 038 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.221511
+The total amount of wall time                        = 143.908343
 
-Test 037 control_lndp_debug PASS
+Test 038 control_ca_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lheatstrg_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_lheatstrg_debug
-Checking test 038 control_lheatstrg_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_lndp_debug
+Checking test 039 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.117007
+The total amount of wall time                        = 144.350588
 
-Test 038 control_lheatstrg_debug PASS
+Test 039 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_merra2_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_merra2_debug
-Checking test 039 control_merra2_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lheatstrg_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_lheatstrg_debug
+Checking test 040 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 211.124701
+The total amount of wall time                        = 141.389206
 
-Test 039 control_merra2_debug PASS
+Test 040 control_lheatstrg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_rrtmgp_debug
-Checking test 040 control_rrtmgp_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_merra2_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_merra2_debug
+Checking test 041 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.358148
+The total amount of wall time                        = 210.767858
 
-Test 040 control_rrtmgp_debug PASS
+Test 041 control_merra2_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_csawmg_debug
-Checking test 041 control_csawmg_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_rrtmgp_debug
+Checking test 042 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 274.847806
+The total amount of wall time                        = 159.470978
 
-Test 041 control_csawmg_debug PASS
+Test 042 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_csawmgt_debug
-Checking test 042 control_csawmgt_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_csawmg_debug
+Checking test 043 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 284.892785
+The total amount of wall time                        = 255.410485
 
-Test 042 control_csawmgt_debug PASS
+Test 043 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ugwpv1_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_ugwpv1_debug
-Checking test 043 control_ugwpv1_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_csawmgt_debug
+Checking test 044 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 155.549450
+The total amount of wall time                        = 284.280579
 
-Test 043 control_ugwpv1_debug PASS
+Test 044 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_ras_debug
-Checking test 044 control_ras_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ugwpv1_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ugwpv1_debug
+Checking test 045 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.109196
+The total amount of wall time                        = 152.106456
 
-Test 044 control_ras_debug PASS
+Test 045 control_ugwpv1_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_thompson_debug
-Checking test 045 control_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_ras_debug
+Checking test 046 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.834555
+The total amount of wall time                        = 145.466361
 
-Test 045 control_thompson_debug PASS
+Test 046 control_ras_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_thompson_no_aero_debug
-Checking test 046 control_thompson_no_aero_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_noahmp_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_noahmp_debug
+Checking test 047 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.912969
+The total amount of wall time                        = 138.881897
 
-Test 046 control_thompson_no_aero_debug PASS
+Test 047 control_noahmp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/control_thompson_extdiag_debug
-Checking test 047 control_thompson_extdiag_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_diag_debug
+Checking test 048 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.802671
+The total amount of wall time                        = 151.056126
 
-Test 047 control_thompson_extdiag_debug PASS
+Test 048 control_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_control_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/regional_control_debug
-Checking test 048 regional_control_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_thompson_debug
+Checking test 049 control_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+The total amount of wall time                        = 166.570874
+
+Test 049 control_thompson_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_thompson_no_aero_debug
+Checking test 050 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+The total amount of wall time                        = 161.743788
+
+Test 050 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_debug_extdiag
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/control_thompson_extdiag_debug
+Checking test 051 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+The total amount of wall time                        = 180.764101
+
+Test 051 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_control_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/regional_control_debug
+Checking test 052 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 243.849589
+The total amount of wall time                        = 244.004124
 
-Test 048 regional_control_debug PASS
+Test 052 regional_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_gsd_debug
-Checking test 049 fv3_gsd_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_gsd_debug
+Checking test 053 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1297,14 +1349,47 @@ Checking test 049 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.894716
+The total amount of wall time                        = 243.498263
 
-Test 049 fv3_gsd_debug PASS
+Test 053 fv3_gsd_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd_diag3d_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_gsd_diag3d_debug
-Checking test 050 fv3_gsd_diag3d_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd_diag_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_gsd_diag_debug
+Checking test 054 fv3_gsd_diag_debug results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf001.tile1.nc .........OK
+ Comparing sfcf001.tile2.nc .........OK
+ Comparing sfcf001.tile3.nc .........OK
+ Comparing sfcf001.tile4.nc .........OK
+ Comparing sfcf001.tile5.nc .........OK
+ Comparing sfcf001.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf001.tile1.nc .........OK
+ Comparing atmf001.tile2.nc .........OK
+ Comparing atmf001.tile3.nc .........OK
+ Comparing atmf001.tile4.nc .........OK
+ Comparing atmf001.tile5.nc .........OK
+ Comparing atmf001.tile6.nc .........OK
+
+The total amount of wall time                        = 471.117156
+
+Test 054 fv3_gsd_diag_debug PASS
+
+
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_rrfs_v1beta_debug
+Checking test 055 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1368,14 +1453,14 @@ Checking test 050 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 248.921328
+The total amount of wall time                        = 191.671087
 
-Test 050 fv3_gsd_diag3d_debug PASS
+Test 055 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_rrfs_v1beta_debug
-Checking test 051 fv3_rrfs_v1beta_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_rrfs_v1alpha_debug
+Checking test 056 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1439,85 +1524,14 @@ Checking test 051 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 190.521555
+The total amount of wall time                        = 190.628757
 
-Test 051 fv3_rrfs_v1beta_debug PASS
-
-
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_rrfs_v1alpha_debug
-Checking test 052 fv3_rrfs_v1alpha_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf003.tile1.nc .........OK
- Comparing sfcf003.tile2.nc .........OK
- Comparing sfcf003.tile3.nc .........OK
- Comparing sfcf003.tile4.nc .........OK
- Comparing sfcf003.tile5.nc .........OK
- Comparing sfcf003.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf003.tile1.nc .........OK
- Comparing atmf003.tile2.nc .........OK
- Comparing atmf003.tile3.nc .........OK
- Comparing atmf003.tile4.nc .........OK
- Comparing atmf003.tile5.nc .........OK
- Comparing atmf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-The total amount of wall time                        = 189.926142
-
-Test 052 fv3_rrfs_v1alpha_debug PASS
+Test 056 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 053 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 057 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1581,14 +1595,14 @@ Checking test 053 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.175546
+The total amount of wall time                        = 201.035033
 
-Test 053 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 057 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_20766/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Minsuk.Ji/FV3_RT/rt_15499/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 058 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -1602,11 +1616,11 @@ Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 373.746371
+The total amount of wall time                        = 358.102155
 
-Test 054 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 058 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jul 19 20:21:19 UTC 2021
-Elapsed time: 00h:29m:27s. Have a nice day!
+Thu Jul 22 23:46:04 UTC 2021
+Elapsed time: 00h:30m:28s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,26 +1,26 @@
-Mon Jul 19 17:36:58 UTC 2021
+Thu Jul 22 23:59:09 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 2068 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 2419 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 584 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 1084 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1560 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1159 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 1346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1151 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 350 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 285 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 317 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 290 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 932 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 345 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 971 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 363 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 1114 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 2129 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 2121 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 589 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 1120 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1573 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 1374 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1170 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 349 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 298 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 289 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 907 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 343 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 973 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 376 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 1159 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 108.791290
+[0] The total amount of wall time                        = 100.973318
 
 Test 001 cpld_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 68.021659
+[0] The total amount of wall time                        = 67.721315
 
 Test 002 cpld_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 98.238873
+[0] The total amount of wall time                        = 94.878646
 
 Test 003 cpld_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 107.049875
+[0] The total amount of wall time                        = 101.387471
 
 Test 004 cpld_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_ca
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_ca
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_ca
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 107.148826
+[0] The total amount of wall time                        = 99.179818
 
 Test 005 cpld_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control_c192
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 416.884034
+[0] The total amount of wall time                        = 410.253670
 
 Test 006 cpld_control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_restart_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control_c192
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 315.367503
+[0] The total amount of wall time                        = 313.230177
 
 Test 007 cpld_restart_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control_c384
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 813.672812
+[0] The total amount of wall time                        = 800.039755
 
 Test 008 cpld_control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_restart_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control_c384
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 465.078186
+[0] The total amount of wall time                        = 467.346310
 
 Test 009 cpld_restart_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_bmark_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 688.783401
+[0] The total amount of wall time                        = 660.434432
 
 Test 010 cpld_bmark_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_restart_bmark_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 433.867417
+[0] The total amount of wall time                        = 434.264952
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_bmark_v16_nsst
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_bmark_v16_nsst
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_bmark_v16_nsst
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 682.235948
+[0] The total amount of wall time                        = 661.759724
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_bmark_wave_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_bmark_wave_v16
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_bmark_wave_v16
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 775.564294
+[0] The total amount of wall time                        = 789.035263
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_bmark_wave_v16_p7b
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_bmark_wave_v16_p7b
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_bmark_wave_v16_p7b
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 846.226590
+[0] The total amount of wall time                        = 801.908784
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_control_wave
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_control_wave
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_control_wave
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 122.594268
+[0] The total amount of wall time                        = 123.235089
 
 Test 015 cpld_control_wave PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/cpld_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/cpld_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/cpld_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 311.362705
+[0] The total amount of wall time                        = 308.860139
 
 Test 016 cpld_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 172.277684
+[0] The total amount of wall time                        = 170.246795
 
 Test 017 control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -986,13 +986,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 176.028969
+[0] The total amount of wall time                        = 174.471487
 
 Test 018 control_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1035,13 +1035,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 157.959832
+[0] The total amount of wall time                        = 155.711259
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1080,13 +1080,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 73.352401
+[0] The total amount of wall time                        = 72.772890
 
 Test 020 control_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_CubedSphereGrid
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,30 +1113,30 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 135.903297
+[0] The total amount of wall time                        = 134.376274
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 198.374582
+[0] The total amount of wall time                        = 198.330677
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_c192
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1147,13 +1147,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 589.428135
+[0] The total amount of wall time                        = 572.871018
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_c384
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1164,13 +1164,13 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1035.296918
+[0] The total amount of wall time                        = 1022.419778
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_c384gdas
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1213,13 +1213,13 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 895.050599
+[0] The total amount of wall time                        = 894.961459
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_stochy
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_stochy
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1230,14 +1230,27 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 122.007785
+[0] The total amount of wall time                        = 121.426011
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ca
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_ca
-Checking test 027 control_ca results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_stochy_restart
+Checking test 027 control_stochy_restart results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 61.846821
+
+Test 027 control_stochy_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ca
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ca
+Checking test 028 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1247,14 +1260,14 @@ Checking test 027 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 119.978056
+[0] The total amount of wall time                        = 118.292332
 
-Test 027 control_ca PASS
+Test 028 control_ca PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lndp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_lndp
-Checking test 028 control_lndp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lndp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_lndp
+Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1264,14 +1277,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 122.976904
+[0] The total amount of wall time                        = 121.773289
 
-Test 028 control_lndp PASS
+Test 029 control_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lheatstrg
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_lheatstrg
-Checking test 029 control_lheatstrg results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lheatstrg
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_lheatstrg
+Checking test 030 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1281,14 +1294,14 @@ Checking test 029 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 170.887148
+[0] The total amount of wall time                        = 171.078999
 
-Test 029 control_lheatstrg PASS
+Test 030 control_lheatstrg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lseaspray
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_lseaspray
-Checking test 030 control_lseaspray results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lseaspray
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_lseaspray
+Checking test 031 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1298,14 +1311,14 @@ Checking test 030 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 179.473790
+[0] The total amount of wall time                        = 178.742401
 
-Test 030 control_lseaspray PASS
+Test 031 control_lseaspray PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_merra2
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_merra2
-Checking test 031 control_merra2 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_merra2
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_merra2
+Checking test 032 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1315,14 +1328,14 @@ Checking test 031 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 198.751631
+[0] The total amount of wall time                        = 196.790890
 
-Test 031 control_merra2 PASS
+Test 032 control_merra2 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_rrtmgp
-Checking test 032 control_rrtmgp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_rrtmgp
+Checking test 033 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1332,14 +1345,14 @@ Checking test 032 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 233.795422
+[0] The total amount of wall time                        = 231.416522
 
-Test 032 control_rrtmgp PASS
+Test 033 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_csawmg
-Checking test 033 control_csawmg results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_csawmg
+Checking test 034 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1349,14 +1362,14 @@ Checking test 033 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 308.437398
+[0] The total amount of wall time                        = 306.893817
 
-Test 033 control_csawmg PASS
+Test 034 control_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_csawmgt
-Checking test 034 control_csawmgt results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_csawmgt
+Checking test 035 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1366,14 +1379,14 @@ Checking test 034 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 375.796927
+[0] The total amount of wall time                        = 369.418182
 
-Test 034 control_csawmgt PASS
+Test 035 control_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_flake
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_flake
-Checking test 035 control_flake results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_flake
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_flake
+Checking test 036 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1383,14 +1396,14 @@ Checking test 035 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 252.178430
+[0] The total amount of wall time                        = 252.881410
 
-Test 035 control_flake PASS
+Test 036 control_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ugwpv1
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_ugwpv1
-Checking test 036 control_ugwpv1 results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ugwpv1
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ugwpv1
+Checking test 037 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1400,14 +1413,14 @@ Checking test 036 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 209.546782
+[0] The total amount of wall time                        = 208.453419
 
-Test 036 control_ugwpv1 PASS
+Test 037 control_ugwpv1 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ras
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_ras
-Checking test 037 control_ras results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ras
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ras
+Checking test 038 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1417,14 +1430,14 @@ Checking test 037 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 201.232889
+[0] The total amount of wall time                        = 200.294664
 
-Test 037 control_ras PASS
+Test 038 control_ras PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_thompson
-Checking test 038 control_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_thompson
+Checking test 039 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1434,14 +1447,14 @@ Checking test 038 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 235.958773
+[0] The total amount of wall time                        = 236.358935
 
-Test 038 control_thompson PASS
+Test 039 control_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_thompson_no_aero
-Checking test 039 control_thompson_no_aero results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_thompson_no_aero
+Checking test 040 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1451,14 +1464,14 @@ Checking test 039 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 226.039888
+[0] The total amount of wall time                        = 227.201987
 
-Test 039 control_thompson_no_aero PASS
+Test 040 control_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_noahmp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_noahmp
-Checking test 040 control_noahmp results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_noahmp
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_noahmp
+Checking test 041 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -1468,40 +1481,40 @@ Checking test 040 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 203.118102
+[0] The total amount of wall time                        = 199.581655
 
-Test 040 control_noahmp PASS
+Test 041 control_noahmp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_control
-Checking test 041 regional_control results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_control
+Checking test 042 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 352.598230
+[0] The total amount of wall time                        = 351.413935
 
-Test 041 regional_control PASS
+Test 042 regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_restart
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_restart
-Checking test 042 regional_restart results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_restart
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_restart
+Checking test 043 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-[0] The total amount of wall time                        = 199.213023
+[0] The total amount of wall time                        = 201.067101
 
-Test 042 regional_restart PASS
+Test 043 regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_quilt
-Checking test 043 regional_quilt results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_quilt
+Checking test 044 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1511,14 +1524,14 @@ Checking test 043 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 347.553553
+[0] The total amount of wall time                        = 345.401776
 
-Test 043 regional_quilt PASS
+Test 044 regional_quilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_quilt_2threads
-Checking test 044 regional_quilt_2threads results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_quilt_2threads
+Checking test 045 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1528,14 +1541,14 @@ Checking test 044 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 192.263551
+[0] The total amount of wall time                        = 191.602554
 
-Test 044 regional_quilt_2threads PASS
+Test 045 regional_quilt_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_hafs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_quilt_hafs
-Checking test 045 regional_quilt_hafs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_hafs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_quilt_hafs
+Checking test 046 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1543,28 +1556,28 @@ Checking test 045 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 345.059452
+[0] The total amount of wall time                        = 338.307555
 
-Test 045 regional_quilt_hafs PASS
+Test 046 regional_quilt_hafs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_quilt_netcdf_parallel
-Checking test 046 regional_quilt_netcdf_parallel results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_quilt_netcdf_parallel
+Checking test 047 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 348.692084
+[0] The total amount of wall time                        = 345.291817
 
-Test 046 regional_quilt_netcdf_parallel PASS
+Test 047 regional_quilt_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_quilt_RRTMGP
-Checking test 047 regional_quilt_RRTMGP results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_quilt_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_quilt_RRTMGP
+Checking test 048 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1574,14 +1587,14 @@ Checking test 047 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 471.171300
+[0] The total amount of wall time                        = 464.118065
 
-Test 047 regional_quilt_RRTMGP PASS
+Test 048 regional_quilt_RRTMGP PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_gsd
-Checking test 048 fv3_gsd results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_gsd
+Checking test 049 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1669,14 +1682,14 @@ Checking test 048 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 204.102029
+[0] The total amount of wall time                        = 253.871369
 
-Test 048 fv3_gsd PASS
+Test 049 fv3_gsd PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1alpha
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_rrfs_v1alpha
-Checking test 049 fv3_rrfs_v1alpha results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1alpha
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_rrfs_v1alpha
+Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1740,14 +1753,14 @@ Checking test 049 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 104.544936
+[0] The total amount of wall time                        = 103.898547
 
-Test 049 fv3_rrfs_v1alpha PASS
+Test 050 fv3_rrfs_v1alpha PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rap
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_rap
-Checking test 050 fv3_rap results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rap
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_rap
+Checking test 051 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1811,14 +1824,14 @@ Checking test 050 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 104.456209
+[0] The total amount of wall time                        = 102.226829
 
-Test 050 fv3_rap PASS
+Test 051 fv3_rap PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_hrrr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_hrrr
-Checking test 051 fv3_hrrr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_hrrr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_hrrr
+Checking test 052 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1882,14 +1895,14 @@ Checking test 051 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 103.010182
+[0] The total amount of wall time                        = 100.890437
 
-Test 051 fv3_hrrr PASS
+Test 052 fv3_hrrr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_rrfs_v1beta
-Checking test 052 fv3_rrfs_v1beta results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_rrfs_v1beta
+Checking test 053 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -1953,14 +1966,14 @@ Checking test 052 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.085184
+[0] The total amount of wall time                        = 101.991407
 
-Test 052 fv3_rrfs_v1beta PASS
+Test 053 fv3_rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_HAFS_v0_hwrf_thompson
-Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_HAFS_v0_hwrf_thompson
+Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2024,14 +2037,14 @@ Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 174.524192
+[0] The total amount of wall time                        = 171.681234
 
-Test 053 fv3_HAFS_v0_hwrf_thompson PASS
+Test 054 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_esg_HAFS_v0_hwrf_thompson
-Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_esg_HAFS_v0_hwrf_thompson
+Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
@@ -2045,40 +2058,40 @@ Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 319.100512
+[0] The total amount of wall time                        = 320.725295
 
-Test 054 fv3_esg_HAFS_v0_hwrf_thompson PASS
+Test 055 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_debug
-Checking test 055 control_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_debug
+Checking test 056 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 167.662895
+[0] The total amount of wall time                        = 164.549410
 
-Test 055 control_debug PASS
+Test 056 control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_2threads_debug
-Checking test 056 control_2threads_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_2threads_debug
+Checking test 057 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 154.880337
+[0] The total amount of wall time                        = 153.102849
 
-Test 056 control_2threads_debug PASS
+Test 057 control_2threads_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_CubedSphereGrid_debug
-Checking test 057 control_CubedSphereGrid_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_CubedSphereGrid_debug
+Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -2104,197 +2117,236 @@ Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 180.925836
+[0] The total amount of wall time                        = 178.645833
 
-Test 057 control_CubedSphereGrid_debug PASS
+Test 058 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_wrtGauss_netcdf_parallel_debug
-Checking test 058 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_wrtGauss_netcdf_parallel_debug
+Checking test 059 control_wrtGauss_netcdf_parallel_debug results ....
+ Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 170.767466
+[0] The total amount of wall time                        = 168.234981
 
-Test 058 control_wrtGauss_netcdf_parallel_debug PASS
+Test 059 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_stochy_debug
-Checking test 059 control_stochy_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_stochy_debug
+Checking test 060 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.980926
+[0] The total amount of wall time                        = 189.573189
 
-Test 059 control_stochy_debug PASS
+Test 060 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_lndp_debug
-Checking test 060 control_lndp_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ca_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ca_debug
+Checking test 061 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 171.977437
+[0] The total amount of wall time                        = 166.922347
 
-Test 060 control_lndp_debug PASS
+Test 061 control_ca_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_lheatstrg_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_lheatstrg_debug
-Checking test 061 control_lheatstrg_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_lndp_debug
+Checking test 062 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 166.925457
+[0] The total amount of wall time                        = 169.496490
 
-Test 061 control_lheatstrg_debug PASS
+Test 062 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_merra2_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_merra2_debug
-Checking test 062 control_merra2_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_lheatstrg_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_lheatstrg_debug
+Checking test 063 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 238.500482
+[0] The total amount of wall time                        = 164.888992
 
-Test 062 control_merra2_debug PASS
+Test 063 control_lheatstrg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_rrtmgp_debug
-Checking test 063 control_rrtmgp_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_merra2_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_merra2_debug
+Checking test 064 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.191954
+[0] The total amount of wall time                        = 238.648672
 
-Test 063 control_rrtmgp_debug PASS
+Test 064 control_merra2_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_csawmg_debug
-Checking test 064 control_csawmg_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_rrtmgp_debug
+Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 283.878581
+[0] The total amount of wall time                        = 188.332214
 
-Test 064 control_csawmg_debug PASS
+Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_csawmgt_debug
-Checking test 065 control_csawmgt_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_csawmg_debug
+Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 319.487855
+[0] The total amount of wall time                        = 282.177729
 
-Test 065 control_csawmgt_debug PASS
+Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ugwpv1_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_ugwpv1_debug
-Checking test 066 control_ugwpv1_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_csawmgt_debug
+Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 181.593320
+[0] The total amount of wall time                        = 318.735917
 
-Test 066 control_ugwpv1_debug PASS
+Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_ras_debug
-Checking test 067 control_ras_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ugwpv1_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ugwpv1_debug
+Checking test 068 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 173.773642
+[0] The total amount of wall time                        = 178.306682
 
-Test 067 control_ras_debug PASS
+Test 068 control_ugwpv1_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_thompson_debug
-Checking test 068 control_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_ras_debug
+Checking test 069 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 196.854277
+[0] The total amount of wall time                        = 170.950416
 
-Test 068 control_thompson_debug PASS
+Test 069 control_ras_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_thompson_no_aero_debug
-Checking test 069 control_thompson_no_aero_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_noahmp_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_noahmp_debug
+Checking test 070 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.553271
+[0] The total amount of wall time                        = 165.319695
 
-Test 069 control_thompson_no_aero_debug PASS
+Test 070 control_noahmp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_thompson_extdiag_debug
-Checking test 070 control_thompson_extdiag_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_diag_debug
+Checking test 071 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 206.512508
+[0] The total amount of wall time                        = 174.732933
 
-Test 070 control_thompson_extdiag_debug PASS
+Test 071 control_diag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_regional_control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/regional_control_debug
-Checking test 071 regional_control_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_thompson_debug
+Checking test 072 control_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 193.848628
+
+Test 072 control_thompson_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_thompson_no_aero_debug
+Checking test 073 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 187.261904
+
+Test 073 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_thompson_debug_extdiag
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_thompson_extdiag_debug
+Checking test 074 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 204.232432
+
+Test 074 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_regional_control_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/regional_control_debug
+Checking test 075 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 279.785512
+[0] The total amount of wall time                        = 277.354554
 
-Test 071 regional_control_debug PASS
+Test 075 regional_control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_gsd_debug
-Checking test 072 fv3_gsd_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_gsd_debug
+Checking test 076 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2358,14 +2410,47 @@ Checking test 072 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 233.278409
+[0] The total amount of wall time                        = 283.210745
 
-Test 072 fv3_gsd_debug PASS
+Test 076 fv3_gsd_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_gsd_diag3d_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_gsd_diag3d_debug
-Checking test 073 fv3_gsd_diag3d_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_gsd_diag_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_gsd_diag_debug
+Checking test 077 fv3_gsd_diag_debug results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf001.tile1.nc .........OK
+ Comparing sfcf001.tile2.nc .........OK
+ Comparing sfcf001.tile3.nc .........OK
+ Comparing sfcf001.tile4.nc .........OK
+ Comparing sfcf001.tile5.nc .........OK
+ Comparing sfcf001.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf001.tile1.nc .........OK
+ Comparing atmf001.tile2.nc .........OK
+ Comparing atmf001.tile3.nc .........OK
+ Comparing atmf001.tile4.nc .........OK
+ Comparing atmf001.tile5.nc .........OK
+ Comparing atmf001.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 432.135680
+
+Test 077 fv3_gsd_diag_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_rrfs_v1beta_debug
+Checking test 078 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2429,14 +2514,14 @@ Checking test 073 fv3_gsd_diag3d_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 304.670585
+[0] The total amount of wall time                        = 223.626501
 
-Test 073 fv3_gsd_diag3d_debug PASS
+Test 078 fv3_rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_rrfs_v1beta_debug
-Checking test 074 fv3_rrfs_v1beta_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_rrfs_v1alpha_debug
+Checking test 079 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2500,85 +2585,14 @@ Checking test 074 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 225.380661
+[0] The total amount of wall time                        = 223.802703
 
-Test 074 fv3_rrfs_v1beta_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_rrfs_v1alpha_debug
-Checking test 075 fv3_rrfs_v1alpha_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing sfcf000.tile1.nc .........OK
- Comparing sfcf000.tile2.nc .........OK
- Comparing sfcf000.tile3.nc .........OK
- Comparing sfcf000.tile4.nc .........OK
- Comparing sfcf000.tile5.nc .........OK
- Comparing sfcf000.tile6.nc .........OK
- Comparing sfcf003.tile1.nc .........OK
- Comparing sfcf003.tile2.nc .........OK
- Comparing sfcf003.tile3.nc .........OK
- Comparing sfcf003.tile4.nc .........OK
- Comparing sfcf003.tile5.nc .........OK
- Comparing sfcf003.tile6.nc .........OK
- Comparing atmf000.tile1.nc .........OK
- Comparing atmf000.tile2.nc .........OK
- Comparing atmf000.tile3.nc .........OK
- Comparing atmf000.tile4.nc .........OK
- Comparing atmf000.tile5.nc .........OK
- Comparing atmf000.tile6.nc .........OK
- Comparing atmf003.tile1.nc .........OK
- Comparing atmf003.tile2.nc .........OK
- Comparing atmf003.tile3.nc .........OK
- Comparing atmf003.tile4.nc .........OK
- Comparing atmf003.tile5.nc .........OK
- Comparing atmf003.tile6.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 225.368648
-
-Test 075 fv3_rrfs_v1alpha_debug PASS
+Test 079 fv3_rrfs_v1alpha_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_HAFS_v0_hwrf_thompson_debug
-Checking test 076 fv3_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_HAFS_v0_hwrf_thompson_debug
+Checking test 080 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
  Comparing atmos_4xdaily.tile3.nc .........OK
@@ -2642,14 +2656,14 @@ Checking test 076 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 236.158162
+[0] The total amount of wall time                        = 234.820919
 
-Test 076 fv3_HAFS_v0_hwrf_thompson_debug PASS
+Test 080 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/fv3_esg_HAFS_v0_hwrf_thompson_debug
-Checking test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/fv3_esg_HAFS_v0_hwrf_thompson_debug
+Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
@@ -2663,74 +2677,86 @@ Checking test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 434.999103
+[0] The total amount of wall time                        = 433.470744
 
-Test 077 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
+Test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_control_cfsr
-Checking test 078 datm_control_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_control_cfsr
+Checking test 082 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 110.022611
+[0] The total amount of wall time                        = 104.595539
 
-Test 078 datm_control_cfsr PASS
+Test 082 datm_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_restart_cfsr
-Checking test 079 datm_restart_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_restart_cfsr
+Checking test 083 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 79.897833
+[0] The total amount of wall time                        = 75.131717
 
-Test 079 datm_restart_cfsr PASS
+Test 083 datm_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_control_gefs
-Checking test 080 datm_control_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_control_gefs
+Checking test 084 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 106.669037
+[0] The total amount of wall time                        = 97.529251
 
-Test 080 datm_control_gefs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_bulk_cfsr
-Checking test 081 datm_bulk_cfsr results ....
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2011-10-02-00000.nc .........OK
- Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 108.412275
-
-Test 081 datm_bulk_cfsr PASS
+Test 084 datm_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_bulk_gefs
-Checking test 082 datm_bulk_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_control_iau_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_control_iau_gefs
+Checking test 085 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 107.024577
+[0] The total amount of wall time                        = 99.200002
 
-Test 082 datm_bulk_gefs PASS
+Test 085 datm_control_iau_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_mx025_cfsr
-Checking test 083 datm_mx025_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_bulk_cfsr
+Checking test 086 datm_bulk_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 101.320209
+
+Test 086 datm_bulk_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_bulk_gefs
+Checking test 087 datm_bulk_gefs results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 98.016166
+
+Test 087 datm_bulk_gefs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_mx025_cfsr
+Checking test 088 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2738,14 +2764,14 @@ Checking test 083 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 359.099850
+[0] The total amount of wall time                        = 355.276907
 
-Test 083 datm_mx025_cfsr PASS
+Test 088 datm_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_mx025_gefs
-Checking test 084 datm_mx025_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_mx025_gefs
+Checking test 089 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2753,86 +2779,86 @@ Checking test 084 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 361.989908
+[0] The total amount of wall time                        = 346.698286
 
-Test 084 datm_mx025_gefs PASS
+Test 089 datm_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_debug_cfsr
-Checking test 085 datm_debug_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_debug_cfsr
+Checking test 090 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 297.987583
+[0] The total amount of wall time                        = 292.688840
 
-Test 085 datm_debug_cfsr PASS
+Test 090 datm_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_control_cfsr
-Checking test 086 datm_cdeps_control_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_control_cfsr
+Checking test 091 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 179.234223
+[0] The total amount of wall time                        = 172.449104
 
-Test 086 datm_cdeps_control_cfsr PASS
+Test 091 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_restart_cfsr
-Checking test 087 datm_cdeps_restart_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_restart_cfsr
+Checking test 092 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 118.885148
+[0] The total amount of wall time                        = 118.297466
 
-Test 087 datm_cdeps_restart_cfsr PASS
+Test 092 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_control_gefs
-Checking test 088 datm_cdeps_control_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_control_gefs
+Checking test 093 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.327672
+[0] The total amount of wall time                        = 167.528450
 
-Test 088 datm_cdeps_control_gefs PASS
+Test 093 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_bulk_cfsr
-Checking test 089 datm_cdeps_bulk_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_bulk_cfsr
+Checking test 094 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 177.473887
+[0] The total amount of wall time                        = 173.904204
 
-Test 089 datm_cdeps_bulk_cfsr PASS
+Test 094 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_bulk_gefs
-Checking test 090 datm_cdeps_bulk_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_bulk_gefs
+Checking test 095 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.756760
+[0] The total amount of wall time                        = 166.124928
 
-Test 090 datm_cdeps_bulk_gefs PASS
+Test 095 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_mx025_cfsr
-Checking test 091 datm_cdeps_mx025_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_mx025_cfsr
+Checking test 096 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2840,14 +2866,14 @@ Checking test 091 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 354.862622
+[0] The total amount of wall time                        = 351.457708
 
-Test 091 datm_cdeps_mx025_cfsr PASS
+Test 096 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_mx025_gefs
-Checking test 092 datm_cdeps_mx025_gefs results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_mx025_gefs
+Checking test 097 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
  Comparing RESTART/MOM.res_2.nc .........OK
@@ -2855,36 +2881,36 @@ Checking test 092 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 350.709698
+[0] The total amount of wall time                        = 340.780027
 
-Test 092 datm_cdeps_mx025_gefs PASS
+Test 097 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_multiple_files_cfsr
-Checking test 093 datm_cdeps_multiple_files_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_multiple_files_cfsr
+Checking test 098 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.369303
+[0] The total amount of wall time                        = 172.462982
 
-Test 093 datm_cdeps_multiple_files_cfsr PASS
+Test 098 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/datm_cdeps_debug_cfsr
-Checking test 094 datm_cdeps_debug_cfsr results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/datm_cdeps_debug_cfsr
+Checking test 099 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 493.438750
+[0] The total amount of wall time                        = 490.639504
 
-Test 094 datm_cdeps_debug_cfsr PASS
+Test 099 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210719/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_155991/control_atmwav
-Checking test 095 control_atmwav results ....
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210722/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Minsuk.Ji/FV3_RT/rt_23465/control_atmwav
+Checking test 100 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2926,11 +2952,11 @@ Checking test 095 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 361.602306
+[0] The total amount of wall time                        = 360.101850
 
-Test 095 control_atmwav PASS
+Test 100 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jul 19 18:53:07 UTC 2021
-Elapsed time: 01h:16m:13s. Have a nice day!
+Fri Jul 23 01:19:27 UTC 2021
+Elapsed time: 01h:20m:20s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -46,7 +46,7 @@ RUN     | control_c192                                                          
 RUN     | control_c384                                                                                                            | - gaea.intel wcoss_cray                 | fv3 |
 RUN     | control_c384gdas                                                                                                        | - gaea.intel wcoss_cray                 | fv3 |
 RUN     | control_stochy                                                                                                          |                                         | fv3 |
-RUN     | control_stochy_restart                                                                                                  |                                         | fv3 | control_stochy
+RUN     | control_stochy_restart                                                                                                  |                                         |     | control_stochy
 RUN     | control_ca                                                                                                              |                                         | fv3 |
 RUN     | control_lndp                                                                                                            |                                         | fv3 |
 RUN     | control_lheatstrg                                                                                                       |                                         | fv3 |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -111,7 +111,7 @@ RUN     | control_2threads_debug                                                
 RUN     | control_CubedSphereGrid_debug                                                                                           |                                         | fv3 |
 RUN     | control_wrtGauss_netcdf_parallel_debug                                                                                  |                                         | fv3 |
 RUN     | control_stochy_debug                                                                                                    |                                         | fv3 |
-#RUN     | control_ca_debug                                                                                                        |                                         | fv3 |
+RUN     | control_ca_debug                                                                                                        |                                         | fv3 |
 RUN     | control_lndp_debug                                                                                                      |                                         | fv3 |
 RUN     | control_lheatstrg_debug                                                                                                 |                                         | fv3 |
 RUN     | control_merra2_debug                                                                                                    |                                         | fv3 |
@@ -120,7 +120,7 @@ RUN     | control_csawmg_debug                                                  
 RUN     | control_csawmgt_debug                                                                                                   |                                         | fv3 |
 RUN     | control_ugwpv1_debug                                                                                                    |                                         | fv3 |
 RUN     | control_ras_debug                                                                                                       |                                         | fv3 |
-#RUN     | control_noahmp_debug                                                                                                    |                                         | fv3 |
+RUN     | control_noahmp_debug                                                                                                    |                                         | fv3 |
 RUN     | control_diag_debug                                                                                                     |                                         | fv3 |
 
 COMPILE | -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON                                                      |                                         | fv3 |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -58,7 +58,7 @@ COMPILE | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_
 RUN     | control_rrtmgp                                                                                                          |                                         | fv3 |
 #RUN     | control_rrtmgp_2threads                                                                                                 |                                         |     |
 #RUN     | control_rrtmgp_c192                                                                                                     |                                         | fv3 |
-RUN     | control_csawmg                                                                                                          | -jet.intel                              | fv3 |
+RUN     | control_csawmg                                                                                                          | - jet.intel cheyenne.intel              | fv3 |
 RUN     | control_csawmgt                                                                                                         |                                         | fv3 |
 RUN     | control_flake                                                                                                           |                                         | fv3 |
 RUN     | control_ugwpv1                                                                                                          |                                         | fv3 |

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -414,7 +414,7 @@ if [[ $TESTS_FILE =~ '35d' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20210720
+BL_DATE=20210722
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 else

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -47,8 +47,9 @@ RUN     | control_thompson_extdiag_debug                                        
 RUN     | control_rrtmgp_debug                                                                                                    |                | fv3         |
 RUN     | control_ugwpv1_debug                                                                                                    |                | fv3         |
 RUN     | control_ras_debug                                                                                                       |                | fv3         |
-RUN     | control_stochy_debug                                                                                                    |                | fv3         |
-RUN     | control_ca_debug                                                                                                        |                | fv3         |
+# Both stochy and ca debug tests crash with GNU
+#RUN     | control_stochy_debug                                                                                                    |                | fv3         |
+#RUN     | control_ca_debug                                                                                                        |                | fv3         |
 RUN     | control_noahmp_debug                                                                                                    |                | fv3         |
 
 COMPILE | -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON                                                   |                | fv3         |

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -14,7 +14,6 @@ RUN     | control_thompson_no_aero                                              
 RUN     | control_ugwpv1                                                                                                          |                | fv3         |
 RUN     | control_ras                                                                                                             |                | fv3         |
 
-
 COMPILE | -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON                     |                | fv3         |
 RUN     | fv3_gsd                                                                                                                 |                | fv3         |
 RUN     | fv3_rrfs_v1alpha                                                                                                        |                | fv3         |
@@ -48,6 +47,9 @@ RUN     | control_thompson_extdiag_debug                                        
 RUN     | control_rrtmgp_debug                                                                                                    |                | fv3         |
 RUN     | control_ugwpv1_debug                                                                                                    |                | fv3         |
 RUN     | control_ras_debug                                                                                                       |                | fv3         |
+RUN     | control_stochy_debug                                                                                                    |                | fv3         |
+RUN     | control_ca_debug                                                                                                        |                | fv3         |
+RUN     | control_noahmp_debug                                                                                                    |                | fv3         |
 
 COMPILE | -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON                                                   |                | fv3         |
 RUN     | fv3_HAFS_v0_hwrf_thompson_debug                                                                                         |                | fv3         |
@@ -64,8 +66,8 @@ RUN     | fv3_esg_HAFS_v0_hwrf_thompson_debug                                   
 COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled                                                                            |                | fv3         |
 RUN     | cpld_control                                                                                                            |                | fv3         |
 
-COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON                                                                 |                | fv3         |
-RUN     | cpld_debug                                                                                                              |                | fv3         |
+#COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON                                                                 |                | fv3         |
+#RUN     | cpld_debug                                                                                                              |                | fv3         |
 
 ##################################################################################################################################################################
 # Data Atmosphere tests                                                                                                                                          #

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -63,14 +63,14 @@ RUN     | fv3_esg_HAFS_v0_hwrf_thompson_debug                                   
 # S2S tests                                                                                                                                                      #
 ##################################################################################################################################################################
 
-COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled                                                                            |                | fv3         |
-RUN     | cpld_control                                                                                                            |                | fv3         |
+COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled                                                                            | - cheyenne.gnu | fv3         |
+RUN     | cpld_control                                                                                                            | - cheyenne.gnu | fv3         |
 
-#COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON                                                                 |                | fv3         |
-#RUN     | cpld_debug                                                                                                              |                | fv3         |
+COMPILE | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON                                                                 | - cheyenne.gnu | fv3         |
+RUN     | cpld_debug                                                                                                              | - cheyenne.gnu | fv3         |
 
 ##################################################################################################################################################################
 # Data Atmosphere tests                                                                                                                                          #
 ##################################################################################################################################################################
 
-COMPILE | -DAPP=NG-GODAS-NEMSDATM                                                                                                 |                | fv3         |
+COMPILE | -DAPP=NG-GODAS-NEMSDATM                                                                                                 | - cheyenne.gnu | fv3         |

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -126,7 +126,7 @@ submit_and_wait() {
         status_label='held in a queue'
       elif [[ $status = 'R' ]];  then
         status_label='running'
-      elif [[ $status = 'E' ]] || [[ $status = 'C' ]];  then
+      elif [[ $status = 'E' ]] || [[ $status = 'C' ]] || [[ $status = '-' ]];  then
         status_label='finished'
         test_status='DONE'
         exit_status=$( qstat ${jobid} -x -f | grep Exit_status | awk '{print $3}')


### PR DESCRIPTION
# PR Checklist

- [X] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [n/a] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

This PR combines many changes:
- update of submodule pointers for fv3atm and ccpp-physics:
    - Thompson inner loop from @ruiyusun
    - Thompson subcycling bugfix from @climbfuji 
    - Noah/NoahMP bugfix/remove snet from Noah LSM from @helinwei-noaa
    - Fix time dimension in restart files from @climbfuji 
- Bug fix in `rt_utils.sh` to correctly detect job failures on Cheyenne with PBS, turn off coupled debug compilation/tests for GNU. which now fail, same for test `control_csawmg`; from @DeniseWorthen and @DusanJovic-NOAA
- Turn on several debug tests in `rt.conf` and `rt_gnu.conf` from @junwang-noaa 
    - Note. `control_stochy_debug` and `control_ca_debug` still not working with GNU
- Don't create baseline for control_stochy_restart run (in `rt.conf`) from @junwang-noaa 

The changes in fv3atm and ccpp-physics do change the results of all regression tests, new baseline date is 20210721.

### Issue(s) addressed

Fixes #697 

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [x] CI

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/702
https://github.com/NOAA-EMC/fv3atm/pull/350
https://github.com/ufs-community/ufs-weather-model/pull/702
