### PR TITLE
Fix for new hera ecflow requirements

### DIFF
--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -59,6 +59,7 @@ case $(hostname -f) in
   hfe10)                   MACHINE_ID=hera ;; ### hera10
   hfe11)                   MACHINE_ID=hera ;; ### hera11
   hfe12)                   MACHINE_ID=hera ;; ### hera12
+  hecflow01)               MACHINE_ID=hera ;; ### heraecflow01
 
   fe1)                     MACHINE_ID=jet ;; ### jet01
   fe2)                     MACHINE_ID=jet ;; ### jet02

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -235,8 +235,13 @@ elif [[ $MACHINE_ID = hera.* ]]; then
   PYTHONHOME=/scratch1/NCEPDEV/nems/emc.nemspara/soft/miniconda3_new_20210629
   export PATH=$PYTHONHOME/bin:$PATH
   export PYTHONPATH=$PYTHONHOME/lib/python3.7/site-packages
-  ECFLOW_START=$PYTHONHOME/bin/ecflow_start.sh
-  ECF_PORT=$(( $(id -u) + 1500 ))
+
+  if [[ ! $HOSTNAME = hecflow* ]]; then
+    echo "ERROR: On Hera we must be logged into 'hecflow' login nodes"
+    exit 1
+  fi
+  module load ecflow
+  ECFLOW_START=ecflow_start.sh
 
   QUEUE=debug
   COMPILE_QUEUE=batch

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -538,7 +538,7 @@ ecflow_run() {
   not_running=$?
   if [[ $not_running -eq 1 ]]; then
     echo "ecflow_server is NOT running on ${ECF_HOST}:${ECF_PORT}"
-    sh ${ECFLOW_START} -p ${ECF_PORT}
+    ${ECFLOW_START} -p ${ECF_PORT}
   else
     echo "ecflow_server is already running on ${ECF_HOST}:${ECF_PORT}"
   fi


### PR DESCRIPTION
# PR Checklist

- [x] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [x] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description
Change to force hecflow01 login node (it's the only one available currently) on hera for use of ecflow server.

### Issue(s) addressed
- fixes #706 

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] CI

## Dependencies
None
