### PR TITLE
Update CCPP standard names for consistency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = std_nm_replace_20210701_dom_20210728
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = std_nm_replace_20210701_dom_20210728
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,26 +1,26 @@
-Tue Jul 27 13:04:21 EDT 2021
+Wed Jul 28 14:13:19 EDT 2021
 Start Regression test
 
-Compile 001 elapsed time 796 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 833 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 302 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 777 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 835 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 296 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 004 elapsed time 695 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 737 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 695 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 695 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 706 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 268 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 258 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 258 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 257 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 333 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 228 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 338 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 227 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 710 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 718 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 696 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 698 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 700 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 257 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 248 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 248 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 245 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 324 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 174 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 323 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 186 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 689 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_control
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 92.503759
+The total amount of wall time                        = 116.526315
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_restart
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 121.115913
+The total amount of wall time                        = 49.529642
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_2threads
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 145.238679
+The total amount of wall time                        = 148.423226
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_decomp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 87.615246
+The total amount of wall time                        = 119.494818
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_ca
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-The total amount of wall time                        = 118.245935
+The total amount of wall time                        = 120.314031
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_control_c192
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 464.850931
+The total amount of wall time                        = 428.445202
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_restart_c192
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-The total amount of wall time                        = 333.777298
+The total amount of wall time                        = 276.087601
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_control_c384
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 850.779959
+The total amount of wall time                        = 833.894216
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_restart_c384
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-The total amount of wall time                        = 435.237023
+The total amount of wall time                        = 432.257482
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 644.268648
+The total amount of wall time                        = 695.117631
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_restart_bmark_v16
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 338.413426
+The total amount of wall time                        = 361.565971
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16_nsst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_bmark_v16_nsst
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 701.407198
+The total amount of wall time                        = 656.875032
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_bmark_wave_v16
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 758.944477
+The total amount of wall time                        = 745.993585
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_bmark_wave_v16_p7b
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-The total amount of wall time                        = 868.122093
+The total amount of wall time                        = 892.937789
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_control_wave
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 168.517835
+The total amount of wall time                        = 102.553070
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/cpld_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-The total amount of wall time                        = 264.491440
+The total amount of wall time                        = 298.395494
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -941,13 +941,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 166.817612
+The total amount of wall time                        = 165.593928
 
 Test 017 control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_decomp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -990,13 +990,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 173.463213
+The total amount of wall time                        = 167.978252
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_2threads
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1039,13 +1039,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 199.633743
+The total amount of wall time                        = 198.421949
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_restart
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1084,13 +1084,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 78.801643
+The total amount of wall time                        = 67.494345
 
 Test 020 control_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_fhzero
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1133,13 +1133,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 164.902267
+The total amount of wall time                        = 165.362352
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1166,13 +1166,13 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 125.350391
+The total amount of wall time                        = 127.124720
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1183,13 +1183,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 847.993022
+The total amount of wall time                        = 511.786407
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_c192
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1200,13 +1200,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 542.711663
+The total amount of wall time                        = 547.979340
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_stochy
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_stochy
 Checking test 025 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1217,26 +1217,26 @@ Checking test 025 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 118.569834
+The total amount of wall time                        = 144.522484
 
 Test 025 control_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_stochy_restart
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_stochy_restart
 Checking test 026 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 102.027090
+The total amount of wall time                        = 60.032233
 
 Test 026 control_stochy_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ca
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ca
 Checking test 027 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1247,13 +1247,13 @@ Checking test 027 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 120.679148
+The total amount of wall time                        = 115.560159
 
 Test 027 control_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_lndp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1264,13 +1264,13 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 121.554210
+The total amount of wall time                        = 145.302284
 
 Test 028 control_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_lheatstrg
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_lheatstrg
 Checking test 029 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1281,13 +1281,13 @@ Checking test 029 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 170.330903
+The total amount of wall time                        = 164.596455
 
 Test 029 control_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lseaspray
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_lseaspray
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_lseaspray
 Checking test 030 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1298,13 +1298,13 @@ Checking test 030 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 201.044591
+The total amount of wall time                        = 171.829430
 
 Test 030 control_lseaspray PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_merra2
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_merra2
 Checking test 031 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1315,13 +1315,13 @@ Checking test 031 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 206.862769
+The total amount of wall time                        = 224.241591
 
 Test 031 control_merra2 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_rrtmgp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_rrtmgp
 Checking test 032 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1332,13 +1332,13 @@ Checking test 032 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 221.073666
+The total amount of wall time                        = 248.037588
 
 Test 032 control_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_csawmg
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_csawmg
 Checking test 033 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1349,13 +1349,13 @@ Checking test 033 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 325.790951
+The total amount of wall time                        = 347.191376
 
 Test 033 control_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_csawmgt
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_csawmgt
 Checking test 034 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1366,13 +1366,13 @@ Checking test 034 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 380.161971
+The total amount of wall time                        = 407.931997
 
 Test 034 control_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_flake
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_flake
 Checking test 035 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1383,13 +1383,13 @@ Checking test 035 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 245.068773
+The total amount of wall time                        = 240.224946
 
 Test 035 control_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ugwpv1
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ugwpv1
 Checking test 036 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1400,13 +1400,13 @@ Checking test 036 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 203.432664
+The total amount of wall time                        = 198.842063
 
 Test 036 control_ugwpv1 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ras
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ras
 Checking test 037 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1417,13 +1417,13 @@ Checking test 037 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 288.894754
+The total amount of wall time                        = 217.755440
 
 Test 037 control_ras PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_thompson
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_thompson
 Checking test 038 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1434,13 +1434,13 @@ Checking test 038 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 249.474962
+The total amount of wall time                        = 224.556019
 
 Test 038 control_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_thompson_no_aero
 Checking test 039 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1451,13 +1451,13 @@ Checking test 039 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 225.856475
+The total amount of wall time                        = 214.887579
 
 Test 039 control_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_noahmp
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_noahmp
 Checking test 040 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1468,13 +1468,13 @@ Checking test 040 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 197.229808
+The total amount of wall time                        = 185.859507
 
 Test 040 control_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_control
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_control
 Checking test 041 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1482,25 +1482,25 @@ Checking test 041 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 328.152289
+The total amount of wall time                        = 327.150908
 
 Test 041 regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_restart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_restart
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_restart
 Checking test 042 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 207.016413
+The total amount of wall time                        = 177.553088
 
 Test 042 regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_quilt
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_quilt
 Checking test 043 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1511,13 +1511,13 @@ Checking test 043 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 366.301168
+The total amount of wall time                        = 326.545233
 
 Test 043 regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_quilt_2threads
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_quilt_2threads
 Checking test 044 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1528,13 +1528,13 @@ Checking test 044 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 281.389940
+The total amount of wall time                        = 285.013269
 
 Test 044 regional_quilt_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_quilt_hafs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_quilt_hafs
 Checking test 045 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1543,27 +1543,27 @@ Checking test 045 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 325.850780
+The total amount of wall time                        = 325.671873
 
 Test 045 regional_quilt_hafs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_quilt_netcdf_parallel
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_quilt_netcdf_parallel
 Checking test 046 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 771.205783
+The total amount of wall time                        = 492.038463
 
 Test 046 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_quilt_RRTMGP
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_quilt_RRTMGP
 Checking test 047 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1574,13 +1574,13 @@ Checking test 047 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 465.788109
+The total amount of wall time                        = 466.729571
 
 Test 047 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_gsd
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_gsd
 Checking test 048 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1669,13 +1669,13 @@ Checking test 048 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.052766
+The total amount of wall time                        = 263.783963
 
 Test 048 fv3_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_rrfs_v1alpha
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_rrfs_v1alpha
 Checking test 049 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1740,13 +1740,13 @@ Checking test 049 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 107.857993
+The total amount of wall time                        = 121.583776
 
 Test 049 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rap
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_rap
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_rap
 Checking test 050 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1811,13 +1811,13 @@ Checking test 050 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 121.578663
+The total amount of wall time                        = 93.537142
 
 Test 050 fv3_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_hrrr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_hrrr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_hrrr
 Checking test 051 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1882,13 +1882,13 @@ Checking test 051 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 119.911578
+The total amount of wall time                        = 89.258198
 
 Test 051 fv3_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_rrfs_v1beta
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_rrfs_v1beta
 Checking test 052 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1953,13 +1953,13 @@ Checking test 052 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 117.367547
+The total amount of wall time                        = 92.089800
 
 Test 052 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_HAFS_v0_hwrf_thompson
 Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2024,13 +2024,13 @@ Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 166.237028
+The total amount of wall time                        = 193.048789
 
 Test 053 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2045,39 +2045,39 @@ Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 323.021806
+The total amount of wall time                        = 329.982608
 
 Test 054 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_debug
 Checking test 055 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.500102
+The total amount of wall time                        = 145.221462
 
 Test 055 control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_2threads_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_2threads_debug
 Checking test 056 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.187769
+The total amount of wall time                        = 260.029695
 
 Test 056 control_2threads_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_CubedSphereGrid_debug
 Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2104,221 +2104,221 @@ Checking test 057 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 154.665178
+The total amount of wall time                        = 155.920646
 
 Test 057 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_wrtGauss_netcdf_parallel_debug
 Checking test 058 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 182.794555
+The total amount of wall time                        = 169.550672
 
 Test 058 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_stochy_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_stochy_debug
 Checking test 059 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.646965
+The total amount of wall time                        = 172.588389
 
 Test 059 control_stochy_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ca_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ca_debug
 Checking test 060 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 147.264862
+The total amount of wall time                        = 146.227863
 
 Test 060 control_ca_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_lndp_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_lndp_debug
 Checking test 061 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.277186
+The total amount of wall time                        = 148.970562
 
 Test 061 control_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_lheatstrg_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_lheatstrg_debug
 Checking test 062 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.724843
+The total amount of wall time                        = 145.740740
 
 Test 062 control_lheatstrg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_merra2_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_merra2_debug
 Checking test 063 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 241.147387
+The total amount of wall time                        = 219.892865
 
 Test 063 control_merra2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_rrtmgp_debug
 Checking test 064 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 167.589673
+The total amount of wall time                        = 166.973007
 
 Test 064 control_rrtmgp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_csawmg_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_csawmg_debug
 Checking test 065 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 284.532587
+The total amount of wall time                        = 270.745146
 
 Test 065 control_csawmg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_csawmgt_debug
 Checking test 066 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 316.572409
+The total amount of wall time                        = 296.108955
 
 Test 066 control_csawmgt_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ugwpv1_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ugwpv1_debug
 Checking test 067 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.378098
+The total amount of wall time                        = 157.696717
 
 Test 067 control_ugwpv1_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_ras_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_ras_debug
 Checking test 068 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 150.940312
+The total amount of wall time                        = 151.575855
 
 Test 068 control_ras_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_noahmp_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_noahmp_debug
 Checking test 069 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.625967
+The total amount of wall time                        = 145.057009
 
 Test 069 control_noahmp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_diag_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_diag_debug
 Checking test 070 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.592405
+The total amount of wall time                        = 155.401571
 
 Test 070 control_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_thompson_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_thompson_debug
 Checking test 071 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.010326
+The total amount of wall time                        = 173.153871
 
 Test 071 control_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_thompson_no_aero_debug
 Checking test 072 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.360421
+The total amount of wall time                        = 165.846809
 
 Test 072 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_thompson_extdiag_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_thompson_extdiag_debug
 Checking test 073 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 179.684462
+The total amount of wall time                        = 180.681621
 
 Test 073 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/regional_control_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/regional_control_debug
 Checking test 074 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2326,13 +2326,13 @@ Checking test 074 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 255.508989
+The total amount of wall time                        = 255.618220
 
 Test 074 regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_gsd_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_gsd_debug
 Checking test 075 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2397,13 +2397,13 @@ Checking test 075 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 251.981383
+The total amount of wall time                        = 253.142572
 
 Test 075 fv3_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_gsd_diag_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_gsd_diag_debug
 Checking test 076 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2430,13 +2430,13 @@ Checking test 076 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 343.806029
+The total amount of wall time                        = 338.259688
 
 Test 076 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_rrfs_v1beta_debug
 Checking test 077 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2501,13 +2501,13 @@ Checking test 077 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.056729
+The total amount of wall time                        = 196.882957
 
 Test 077 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_rrfs_v1alpha_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_rrfs_v1alpha_debug
 Checking test 078 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2572,13 +2572,13 @@ Checking test 078 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.163660
+The total amount of wall time                        = 198.003699
 
 Test 078 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 079 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2643,13 +2643,13 @@ Checking test 079 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 237.747748
+The total amount of wall time                        = 209.298306
 
 Test 079 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 080 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2664,85 +2664,85 @@ Checking test 080 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 380.127044
+The total amount of wall time                        = 377.897979
 
 Test 080 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_control_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_control_cfsr
 Checking test 081 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 105.596063
+The total amount of wall time                        = 99.983803
 
 Test 081 datm_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_restart_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_restart_cfsr
 Checking test 082 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 55.334727
+The total amount of wall time                        = 59.316201
 
 Test 082 datm_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_control_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_control_gefs
 Checking test 083 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 93.781077
+The total amount of wall time                        = 89.915826
 
 Test 083 datm_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_control_iau_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_control_iau_gefs
 Checking test 084 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 158.717405
+The total amount of wall time                        = 90.904436
 
 Test 084 datm_control_iau_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_bulk_cfsr
 Checking test 085 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 127.753631
+The total amount of wall time                        = 91.066130
 
 Test 085 datm_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_bulk_gefs
 Checking test 086 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 93.970665
+The total amount of wall time                        = 126.660982
 
 Test 086 datm_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_mx025_gefs
 Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2751,85 +2751,85 @@ Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 358.498257
+The total amount of wall time                        = 371.877742
 
 Test 087 datm_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_debug_cfsr
 Checking test 088 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 244.141162
+The total amount of wall time                        = 246.493106
 
 Test 088 datm_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_control_cfsr
 Checking test 089 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 146.796789
+The total amount of wall time                        = 148.256817
 
 Test 089 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_restart_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_restart_cfsr
 Checking test 090 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 84.863128
+The total amount of wall time                        = 84.166283
 
 Test 090 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_control_gefs
 Checking test 091 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.204221
+The total amount of wall time                        = 145.347715
 
 Test 091 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_bulk_cfsr
 Checking test 092 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 153.983166
+The total amount of wall time                        = 147.076809
 
 Test 092 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_bulk_gefs
 Checking test 093 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.586913
+The total amount of wall time                        = 142.551783
 
 Test 093 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_mx025_cfsr
 Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2838,13 +2838,13 @@ Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 328.303612
+The total amount of wall time                        = 374.193958
 
 Test 094 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_mx025_gefs
 Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2853,35 +2853,35 @@ Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 352.849833
+The total amount of wall time                        = 331.332009
 
 Test 095 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_multiple_files_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_multiple_files_cfsr
 Checking test 096 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 184.192603
+The total amount of wall time                        = 147.957128
 
 Test 096 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/datm_cdeps_debug_cfsr
 Checking test 097 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-The total amount of wall time                        = 359.043081
+The total amount of wall time                        = 358.191773
 
 Test 097 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_11664/control_atmwav
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42792/control_atmwav
 Checking test 098 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2924,11 +2924,11 @@ Checking test 098 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.143220
+The total amount of wall time                        = 367.705486
 
 Test 098 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 14:04:00 EDT 2021
-Elapsed time: 00h:59m:40s. Have a nice day!
+Wed Jul 28 15:15:31 EDT 2021
+Elapsed time: 01h:02m:13s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,17 @@
-Tue Jul 27 16:41:42 UTC 2021
+Wed Jul 28 17:33:53 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 002 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 166 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 003 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 168 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 005 elapsed time 87 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 194 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 102 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 008 elapsed time 93 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 193 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 106 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 008 elapsed time 95 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,13 +58,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 877.719408
+  0: The total amount of wall time                        = 828.470353
 
 Test 001 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,13 +103,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 385.734308
+  0: The total amount of wall time                        = 390.211062
 
 Test 002 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_stochy
 Checking test 003 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -120,13 +120,13 @@ Checking test 003 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 686.733110
+  0: The total amount of wall time                        = 646.033393
 
 Test 003 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_flake
 Checking test 004 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -137,13 +137,13 @@ Checking test 004 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1405.764625
+  0: The total amount of wall time                        = 1407.392509
 
 Test 004 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_rrtmgp
 Checking test 005 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -154,13 +154,13 @@ Checking test 005 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 917.376444
+  0: The total amount of wall time                        = 865.618553
 
 Test 005 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -171,13 +171,13 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1051.264338
+  0: The total amount of wall time                        = 1043.900950
 
 Test 006 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -188,13 +188,13 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1024.677382
+  0: The total amount of wall time                        = 970.798594
 
 Test 007 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_ugwpv1
 Checking test 008 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -205,13 +205,13 @@ Checking test 008 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1004.009106
+  0: The total amount of wall time                        = 953.022465
 
 Test 008 control_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -222,13 +222,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 877.102220
+  0: The total amount of wall time                        = 888.381228
 
 Test 009 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_gsd
 Checking test 010 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,13 +317,13 @@ Checking test 010 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1143.721564
+  0: The total amount of wall time                        = 1032.486431
 
 Test 010 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_rrfs_v1alpha
 Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -388,13 +388,13 @@ Checking test 011 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.081199
+  0: The total amount of wall time                        = 390.821660
 
 Test 011 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_rrfs_v1beta
 Checking test 012 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -459,13 +459,13 @@ Checking test 012 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 381.608883
+  0: The total amount of wall time                        = 363.285297
 
 Test 012 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_HAFS_v0_hwrf_thompson
 Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -530,13 +530,13 @@ Checking test 013 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 679.903040
+  0: The total amount of wall time                        = 603.844282
 
 Test 013 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -551,39 +551,39 @@ Checking test 014 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 455.278811
+ 0: The total amount of wall time                        = 445.784440
 
 Test 014 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_debug
 Checking test 015 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 97.511603
+  0: The total amount of wall time                        = 99.975995
 
 Test 015 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_diag_debug
 Checking test 016 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 121.310068
+  0: The total amount of wall time                        = 124.709798
 
 Test 016 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/regional_control_debug
 Checking test 017 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -591,13 +591,13 @@ Checking test 017 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 117.182648
+ 0: The total amount of wall time                        = 127.676900
 
 Test 017 regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_rrfs_v1alpha_debug
 Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -662,13 +662,13 @@ Checking test 018 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.280329
+  0: The total amount of wall time                        = 118.085159
 
 Test 018 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_rrfs_v1beta_debug
 Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -733,13 +733,13 @@ Checking test 019 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.986120
+  0: The total amount of wall time                        = 115.821538
 
 Test 019 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_gsd_debug
 Checking test 020 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -804,13 +804,13 @@ Checking test 020 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.983370
+  0: The total amount of wall time                        = 143.118921
 
 Test 020 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_gsd_diag_debug
 Checking test 021 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -837,104 +837,104 @@ Checking test 021 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 432.510974
+  0: The total amount of wall time                        = 381.879234
 
 Test 021 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_thompson_debug
 Checking test 022 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.980756
+  0: The total amount of wall time                        = 109.621488
 
 Test 022 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_thompson_no_aero_debug
 Checking test 023 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 118.536236
+  0: The total amount of wall time                        = 108.697318
 
 Test 023 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_thompson_extdiag_debug
 Checking test 024 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 131.244806
+  0: The total amount of wall time                        = 131.237704
 
 Test 024 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_rrtmgp_debug
 Checking test 025 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.351682
+  0: The total amount of wall time                        = 106.324561
 
 Test 025 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_ugwpv1_debug
 Checking test 026 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.740151
+  0: The total amount of wall time                        = 106.180379
 
 Test 026 control_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_ras_debug
 Checking test 027 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 126.082021
+  0: The total amount of wall time                        = 99.177598
 
 Test 027 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/control_noahmp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/control_noahmp_debug
 Checking test 028 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 96.472202
+  0: The total amount of wall time                        = 105.718311
 
 Test 028 control_noahmp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 029 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -999,13 +999,13 @@ Checking test 029 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.408366
+  0: The total amount of wall time                        = 148.637146
 
 Test 029 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1020,13 +1020,13 @@ Checking test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 235.818318
+ 0: The total amount of wall time                        = 238.533712
 
 Test 030 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/cpld_control
 Checking test 031 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1076,13 +1076,13 @@ Checking test 031 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 626.699161
+  0: The total amount of wall time                        = 622.441393
 
 Test 031 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/GNU/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10939/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_26086/cpld_debug
 Checking test 032 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1132,11 +1132,11 @@ Checking test 032 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 336.775072
+  0: The total amount of wall time                        = 331.469942
 
 Test 032 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 18:41:01 UTC 2021
-Elapsed time: 01h:59m:20s. Have a nice day!
+Wed Jul 28 21:02:39 UTC 2021
+Elapsed time: 03h:28m:47s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,27 +1,27 @@
-Tue Jul 27 18:50:37 UTC 2021
+Wed Jul 28 20:17:37 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 639 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 716 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 219 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 516 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 677 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 552 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 792 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 750 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 472 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 447 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 385 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 174 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 176 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 114 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 170 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 88 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 535 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 018 elapsed time 637 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1630 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1651 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 572 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 1545 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 807 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1526 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 633 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1561 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 1698 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 844 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 745 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 1242 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 1021 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 221 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 777 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 681 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 1001 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 868 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -71,13 +71,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 94.726682
+  0: The total amount of wall time                        = 88.169292
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -127,13 +127,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 52.738029
+  0: The total amount of wall time                        = 64.907390
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -183,13 +183,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 100.299739
+  0: The total amount of wall time                        = 91.726617
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -239,13 +239,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.580496
+  0: The total amount of wall time                        = 86.413504
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -295,13 +295,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 104.575896
+  0: The total amount of wall time                        = 82.509722
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -351,13 +351,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 569.709576
+  0: The total amount of wall time                        = 391.467289
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_restart_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -407,13 +407,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 258.687464
+  0: The total amount of wall time                        = 273.367513
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -466,13 +466,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 779.297762
+  0: The total amount of wall time                        = 784.648102
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_restart_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -525,13 +525,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 403.536267
+  0: The total amount of wall time                        = 405.986569
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -574,13 +574,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 614.944319
+  0: The total amount of wall time                        = 609.817766
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_restart_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -623,13 +623,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 347.714743
+  0: The total amount of wall time                        = 345.652101
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16_nsst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_bmark_v16_nsst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -672,13 +672,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 593.618467
+  0: The total amount of wall time                        = 614.033455
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_bmark_wave_v16
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -723,13 +723,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 649.779268
+  0: The total amount of wall time                        = 650.056127
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_bmark_wave_v16_p7b
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -774,13 +774,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 685.461667
+  0: The total amount of wall time                        = 685.138319
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_control_wave
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -833,13 +833,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 98.149502
+  0: The total amount of wall time                        = 109.080859
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -889,13 +889,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 275.690095
+  0: The total amount of wall time                        = 267.571466
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -942,13 +942,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.037282
+  0: The total amount of wall time                        = 153.473348
 
 Test 017 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -991,13 +991,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.815652
+  0: The total amount of wall time                        = 153.676256
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1040,13 +1040,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 176.937601
+ 0: The total amount of wall time                        = 158.917062
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1085,13 +1085,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 73.516937
+  0: The total amount of wall time                        = 63.532419
 
 Test 020 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_fhzero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1134,13 +1134,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.573956
+  0: The total amount of wall time                        = 162.399884
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1167,15 +1167,15 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 150.437139
+  0: The total amount of wall time                        = 113.993091
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
@@ -1184,13 +1184,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 194.447505
+  0: The total amount of wall time                        = 168.846373
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1201,13 +1201,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 484.198351
+  0: The total amount of wall time                        = 464.957636
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1218,13 +1218,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 790.415608
+  0: The total amount of wall time                        = 786.034624
 
 Test 025 control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1267,13 +1267,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 646.890308
+  0: The total amount of wall time                        = 641.689244
 
 Test 026 control_c384gdas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1284,26 +1284,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.013333
+  0: The total amount of wall time                        = 109.643417
 
 Test 027 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_stochy_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 261.936596
+  0: The total amount of wall time                        = 59.761982
 
 Test 028 control_stochy_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ca
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ca
 Checking test 029 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1314,13 +1314,13 @@ Checking test 029 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 110.249577
+  0: The total amount of wall time                        = 110.260949
 
 Test 029 control_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1331,13 +1331,13 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 129.630957
+  0: The total amount of wall time                        = 108.068211
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_lheatstrg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_lheatstrg
 Checking test 031 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1348,13 +1348,13 @@ Checking test 031 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 154.970905
+  0: The total amount of wall time                        = 155.964204
 
 Test 031 control_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lseaspray
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_lseaspray
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_lseaspray
 Checking test 032 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1365,13 +1365,13 @@ Checking test 032 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 160.152445
+  0: The total amount of wall time                        = 164.329107
 
 Test 032 control_lseaspray PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_merra2
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_merra2
 Checking test 033 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1382,13 +1382,13 @@ Checking test 033 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.722233
+  0: The total amount of wall time                        = 180.624047
 
 Test 033 control_merra2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_rrtmgp
 Checking test 034 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1399,13 +1399,13 @@ Checking test 034 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 206.393586
+  0: The total amount of wall time                        = 196.801814
 
 Test 034 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_csawmg
 Checking test 035 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1416,13 +1416,13 @@ Checking test 035 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 261.301105
+  0: The total amount of wall time                        = 255.771530
 
 Test 035 control_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_csawmgt
 Checking test 036 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1433,13 +1433,13 @@ Checking test 036 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 317.225527
+  0: The total amount of wall time                        = 313.538105
 
 Test 036 control_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_flake
 Checking test 037 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1450,13 +1450,13 @@ Checking test 037 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 228.574773
+  0: The total amount of wall time                        = 224.055128
 
 Test 037 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ugwpv1
 Checking test 038 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1467,13 +1467,13 @@ Checking test 038 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.182334
+  0: The total amount of wall time                        = 181.756737
 
 Test 038 control_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ras
 Checking test 039 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1484,13 +1484,13 @@ Checking test 039 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 176.412411
+  0: The total amount of wall time                        = 177.496485
 
 Test 039 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_thompson
 Checking test 040 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1501,13 +1501,13 @@ Checking test 040 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 202.751746
+  0: The total amount of wall time                        = 203.164957
 
 Test 040 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_thompson_no_aero
 Checking test 041 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1518,13 +1518,13 @@ Checking test 041 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.146977
+  0: The total amount of wall time                        = 194.323507
 
 Test 041 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_noahmp
 Checking test 042 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1535,13 +1535,13 @@ Checking test 042 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 170.708139
+  0: The total amount of wall time                        = 176.499393
 
 Test 042 control_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_control
 Checking test 043 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1549,25 +1549,25 @@ Checking test 043 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 299.050824
+ 0: The total amount of wall time                        = 288.534526
 
 Test 043 regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_restart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_restart
 Checking test 044 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 154.102324
+ 0: The total amount of wall time                        = 157.042629
 
 Test 044 regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_quilt
 Checking test 045 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1578,13 +1578,13 @@ Checking test 045 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 311.155413
+ 0: The total amount of wall time                        = 299.168268
 
 Test 045 regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_quilt_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_quilt_2threads
 Checking test 046 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1595,13 +1595,13 @@ Checking test 046 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 216.894531
+ 0: The total amount of wall time                        = 215.143229
 
 Test 046 regional_quilt_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_quilt_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_quilt_hafs
 Checking test 047 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1610,13 +1610,13 @@ Checking test 047 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 294.468565
+ 0: The total amount of wall time                        = 304.637335
 
 Test 047 regional_quilt_hafs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_quilt_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_quilt_netcdf_parallel
 Checking test 048 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
@@ -1624,13 +1624,13 @@ Checking test 048 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 297.497818
+ 0: The total amount of wall time                        = 310.356491
 
 Test 048 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_quilt_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_quilt_RRTMGP
 Checking test 049 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1641,13 +1641,13 @@ Checking test 049 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 393.952092
+ 0: The total amount of wall time                        = 385.574312
 
 Test 049 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_gsd
 Checking test 050 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1736,13 +1736,13 @@ Checking test 050 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.835463
+  0: The total amount of wall time                        = 223.393370
 
 Test 050 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_rrfs_v1alpha
 Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1807,13 +1807,13 @@ Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.009211
+  0: The total amount of wall time                        = 86.193697
 
 Test 051 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rap
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_rap
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_rap
 Checking test 052 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1878,13 +1878,13 @@ Checking test 052 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 84.190803
+  0: The total amount of wall time                        = 86.043545
 
 Test 052 fv3_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_hrrr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_hrrr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_hrrr
 Checking test 053 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1949,13 +1949,13 @@ Checking test 053 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 83.455883
+  0: The total amount of wall time                        = 84.056508
 
 Test 053 fv3_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_rrfs_v1beta
 Checking test 054 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2020,13 +2020,13 @@ Checking test 054 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.766979
+  0: The total amount of wall time                        = 87.026676
 
 Test 054 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2091,13 +2091,13 @@ Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.367632
+  0: The total amount of wall time                        = 144.009411
 
 Test 055 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2112,39 +2112,39 @@ Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 283.389049
+ 0: The total amount of wall time                        = 285.824771
 
 Test 056 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_debug
 Checking test 057 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.302140
+  0: The total amount of wall time                        = 139.904739
 
 Test 057 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_2threads_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_2threads_debug
 Checking test 058 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 210.166984
+ 0: The total amount of wall time                        = 208.616782
 
 Test 058 control_2threads_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_CubedSphereGrid_debug
 Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2171,221 +2171,221 @@ Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.490948
+  0: The total amount of wall time                        = 156.379430
 
 Test 059 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_wrtGauss_netcdf_parallel_debug
 Checking test 060 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 142.949329
+  0: The total amount of wall time                        = 142.734428
 
 Test 060 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_stochy_debug
 Checking test 061 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.635222
+  0: The total amount of wall time                        = 160.087972
 
 Test 061 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ca_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ca_debug
 Checking test 062 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 141.008321
+  0: The total amount of wall time                        = 143.880093
 
 Test 062 control_ca_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_lndp_debug
 Checking test 063 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.555972
+  0: The total amount of wall time                        = 149.810838
 
 Test 063 control_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_lheatstrg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_lheatstrg_debug
 Checking test 064 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 143.567658
+  0: The total amount of wall time                        = 144.043703
 
 Test 064 control_lheatstrg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_merra2_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_merra2_debug
 Checking test 065 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.745740
+  0: The total amount of wall time                        = 196.343476
 
 Test 065 control_merra2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_rrtmgp_debug
 Checking test 066 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.347128
+  0: The total amount of wall time                        = 161.139038
 
 Test 066 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_csawmg_debug
 Checking test 067 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.490609
+  0: The total amount of wall time                        = 227.837031
 
 Test 067 control_csawmg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_csawmgt_debug
 Checking test 068 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.769008
+  0: The total amount of wall time                        = 259.756764
 
 Test 068 control_csawmgt_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ugwpv1_debug
 Checking test 069 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.053508
+  0: The total amount of wall time                        = 155.766859
 
 Test 069 control_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_ras_debug
 Checking test 070 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.820655
+  0: The total amount of wall time                        = 151.096710
 
 Test 070 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_noahmp_debug
 Checking test 071 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.501452
+  0: The total amount of wall time                        = 142.460392
 
 Test 071 control_noahmp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.930748
+  0: The total amount of wall time                        = 160.481853
 
 Test 072 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_thompson_debug
 Checking test 073 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.941836
+  0: The total amount of wall time                        = 168.443012
 
 Test 073 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_thompson_no_aero_debug
 Checking test 074 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.099732
+  0: The total amount of wall time                        = 161.006930
 
 Test 074 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_thompson_extdiag_debug
 Checking test 075 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.196472
+  0: The total amount of wall time                        = 179.064740
 
 Test 075 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/regional_control_debug
 Checking test 076 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2393,13 +2393,13 @@ Checking test 076 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 227.889782
+ 0: The total amount of wall time                        = 224.783326
 
 Test 076 regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_gsd_debug
 Checking test 077 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2464,13 +2464,13 @@ Checking test 077 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.168372
+  0: The total amount of wall time                        = 240.423384
 
 Test 077 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_gsd_diag_debug
 Checking test 078 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2497,13 +2497,13 @@ Checking test 078 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 517.172037
+  0: The total amount of wall time                        = 490.337800
 
 Test 078 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_rrfs_v1beta_debug
 Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2568,13 +2568,13 @@ Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.556956
+  0: The total amount of wall time                        = 194.117125
 
 Test 079 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_rrfs_v1alpha_debug
 Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2639,13 +2639,13 @@ Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.647610
+  0: The total amount of wall time                        = 193.359125
 
 Test 080 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2710,13 +2710,13 @@ Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 192.121440
+  0: The total amount of wall time                        = 197.979439
 
 Test 081 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2731,85 +2731,85 @@ Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 397.450107
+ 0: The total amount of wall time                        = 379.379066
 
 Test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_control_cfsr
 Checking test 083 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 98.654000
+  0: The total amount of wall time                        = 102.599286
 
 Test 083 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_restart_cfsr
 Checking test 084 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 62.536508
+  0: The total amount of wall time                        = 62.946397
 
 Test 084 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_control_gefs
 Checking test 085 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 88.807885
+  0: The total amount of wall time                        = 95.410471
 
 Test 085 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_control_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_control_iau_gefs
 Checking test 086 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 93.438551
+  0: The total amount of wall time                        = 103.010187
 
 Test 086 datm_control_iau_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_bulk_cfsr
 Checking test 087 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 90.500012
+  0: The total amount of wall time                        = 91.266746
 
 Test 087 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_bulk_gefs
 Checking test 088 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.128015
+  0: The total amount of wall time                        = 87.977910
 
 Test 088 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_mx025_cfsr
 Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2818,13 +2818,13 @@ Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 316.571180
+  0: The total amount of wall time                        = 326.684955
 
 Test 089 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_mx025_gefs
 Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2833,85 +2833,85 @@ Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 314.850844
+  0: The total amount of wall time                        = 338.400895
 
 Test 090 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_debug_cfsr
 Checking test 091 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 254.199242
+  0: The total amount of wall time                        = 252.598277
 
 Test 091 datm_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_control_cfsr
 Checking test 092 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.593447
+ 0: The total amount of wall time                        = 148.206081
 
 Test 092 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_restart_cfsr
 Checking test 093 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.129439
+ 0: The total amount of wall time                        = 109.073413
 
 Test 093 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_control_gefs
 Checking test 094 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.135847
+ 0: The total amount of wall time                        = 145.631011
 
 Test 094 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_bulk_cfsr
 Checking test 095 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.136167
+ 0: The total amount of wall time                        = 152.386312
 
 Test 095 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_bulk_gefs
 Checking test 096 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.177798
+ 0: The total amount of wall time                        = 147.296162
 
 Test 096 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_mx025_cfsr
 Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2920,13 +2920,13 @@ Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 307.396158
+  0: The total amount of wall time                        = 313.874013
 
 Test 097 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_mx025_gefs
 Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2935,35 +2935,35 @@ Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 308.011917
+  0: The total amount of wall time                        = 309.936272
 
 Test 098 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_multiple_files_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_multiple_files_cfsr
 Checking test 099 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.703870
+ 0: The total amount of wall time                        = 149.219841
 
 Test 099 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/datm_cdeps_debug_cfsr
 Checking test 100 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 441.566691
+ 0: The total amount of wall time                        = 441.398876
 
 Test 100 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_atmwav
 Checking test 101 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3006,13 +3006,13 @@ Checking test 101 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 323.294179
+  0: The total amount of wall time                        = 324.374892
 
 Test 101 control_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_5363/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_24821/control_atm_aerosols
 Checking test 102 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3059,11 +3059,11 @@ Checking test 102 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 312.202222
+  0: The total amount of wall time                        = 294.354020
 
 Test 102 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 19:44:16 UTC 2021
-Elapsed time: 00h:53m:39s. Have a nice day!
+Wed Jul 28 21:23:58 UTC 2021
+Elapsed time: 01h:06m:22s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,26 +1,26 @@
-Tue Jul 27 18:51:14 GMT 2021
+Wed Jul 28 20:16:27 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 2472 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 2522 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 227 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 2285 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 2389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 2301 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 2475 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2513 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 231 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 2283 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 2380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 2293 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 Compile 007 elapsed time 2319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 2335 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 201 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 2357 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 212 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 010 elapsed time 200 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 199 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 254 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 014 elapsed time 126 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 273 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 016 elapsed time 132 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 2338 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 237 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 256 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 014 elapsed time 133 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 266 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 016 elapsed time 139 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 2343 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 122.592909
+  0: The total amount of wall time                        = 124.322314
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 70.396878
+  0: The total amount of wall time                        = 69.229338
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 577.069452
+  0: The total amount of wall time                        = 544.969752
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 120.186669
+  0: The total amount of wall time                        = 122.234373
 
 Test 004 cpld_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 519.888658
+  0: The total amount of wall time                        = 518.112201
 
 Test 005 cpld_control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_restart_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 355.116568
+  0: The total amount of wall time                        = 366.178644
 
 Test 006 cpld_restart_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 620.659961
+  0: The total amount of wall time                        = 616.364330
 
 Test 007 cpld_control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_restart_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 338.490480
+  0: The total amount of wall time                        = 345.756379
 
 Test 008 cpld_restart_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 798.476854
+  0: The total amount of wall time                        = 804.550709
 
 Test 009 cpld_bmark_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_restart_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -566,13 +566,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 452.839470
+  0: The total amount of wall time                        = 457.320121
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16_nsst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_bmark_v16_nsst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -615,13 +615,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 795.098362
+  0: The total amount of wall time                        = 831.311995
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_bmark_wave_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -666,13 +666,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1015.723712
+  0: The total amount of wall time                        = 1031.956327
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_bmark_wave_v16_p7b
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_bmark_wave_v16_p7b
 Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -717,13 +717,13 @@ Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1081.556153
+  0: The total amount of wall time                        = 1116.795271
 
 Test 013 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_wave
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_control_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 985.610790
+  0: The total amount of wall time                        = 991.352108
 
 Test 014 cpld_control_wave PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/cpld_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.575011
+  0: The total amount of wall time                        = 356.571531
 
 Test 015 cpld_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -885,13 +885,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.504766
+  0: The total amount of wall time                        = 204.514691
 
 Test 016 control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_decomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -934,13 +934,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 219.617183
+  0: The total amount of wall time                        = 209.273294
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -983,13 +983,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 821.824098
+ 0: The total amount of wall time                        = 787.626456
 
 Test 018 control_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1028,13 +1028,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.237421
+  0: The total amount of wall time                        = 87.639488
 
 Test 019 control_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_fhzero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1077,13 +1077,13 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 210.749077
+  0: The total amount of wall time                        = 204.474144
 
 Test 020 control_fhzero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1110,15 +1110,15 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.013328
+  0: The total amount of wall time                        = 158.437052
 
 Test 021 control_CubedSphereGrid PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
@@ -1127,13 +1127,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 236.433513
+  0: The total amount of wall time                        = 238.682025
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1144,13 +1144,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 640.311933
+  0: The total amount of wall time                        = 640.059290
 
 Test 023 control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1161,13 +1161,13 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 896.847381
+  0: The total amount of wall time                        = 894.176926
 
 Test 024 control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1210,13 +1210,13 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 770.326534
+  0: The total amount of wall time                        = 769.698655
 
 Test 025 control_c384gdas PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1227,26 +1227,26 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 147.310073
+  0: The total amount of wall time                        = 147.047010
 
 Test 026 control_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_stochy_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.174393
+  0: The total amount of wall time                        = 75.295318
 
 Test 027 control_stochy_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ca
 Checking test 028 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1257,13 +1257,13 @@ Checking test 028 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 145.909951
+  0: The total amount of wall time                        = 144.147597
 
 Test 028 control_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1274,13 +1274,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 154.691398
+  0: The total amount of wall time                        = 148.942464
 
 Test 029 control_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_lheatstrg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_lheatstrg
 Checking test 030 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1291,13 +1291,13 @@ Checking test 030 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 217.195625
+  0: The total amount of wall time                        = 204.440099
 
 Test 030 control_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lseaspray
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_lseaspray
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_lseaspray
 Checking test 031 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1308,13 +1308,13 @@ Checking test 031 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.962997
+  0: The total amount of wall time                        = 220.522912
 
 Test 031 control_lseaspray PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_merra2
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_merra2
 Checking test 032 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1325,13 +1325,13 @@ Checking test 032 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 238.578638
+  0: The total amount of wall time                        = 244.833721
 
 Test 032 control_merra2 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_rrtmgp
 Checking test 033 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1342,13 +1342,13 @@ Checking test 033 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 263.562446
+  0: The total amount of wall time                        = 266.570998
 
 Test 033 control_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_csawmgt
 Checking test 034 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1359,13 +1359,13 @@ Checking test 034 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 421.341564
+  0: The total amount of wall time                        = 425.621794
 
 Test 034 control_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_flake
 Checking test 035 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1376,13 +1376,13 @@ Checking test 035 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 291.453148
+  0: The total amount of wall time                        = 290.657655
 
 Test 035 control_flake PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ugwpv1
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ugwpv1
 Checking test 036 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1393,13 +1393,13 @@ Checking test 036 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 251.508626
+  0: The total amount of wall time                        = 252.206918
 
 Test 036 control_ugwpv1 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ras
 Checking test 037 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1410,13 +1410,13 @@ Checking test 037 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 242.914060
+  0: The total amount of wall time                        = 245.297393
 
 Test 037 control_ras PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_thompson
 Checking test 038 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1427,13 +1427,13 @@ Checking test 038 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 276.618395
+  0: The total amount of wall time                        = 279.307758
 
 Test 038 control_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_thompson_no_aero
 Checking test 039 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1444,13 +1444,13 @@ Checking test 039 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 270.659749
+  0: The total amount of wall time                        = 271.053377
 
 Test 039 control_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_noahmp
 Checking test 040 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1461,13 +1461,13 @@ Checking test 040 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 236.143576
+  0: The total amount of wall time                        = 235.356391
 
 Test 040 control_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_control
 Checking test 041 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1475,25 +1475,25 @@ Checking test 041 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 413.988887
+ 0: The total amount of wall time                        = 416.763431
 
 Test 041 regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_restart
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_restart
 Checking test 042 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 224.886701
+ 0: The total amount of wall time                        = 225.894135
 
 Test 042 regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_quilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_quilt
 Checking test 043 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1504,13 +1504,13 @@ Checking test 043 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 412.815411
+ 0: The total amount of wall time                        = 407.068553
 
 Test 043 regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_quilt_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_quilt_hafs
 Checking test 044 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1519,13 +1519,13 @@ Checking test 044 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 404.836445
+ 0: The total amount of wall time                        = 410.200383
 
 Test 044 regional_quilt_hafs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_quilt_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_quilt_netcdf_parallel
 Checking test 045 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1533,13 +1533,13 @@ Checking test 045 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 412.721183
+ 0: The total amount of wall time                        = 412.209019
 
 Test 045 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_quilt_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_quilt_RRTMGP
 Checking test 046 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1550,13 +1550,13 @@ Checking test 046 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 526.945927
+ 0: The total amount of wall time                        = 558.361770
 
 Test 046 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_gsd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_gsd
 Checking test 047 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1645,13 +1645,13 @@ Checking test 047 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 301.601267
+  0: The total amount of wall time                        = 313.974119
 
 Test 047 fv3_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_rrfs_v1alpha
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_rrfs_v1alpha
 Checking test 048 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1716,13 +1716,13 @@ Checking test 048 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.514762
+  0: The total amount of wall time                        = 119.096266
 
 Test 048 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rap
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_rap
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_rap
 Checking test 049 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1787,13 +1787,13 @@ Checking test 049 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.389362
+  0: The total amount of wall time                        = 141.952861
 
 Test 049 fv3_rap PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_hrrr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_hrrr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_hrrr
 Checking test 050 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1858,13 +1858,13 @@ Checking test 050 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.201926
+  0: The total amount of wall time                        = 116.626003
 
 Test 050 fv3_hrrr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_rrfs_v1beta
 Checking test 051 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1929,13 +1929,13 @@ Checking test 051 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.232818
+  0: The total amount of wall time                        = 133.513596
 
 Test 051 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_HAFS_v0_hwrf_thompson
 Checking test 052 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2000,13 +2000,13 @@ Checking test 052 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.785777
+  0: The total amount of wall time                        = 195.582064
 
 Test 052 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 053 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2021,39 +2021,39 @@ Checking test 053 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 366.711028
+ 0: The total amount of wall time                        = 359.791421
 
 Test 053 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_debug
 Checking test 054 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.994147
+  0: The total amount of wall time                        = 188.862902
 
 Test 054 control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_2threads_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_2threads_debug
 Checking test 055 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 363.223620
+ 0: The total amount of wall time                        = 364.220392
 
 Test 055 control_2threads_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_CubedSphereGrid_debug
 Checking test 056 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2080,221 +2080,221 @@ Checking test 056 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.042406
+  0: The total amount of wall time                        = 204.010782
 
 Test 056 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_wrtGauss_netcdf_parallel_debug
 Checking test 057 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.087202
+  0: The total amount of wall time                        = 192.611152
 
 Test 057 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_stochy_debug
 Checking test 058 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.395069
+  0: The total amount of wall time                        = 214.581017
 
 Test 058 control_stochy_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ca_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ca_debug
 Checking test 059 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.191796
+  0: The total amount of wall time                        = 190.266020
 
 Test 059 control_ca_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_lndp_debug
 Checking test 060 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.871882
+  0: The total amount of wall time                        = 193.963651
 
 Test 060 control_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_lheatstrg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_lheatstrg_debug
 Checking test 061 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.762599
+  0: The total amount of wall time                        = 189.058332
 
 Test 061 control_lheatstrg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_merra2_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_merra2_debug
 Checking test 062 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.171710
+  0: The total amount of wall time                        = 257.972402
 
 Test 062 control_merra2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_rrtmgp_debug
 Checking test 063 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.650535
+  0: The total amount of wall time                        = 213.329294
 
 Test 063 control_rrtmgp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_csawmg_debug
 Checking test 064 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 311.249895
+  0: The total amount of wall time                        = 309.710118
 
 Test 064 control_csawmg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_csawmgt_debug
 Checking test 065 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.927798
+  0: The total amount of wall time                        = 351.183343
 
 Test 065 control_csawmgt_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ugwpv1_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ugwpv1_debug
 Checking test 066 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.301653
+  0: The total amount of wall time                        = 203.652805
 
 Test 066 control_ugwpv1_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_ras_debug
 Checking test 067 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 196.268948
+  0: The total amount of wall time                        = 196.232781
 
 Test 067 control_ras_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_noahmp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_noahmp_debug
 Checking test 068 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 187.324194
+  0: The total amount of wall time                        = 191.673773
 
 Test 068 control_noahmp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_diag_debug
 Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.036969
+  0: The total amount of wall time                        = 204.606140
 
 Test 069 control_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_thompson_debug
 Checking test 070 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.512769
+  0: The total amount of wall time                        = 220.240814
 
 Test 070 control_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_thompson_no_aero_debug
 Checking test 071 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 211.796375
+  0: The total amount of wall time                        = 213.289410
 
 Test 071 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_thompson_extdiag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_thompson_extdiag_debug
 Checking test 072 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.999550
+  0: The total amount of wall time                        = 236.865643
 
 Test 072 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/regional_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/regional_control_debug
 Checking test 073 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2302,13 +2302,13 @@ Checking test 073 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 315.686105
+ 0: The total amount of wall time                        = 316.664588
 
 Test 073 regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_gsd_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_gsd_debug
 Checking test 074 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2373,13 +2373,13 @@ Checking test 074 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 320.240891
+  0: The total amount of wall time                        = 318.165988
 
 Test 074 fv3_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_gsd_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_gsd_diag_debug
 Checking test 075 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2406,13 +2406,13 @@ Checking test 075 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 538.661253
+  0: The total amount of wall time                        = 548.794109
 
 Test 075 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_rrfs_v1beta_debug
 Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2477,13 +2477,13 @@ Checking test 076 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 252.190066
+  0: The total amount of wall time                        = 251.667283
 
 Test 076 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_rrfs_v1alpha_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_rrfs_v1alpha_debug
 Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2548,13 +2548,13 @@ Checking test 077 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.250424
+  0: The total amount of wall time                        = 251.567851
 
 Test 077 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2619,13 +2619,13 @@ Checking test 078 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 265.153310
+  0: The total amount of wall time                        = 265.459668
 
 Test 078 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2640,85 +2640,85 @@ Checking test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 501.759995
+ 0: The total amount of wall time                        = 505.918894
 
 Test 079 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_control_cfsr
 Checking test 080 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 128.351329
+  0: The total amount of wall time                        = 127.909726
 
 Test 080 datm_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_restart_cfsr
 Checking test 081 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 79.302995
+  0: The total amount of wall time                        = 90.453241
 
 Test 081 datm_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_control_gefs
 Checking test 082 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 118.424742
+  0: The total amount of wall time                        = 118.856954
 
 Test 082 datm_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_control_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_control_iau_gefs
 Checking test 083 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 120.599012
+  0: The total amount of wall time                        = 120.909030
 
 Test 083 datm_control_iau_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_bulk_cfsr
 Checking test 084 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 121.814607
+  0: The total amount of wall time                        = 122.499945
 
 Test 084 datm_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_bulk_gefs
 Checking test 085 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 118.614135
+  0: The total amount of wall time                        = 117.780982
 
 Test 085 datm_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_mx025_cfsr
 Checking test 086 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2727,13 +2727,13 @@ Checking test 086 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 414.305520
+  0: The total amount of wall time                        = 422.884208
 
 Test 086 datm_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_mx025_gefs
 Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2742,85 +2742,85 @@ Checking test 087 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 408.254098
+  0: The total amount of wall time                        = 417.435800
 
 Test 087 datm_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_debug_cfsr
 Checking test 088 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.474789
+  0: The total amount of wall time                        = 336.939396
 
 Test 088 datm_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_control_cfsr
 Checking test 089 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 196.560022
+ 0: The total amount of wall time                        = 199.502269
 
 Test 089 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_restart_cfsr
 Checking test 090 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 121.078415
+ 0: The total amount of wall time                        = 122.148963
 
 Test 090 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_control_gefs
 Checking test 091 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.870737
+ 0: The total amount of wall time                        = 195.669914
 
 Test 091 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_bulk_cfsr
 Checking test 092 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.892395
+ 0: The total amount of wall time                        = 198.760332
 
 Test 092 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_bulk_gefs
 Checking test 093 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.710525
+ 0: The total amount of wall time                        = 192.987252
 
 Test 093 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_mx025_cfsr
 Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2829,13 +2829,13 @@ Checking test 094 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 419.721215
+  0: The total amount of wall time                        = 428.506289
 
 Test 094 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_mx025_gefs
 Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2844,35 +2844,35 @@ Checking test 095 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 404.820658
+  0: The total amount of wall time                        = 417.899814
 
 Test 095 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_multiple_files_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_multiple_files_cfsr
 Checking test 096 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.819448
+ 0: The total amount of wall time                        = 196.964550
 
 Test 096 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/datm_cdeps_debug_cfsr
 Checking test 097 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 565.507670
+ 0: The total amount of wall time                        = 569.737755
 
 Test 097 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_246445/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_169923/control_atmwav
 Checking test 098 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2915,11 +2915,11 @@ Checking test 098 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 428.279731
+  0: The total amount of wall time                        = 422.342184
 
 Test 098 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 21:50:47 GMT 2021
-Elapsed time: 02h:59m:34s. Have a nice day!
+Wed Jul 28 23:30:27 GMT 2021
+Elapsed time: 03h:14m:00s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,26 +1,26 @@
-Tue Jul 27 12:59:08 CDT 2021
+Wed Jul 28 22:18:46 CDT 2021
 Start Regression test
 
-Compile 001 elapsed time 609 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 663 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 202 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 542 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 574 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 542 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 557 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 156 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 177 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 136 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 218 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 252 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 88 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 177 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 177 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 626 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1237 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1276 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 768 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 1166 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1175 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1119 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 1187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1144 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 762 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 740 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 184 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 215 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 197 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 139 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 232 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 169 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 596 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_control
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 103.213681
+  0: The total amount of wall time                        = 146.624338
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_restart
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 80.703004
+  0: The total amount of wall time                        = 126.908246
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_2threads
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 105.939255
+  0: The total amount of wall time                        = 167.695087
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_decomp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.838611
+  0: The total amount of wall time                        = 240.031857
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_ca
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 97.199998
+  0: The total amount of wall time                        = 132.498694
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_control_c192
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 384.935563
+  0: The total amount of wall time                        = 493.005635
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_restart_c192
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 278.770902
+  0: The total amount of wall time                        = 316.568974
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_control_c384
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 776.477335
+  0: The total amount of wall time                        = 912.353902
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_restart_c384
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 441.795390
+  0: The total amount of wall time                        = 483.136264
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_bmark_v16
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 664.035672
+  0: The total amount of wall time                        = 701.103694
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_restart_bmark_v16
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 383.051860
+  0: The total amount of wall time                        = 449.789531
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_v16_nsst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_bmark_v16_nsst
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 677.173127
+  0: The total amount of wall time                        = 731.942492
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_bmark_wave_v16
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 694.759979
+  0: The total amount of wall time                        = 796.505970
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_bmark_wave_v16_p7b
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 819.183185
+  0: The total amount of wall time                        = 1007.337240
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_control_wave
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_control_wave
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 144.887814
+  0: The total amount of wall time                        = 161.419550
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/cpld_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/cpld_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 311.009486
+  0: The total amount of wall time                        = 331.015948
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -941,13 +941,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.909281
+  0: The total amount of wall time                        = 238.043620
 
 Test 017 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_decomp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -990,13 +990,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 184.060135
+  0: The total amount of wall time                        = 205.636039
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_2threads
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1039,13 +1039,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 173.692449
+ 0: The total amount of wall time                        = 214.932027
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_restart
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1084,13 +1084,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 74.701703
+  0: The total amount of wall time                        = 108.247035
 
 Test 020 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_fhzero
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1133,13 +1133,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.166076
+  0: The total amount of wall time                        = 204.824597
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1166,13 +1166,13 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.717620
+  0: The total amount of wall time                        = 231.911688
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1183,13 +1183,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 214.681726
+  0: The total amount of wall time                        = 514.360874
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_c192
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1200,13 +1200,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 501.489090
+  0: The total amount of wall time                        = 747.392474
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_c384
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1217,13 +1217,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 746.105284
+  0: The total amount of wall time                        = 946.607535
 
 Test 025 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_c384gdas
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1266,13 +1266,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 680.778472
+  0: The total amount of wall time                        = 780.537975
 
 Test 026 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_stochy
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1283,26 +1283,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 122.904286
+  0: The total amount of wall time                        = 176.836512
 
 Test 027 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_stochy_restart
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 58.193995
+  0: The total amount of wall time                        = 77.599402
 
 Test 028 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ca
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ca
 Checking test 029 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1313,13 +1313,13 @@ Checking test 029 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.501183
+  0: The total amount of wall time                        = 168.676555
 
 Test 029 control_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_lndp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1330,13 +1330,13 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 129.387049
+  0: The total amount of wall time                        = 152.557415
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_lheatstrg
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_lheatstrg
 Checking test 031 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1347,13 +1347,13 @@ Checking test 031 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 159.896227
+  0: The total amount of wall time                        = 250.807455
 
 Test 031 control_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lseaspray
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_lseaspray
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_lseaspray
 Checking test 032 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1364,13 +1364,13 @@ Checking test 032 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 169.418489
+  0: The total amount of wall time                        = 223.019121
 
 Test 032 control_lseaspray PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_merra2
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_merra2
 Checking test 033 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,13 +1381,13 @@ Checking test 033 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 280.387668
+  0: The total amount of wall time                        = 309.159257
 
 Test 033 control_merra2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_rrtmgp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_rrtmgp
 Checking test 034 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1398,13 +1398,13 @@ Checking test 034 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 217.448579
+  0: The total amount of wall time                        = 255.464919
 
 Test 034 control_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_csawmg
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_csawmg
 Checking test 035 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1415,13 +1415,13 @@ Checking test 035 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 354.257837
+  0: The total amount of wall time                        = 392.861091
 
 Test 035 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_csawmgt
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_csawmgt
 Checking test 036 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1432,13 +1432,13 @@ Checking test 036 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 410.472171
+  0: The total amount of wall time                        = 447.700554
 
 Test 036 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_flake
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_flake
 Checking test 037 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1449,13 +1449,13 @@ Checking test 037 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 238.396137
+  0: The total amount of wall time                        = 320.413255
 
 Test 037 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ugwpv1
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ugwpv1
 Checking test 038 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1466,13 +1466,13 @@ Checking test 038 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 201.592894
+  0: The total amount of wall time                        = 265.079163
 
 Test 038 control_ugwpv1 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ras
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ras
 Checking test 039 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1483,13 +1483,13 @@ Checking test 039 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.773538
+  0: The total amount of wall time                        = 235.277040
 
 Test 039 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_thompson
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_thompson
 Checking test 040 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1500,13 +1500,13 @@ Checking test 040 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 213.547337
+  0: The total amount of wall time                        = 287.743735
 
 Test 040 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_thompson_no_aero
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_thompson_no_aero
 Checking test 041 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1517,13 +1517,13 @@ Checking test 041 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.484387
+  0: The total amount of wall time                        = 254.836960
 
 Test 041 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_noahmp
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_noahmp
 Checking test 042 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1534,13 +1534,13 @@ Checking test 042 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.012538
+  0: The total amount of wall time                        = 225.196467
 
 Test 042 control_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_control
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_control
 Checking test 043 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1548,25 +1548,25 @@ Checking test 043 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 302.392661
+ 0: The total amount of wall time                        = 348.746409
 
 Test 043 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_restart
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_restart
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_restart
 Checking test 044 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 164.352676
+ 0: The total amount of wall time                        = 182.290850
 
 Test 044 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_quilt
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_quilt
 Checking test 045 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1577,13 +1577,13 @@ Checking test 045 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 313.514098
+ 0: The total amount of wall time                        = 392.534992
 
 Test 045 regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_quilt_2threads
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_quilt_2threads
 Checking test 046 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1594,13 +1594,13 @@ Checking test 046 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 227.979267
+ 0: The total amount of wall time                        = 322.916898
 
 Test 046 regional_quilt_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_quilt_hafs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_quilt_hafs
 Checking test 047 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1609,27 +1609,27 @@ Checking test 047 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 307.547809
+ 0: The total amount of wall time                        = 358.485888
 
 Test 047 regional_quilt_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_quilt_netcdf_parallel
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_quilt_netcdf_parallel
 Checking test 048 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 310.704975
+ 0: The total amount of wall time                        = 483.059760
 
 Test 048 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_quilt_RRTMGP
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_quilt_RRTMGP
 Checking test 049 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1640,13 +1640,13 @@ Checking test 049 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 400.098169
+ 0: The total amount of wall time                        = 431.900939
 
 Test 049 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_gsd
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_gsd
 Checking test 050 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1735,13 +1735,13 @@ Checking test 050 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 241.494525
+  0: The total amount of wall time                        = 251.910461
 
 Test 050 fv3_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_rrfs_v1alpha
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_rrfs_v1alpha
 Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1806,13 +1806,13 @@ Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 105.059022
+  0: The total amount of wall time                        = 140.900804
 
 Test 051 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rap
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_rap
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_rap
 Checking test 052 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1877,13 +1877,13 @@ Checking test 052 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 109.720285
+  0: The total amount of wall time                        = 104.188270
 
 Test 052 fv3_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_hrrr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_hrrr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_hrrr
 Checking test 053 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1948,13 +1948,13 @@ Checking test 053 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 100.331197
+  0: The total amount of wall time                        = 149.972518
 
 Test 053 fv3_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_rrfs_v1beta
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_rrfs_v1beta
 Checking test 054 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2019,13 +2019,13 @@ Checking test 054 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 103.104579
+  0: The total amount of wall time                        = 115.443102
 
 Test 054 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2090,13 +2090,13 @@ Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.291278
+  0: The total amount of wall time                        = 161.773742
 
 Test 055 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2111,39 +2111,39 @@ Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 292.679619
+ 0: The total amount of wall time                        = 290.513099
 
 Test 056 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_debug
 Checking test 057 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.944926
+  0: The total amount of wall time                        = 180.796745
 
 Test 057 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_2threads_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_2threads_debug
 Checking test 058 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 256.454678
+ 0: The total amount of wall time                        = 276.247574
 
 Test 058 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_CubedSphereGrid_debug
 Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2170,221 +2170,221 @@ Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.328814
+  0: The total amount of wall time                        = 238.445207
 
 Test 059 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_wrtGauss_netcdf_parallel_debug
 Checking test 060 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.588780
+  0: The total amount of wall time                        = 204.571415
 
 Test 060 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_stochy_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_stochy_debug
 Checking test 061 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 184.540937
+  0: The total amount of wall time                        = 202.765072
 
 Test 061 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ca_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ca_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ca_debug
 Checking test 062 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.918254
+  0: The total amount of wall time                        = 183.249011
 
 Test 062 control_ca_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_lndp_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_lndp_debug
 Checking test 063 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.950451
+  0: The total amount of wall time                        = 182.194692
 
 Test 063 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_lheatstrg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_lheatstrg_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_lheatstrg_debug
 Checking test 064 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.561376
+  0: The total amount of wall time                        = 180.147362
 
 Test 064 control_lheatstrg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_merra2_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_merra2_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_merra2_debug
 Checking test 065 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 254.250674
+  0: The total amount of wall time                        = 368.718823
 
 Test 065 control_merra2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_rrtmgp_debug
 Checking test 066 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 203.821018
+  0: The total amount of wall time                        = 204.115398
 
 Test 066 control_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_csawmg_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_csawmg_debug
 Checking test 067 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 303.988898
+  0: The total amount of wall time                        = 400.885451
 
 Test 067 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_csawmgt_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_csawmgt_debug
 Checking test 068 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 326.857540
+  0: The total amount of wall time                        = 562.327479
 
 Test 068 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ugwpv1_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ugwpv1_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ugwpv1_debug
 Checking test 069 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.221069
+  0: The total amount of wall time                        = 198.409285
 
 Test 069 control_ugwpv1_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_ras_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_ras_debug
 Checking test 070 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.559316
+  0: The total amount of wall time                        = 204.658252
 
 Test 070 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_noahmp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_noahmp_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_noahmp_debug
 Checking test 071 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.061983
+  0: The total amount of wall time                        = 232.980638
 
 Test 071 control_noahmp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_diag_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.498038
+  0: The total amount of wall time                        = 198.069992
 
 Test 072 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_thompson_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_thompson_debug
 Checking test 073 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.495769
+  0: The total amount of wall time                        = 206.445726
 
 Test 073 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_thompson_no_aero_debug
 Checking test 074 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.647422
+  0: The total amount of wall time                        = 239.445761
 
 Test 074 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_thompson_extdiag_debug
 Checking test 075 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 225.550021
+  0: The total amount of wall time                        = 252.333852
 
 Test 075 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_regional_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/regional_control_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/regional_control_debug
 Checking test 076 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2392,13 +2392,13 @@ Checking test 076 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 240.624553
+ 0: The total amount of wall time                        = 302.294403
 
 Test 076 regional_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_gsd_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_gsd_debug
 Checking test 077 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2463,13 +2463,13 @@ Checking test 077 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.402652
+  0: The total amount of wall time                        = 286.726557
 
 Test 077 fv3_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_gsd_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_gsd_diag_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_gsd_diag_debug
 Checking test 078 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2496,13 +2496,13 @@ Checking test 078 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 513.275373
+  0: The total amount of wall time                        = 967.585536
 
 Test 078 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_rrfs_v1beta_debug
 Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2567,13 +2567,13 @@ Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 248.474987
+  0: The total amount of wall time                        = 244.455567
 
 Test 079 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_rrfs_v1alpha_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_rrfs_v1alpha_debug
 Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2638,13 +2638,13 @@ Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 248.805566
+  0: The total amount of wall time                        = 300.889669
 
 Test 080 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2709,13 +2709,13 @@ Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.480128
+  0: The total amount of wall time                        = 236.376591
 
 Test 081 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2730,85 +2730,85 @@ Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 439.706392
+ 0: The total amount of wall time                        = 429.183696
 
 Test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_control_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_control_cfsr
 Checking test 083 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 103.094248
+  0: The total amount of wall time                        = 195.276928
 
 Test 083 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_restart_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_restart_cfsr
 Checking test 084 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 72.488075
+  0: The total amount of wall time                        = 84.863659
 
 Test 084 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_control_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_control_gefs
 Checking test 085 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 102.366223
+  0: The total amount of wall time                        = 152.308831
 
 Test 085 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_control_iau_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_control_iau_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_control_iau_gefs
 Checking test 086 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 108.986799
+  0: The total amount of wall time                        = 168.043386
 
 Test 086 datm_control_iau_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_bulk_cfsr
 Checking test 087 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 102.836388
+  0: The total amount of wall time                        = 210.295631
 
 Test 087 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_bulk_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_bulk_gefs
 Checking test 088 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 94.447735
+  0: The total amount of wall time                        = 186.393297
 
 Test 088 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_mx025_cfsr
 Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2817,13 +2817,13 @@ Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 380.271854
+  0: The total amount of wall time                        = 600.475556
 
 Test 089 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_mx025_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_mx025_gefs
 Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2832,85 +2832,85 @@ Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 388.234327
+  0: The total amount of wall time                        = 651.455103
 
 Test 090 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_debug_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_debug_cfsr
 Checking test 091 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 275.770531
+  0: The total amount of wall time                        = 279.447728
 
 Test 091 datm_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_control_cfsr
 Checking test 092 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.336199
+ 0: The total amount of wall time                        = 162.923043
 
 Test 092 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_restart_cfsr
 Checking test 093 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.037767
+ 0: The total amount of wall time                        = 102.810418
 
 Test 093 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_control_gefs
 Checking test 094 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.861377
+ 0: The total amount of wall time                        = 161.874780
 
 Test 094 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_bulk_cfsr
 Checking test 095 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.767432
+ 0: The total amount of wall time                        = 224.052184
 
 Test 095 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_bulk_gefs
 Checking test 096 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.519314
+ 0: The total amount of wall time                        = 157.005427
 
 Test 096 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_mx025_cfsr
 Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2919,13 +2919,13 @@ Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 354.468176
+  0: The total amount of wall time                        = 392.714896
 
 Test 097 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_mx025_gefs
 Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2934,35 +2934,35 @@ Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 353.169688
+  0: The total amount of wall time                        = 498.778815
 
 Test 098 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_multiple_files_cfsr
 Checking test 099 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.347002
+ 0: The total amount of wall time                        = 160.423454
 
 Test 099 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/datm_cdeps_debug_cfsr
 Checking test 100 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 455.713592
+ 0: The total amount of wall time                        = 454.228581
 
 Test 100 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_233499/control_atmwav
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_35871/control_atmwav
 Checking test 101 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3005,11 +3005,11 @@ Checking test 101 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 350.498727
+  0: The total amount of wall time                        = 375.894777
 
 Test 101 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 15:45:43 CDT 2021
-Elapsed time: 02h:46m:36s. Have a nice day!
+Wed Jul 28 23:40:41 CDT 2021
+Elapsed time: 01h:21m:58s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,18 +1,18 @@
-Wed Jul 28 01:12:08 UTC 2021
+Wed Jul 28 21:16:34 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 931 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 974 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 930 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 936 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 889 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 542 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 488 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 545 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 526 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 905 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 996 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 890 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 954 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 906 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 521 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 530 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 506 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -59,13 +59,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.296472
+The total amount of wall time                        = 210.022929
 
 Test 001 control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_decomp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -108,13 +108,13 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.607841
+The total amount of wall time                        = 201.819298
 
 Test 002 control_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_restart
 Checking test 003 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -153,13 +153,13 @@ Checking test 003 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 73.266915
+The total amount of wall time                        = 76.454272
 
 Test 003 control_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_fhzero
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_fhzero
 Checking test 004 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -202,13 +202,13 @@ Checking test 004 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 202.579881
+The total amount of wall time                        = 211.779711
 
 Test 004 control_fhzero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_CubedSphereGrid
 Checking test 005 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -235,13 +235,13 @@ Checking test 005 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 144.183542
+The total amount of wall time                        = 148.438018
 
 Test 005 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_wrtGauss_netcdf_parallel
 Checking test 006 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -252,13 +252,13 @@ Checking test 006 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 218.284809
+The total amount of wall time                        = 213.104414
 
 Test 006 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_c192
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_c192
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_c192
 Checking test 007 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -269,13 +269,13 @@ Checking test 007 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 531.919331
+The total amount of wall time                        = 540.052524
 
 Test 007 control_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_stochy
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_stochy
 Checking test 008 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -286,26 +286,26 @@ Checking test 008 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 152.387403
+The total amount of wall time                        = 155.872117
 
 Test 008 control_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_stochy_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_stochy_restart
 Checking test 009 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 75.165741
+The total amount of wall time                        = 74.544690
 
 Test 009 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ca
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ca
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ca
 Checking test 010 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -316,13 +316,13 @@ Checking test 010 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 153.363406
+The total amount of wall time                        = 159.404531
 
 Test 010 control_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lndp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_lndp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_lndp
 Checking test 011 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -333,13 +333,13 @@ Checking test 011 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 157.765774
+The total amount of wall time                        = 162.144693
 
 Test 011 control_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lheatstrg
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_lheatstrg
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_lheatstrg
 Checking test 012 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -350,13 +350,13 @@ Checking test 012 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 204.476889
+The total amount of wall time                        = 192.132790
 
 Test 012 control_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lseaspray
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_lseaspray
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_lseaspray
 Checking test 013 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -367,13 +367,13 @@ Checking test 013 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 217.054207
+The total amount of wall time                        = 212.361916
 
 Test 013 control_lseaspray PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_merra2
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_merra2
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_merra2
 Checking test 014 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -384,13 +384,13 @@ Checking test 014 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 310.510984
+The total amount of wall time                        = 354.472298
 
 Test 014 control_merra2 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_rrtmgp
 Checking test 015 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -401,13 +401,13 @@ Checking test 015 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 237.962402
+The total amount of wall time                        = 252.148345
 
 Test 015 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmg
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_csawmg
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_csawmg
 Checking test 016 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -418,13 +418,13 @@ Checking test 016 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 442.957037
+The total amount of wall time                        = 424.240324
 
 Test 016 control_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_csawmgt
 Checking test 017 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -435,13 +435,13 @@ Checking test 017 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 509.595047
+The total amount of wall time                        = 517.000785
 
 Test 017 control_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_flake
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_flake
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_flake
 Checking test 018 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -452,13 +452,13 @@ Checking test 018 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 261.349705
+The total amount of wall time                        = 283.791916
 
 Test 018 control_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ugwpv1
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ugwpv1
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ugwpv1
 Checking test 019 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -469,13 +469,13 @@ Checking test 019 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 229.837522
+The total amount of wall time                        = 236.271360
 
 Test 019 control_ugwpv1 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ras
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ras
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ras
 Checking test 020 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -486,13 +486,13 @@ Checking test 020 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 221.261600
+The total amount of wall time                        = 225.069035
 
 Test 020 control_ras PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_noahmp
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_noahmp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_noahmp
 Checking test 021 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -503,13 +503,13 @@ Checking test 021 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 215.490018
+The total amount of wall time                        = 231.904191
 
 Test 021 control_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_control
 Checking test 022 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -517,25 +517,25 @@ Checking test 022 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 366.526194
+The total amount of wall time                        = 376.732790
 
 Test 022 regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_restart
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_restart
 Checking test 023 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 235.793949
+The total amount of wall time                        = 231.891467
 
 Test 023 regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_quilt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_quilt
 Checking test 024 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -546,13 +546,13 @@ Checking test 024 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 352.740571
+The total amount of wall time                        = 351.622876
 
 Test 024 regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_hafs
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_quilt_hafs
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_quilt_hafs
 Checking test 025 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -561,13 +561,13 @@ Checking test 025 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 354.759864
+The total amount of wall time                        = 350.883766
 
 Test 025 regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_quilt_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_quilt_netcdf_parallel
 Checking test 026 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -575,13 +575,13 @@ Checking test 026 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 353.034366
+The total amount of wall time                        = 349.202461
 
 Test 026 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_quilt_RRTMGP
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_quilt_RRTMGP
 Checking test 027 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -592,13 +592,13 @@ Checking test 027 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 458.525328
+The total amount of wall time                        = 460.689402
 
 Test 027 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_gsd
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_gsd
 Checking test 028 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -687,13 +687,13 @@ Checking test 028 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 265.284839
+The total amount of wall time                        = 280.332582
 
 Test 028 fv3_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1alpha
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_rrfs_v1alpha
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_rrfs_v1alpha
 Checking test 029 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -758,13 +758,13 @@ Checking test 029 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 112.763752
+The total amount of wall time                        = 112.315086
 
 Test 029 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rap
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_rap
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_rap
 Checking test 030 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -829,13 +829,13 @@ Checking test 030 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 111.397049
+The total amount of wall time                        = 113.195907
 
 Test 030 fv3_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_hrrr
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_hrrr
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_hrrr
 Checking test 031 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -900,13 +900,13 @@ Checking test 031 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 111.958025
+The total amount of wall time                        = 108.231647
 
 Test 031 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_rrfs_v1beta
 Checking test 032 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -971,13 +971,13 @@ Checking test 032 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 111.273213
+The total amount of wall time                        = 108.194751
 
 Test 032 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_HAFS_v0_hwrf_thompson
 Checking test 033 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1042,13 +1042,13 @@ Checking test 033 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 171.452191
+The total amount of wall time                        = 170.974237
 
 Test 033 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1063,26 +1063,26 @@ Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 482.154406
+The total amount of wall time                        = 512.470650
 
 Test 034 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_debug
 Checking test 035 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 147.486328
+The total amount of wall time                        = 145.650373
 
 Test 035 control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_CubedSphereGrid_debug
 Checking test 036 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1109,221 +1109,221 @@ Checking test 036 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 160.018255
+The total amount of wall time                        = 157.126699
 
 Test 036 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_wrtGauss_netcdf_parallel_debug
 Checking test 037 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 151.763780
+The total amount of wall time                        = 149.615090
 
 Test 037 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_stochy_debug
 Checking test 038 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.855384
+The total amount of wall time                        = 166.723547
 
 Test 038 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ca_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ca_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ca_debug
 Checking test 039 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.642626
+The total amount of wall time                        = 148.854507
 
 Test 039 control_ca_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_lndp_debug
 Checking test 040 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 150.941218
+The total amount of wall time                        = 150.179944
 
 Test 040 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lheatstrg_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_lheatstrg_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_lheatstrg_debug
 Checking test 041 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.477030
+The total amount of wall time                        = 145.802462
 
 Test 041 control_lheatstrg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_merra2_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_merra2_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_merra2_debug
 Checking test 042 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 225.225483
+The total amount of wall time                        = 241.543086
 
 Test 042 control_merra2_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_rrtmgp_debug
 Checking test 043 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.218272
+The total amount of wall time                        = 164.978356
 
 Test 043 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_csawmg_debug
 Checking test 044 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 267.748285
+The total amount of wall time                        = 258.801104
 
 Test 044 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_csawmgt_debug
 Checking test 045 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.891941
+The total amount of wall time                        = 322.129857
 
 Test 045 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ugwpv1_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ugwpv1_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ugwpv1_debug
 Checking test 046 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.040247
+The total amount of wall time                        = 158.350401
 
 Test 046 control_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_ras_debug
 Checking test 047 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.813341
+The total amount of wall time                        = 153.826370
 
 Test 047 control_ras_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_noahmp_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_noahmp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_noahmp_debug
 Checking test 048 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 147.734507
+The total amount of wall time                        = 149.974571
 
 Test 048 control_noahmp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_diag_debug
 Checking test 049 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.541111
+The total amount of wall time                        = 155.283860
 
 Test 049 control_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_thompson_debug
 Checking test 050 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.586848
+The total amount of wall time                        = 176.832528
 
 Test 050 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_thompson_no_aero_debug
 Checking test 051 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 167.882916
+The total amount of wall time                        = 172.938040
 
 Test 051 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/control_thompson_extdiag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/control_thompson_extdiag_debug
 Checking test 052 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 181.823783
+The total amount of wall time                        = 181.612823
 
 Test 052 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_control_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/regional_control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/regional_control_debug
 Checking test 053 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1331,13 +1331,13 @@ Checking test 053 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 256.078471
+The total amount of wall time                        = 251.443130
 
 Test 053 regional_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_gsd_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_gsd_debug
 Checking test 054 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1402,13 +1402,13 @@ Checking test 054 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 247.328453
+The total amount of wall time                        = 252.424320
 
 Test 054 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd_diag_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_gsd_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_gsd_diag_debug
 Checking test 055 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1435,13 +1435,13 @@ Checking test 055 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 474.727612
+The total amount of wall time                        = 446.831006
 
 Test 055 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_rrfs_v1beta_debug
 Checking test 056 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1506,13 +1506,13 @@ Checking test 056 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 195.934710
+The total amount of wall time                        = 196.090145
 
 Test 056 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_rrfs_v1alpha_debug
 Checking test 057 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1577,13 +1577,13 @@ Checking test 057 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 196.958800
+The total amount of wall time                        = 198.012576
 
 Test 057 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 058 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1648,13 +1648,13 @@ Checking test 058 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.515413
+The total amount of wall time                        = 203.404872
 
 Test 058 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_12577/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34055/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 059 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1669,11 +1669,11 @@ Checking test 059 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 378.296646
+The total amount of wall time                        = 375.206889
 
 Test 059 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jul 28 01:42:58 UTC 2021
-Elapsed time: 00h:30m:50s. Have a nice day!
+Wed Jul 28 21:46:23 UTC 2021
+Elapsed time: 00h:29m:49s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,26 +1,26 @@
-Tue Jul 27 21:41:17 UTC 2021
+Wed Jul 28 21:15:28 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 2125 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 2408 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 589 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 1106 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1575 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 1359 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1178 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 374 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 282 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 312 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 290 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 923 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 014 elapsed time 333 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 015 elapsed time 973 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 363 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 1112 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 2113 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 2502 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 588 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 1129 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1562 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1179 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 1425 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1196 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 356 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 374 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 313 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 282 seconds. -DAPP=ATM -DCCPP_SUITES=HAFS_v0_hwrf_thompson,HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 907 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 014 elapsed time 327 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 015 elapsed time 968 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 375 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 1125 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 104.086554
+[0] The total amount of wall time                        = 101.584485
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -126,13 +126,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 67.591416
+[0] The total amount of wall time                        = 63.367819
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -182,13 +182,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 97.048686
+[0] The total amount of wall time                        = 94.419284
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_decomp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -238,13 +238,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 101.441941
+[0] The total amount of wall time                        = 99.112727
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_ca
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_ca
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -294,13 +294,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 101.161119
+[0] The total amount of wall time                        = 98.533268
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_control_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -350,13 +350,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 418.605963
+[0] The total amount of wall time                        = 412.362730
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_restart_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -406,13 +406,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 310.626041
+[0] The total amount of wall time                        = 312.566463
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_control_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 811.016034
+[0] The total amount of wall time                        = 802.211668
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_restart_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -524,13 +524,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 468.186471
+[0] The total amount of wall time                        = 463.976685
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 658.718233
+[0] The total amount of wall time                        = 653.704869
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_restart_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 447.322353
+[0] The total amount of wall time                        = 437.429355
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_bmark_v16_nsst
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_bmark_v16_nsst
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 659.985820
+[0] The total amount of wall time                        = 654.775882
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_bmark_wave_v16
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_bmark_wave_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -722,13 +722,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 761.660111
+[0] The total amount of wall time                        = 764.671744
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_bmark_wave_v16_p7b
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_bmark_wave_v16_p7b
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -773,13 +773,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 809.962522
+[0] The total amount of wall time                        = 812.723809
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_control_wave
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_control_wave
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -832,13 +832,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 121.353887
+[0] The total amount of wall time                        = 124.088623
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/cpld_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/cpld_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 308.261087
+[0] The total amount of wall time                        = 308.503032
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -941,13 +941,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 171.553648
+[0] The total amount of wall time                        = 168.636372
 
 Test 017 control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_decomp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -990,13 +990,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 175.282457
+[0] The total amount of wall time                        = 173.773863
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1039,13 +1039,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 157.150651
+[0] The total amount of wall time                        = 156.395093
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1084,13 +1084,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 73.527927
+[0] The total amount of wall time                        = 73.409365
 
 Test 020 control_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_fhzero
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1133,13 +1133,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 170.521262
+[0] The total amount of wall time                        = 170.500481
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1166,16 +1166,16 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 134.160198
+[0] The total amount of wall time                        = 133.375620
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1183,13 +1183,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 196.227899
+[0] The total amount of wall time                        = 197.052210
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_c192
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1200,13 +1200,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 581.896022
+[0] The total amount of wall time                        = 543.155846
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_c384
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1217,13 +1217,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1030.149194
+[0] The total amount of wall time                        = 1026.138897
 
 Test 025 control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1266,13 +1266,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 872.761948
+[0] The total amount of wall time                        = 890.958341
 
 Test 026 control_c384gdas PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_stochy
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1283,26 +1283,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 121.312167
+[0] The total amount of wall time                        = 120.096616
 
 Test 027 control_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_stochy_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 62.670020
+[0] The total amount of wall time                        = 62.153729
 
 Test 028 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ca
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ca
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ca
 Checking test 029 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1313,13 +1313,13 @@ Checking test 029 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 119.651511
+[0] The total amount of wall time                        = 119.308922
 
 Test 029 control_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lndp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_lndp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1330,13 +1330,13 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 122.993270
+[0] The total amount of wall time                        = 120.622176
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lheatstrg
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_lheatstrg
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_lheatstrg
 Checking test 031 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1347,13 +1347,13 @@ Checking test 031 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 171.467545
+[0] The total amount of wall time                        = 168.873845
 
 Test 031 control_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lseaspray
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_lseaspray
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_lseaspray
 Checking test 032 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1364,13 +1364,13 @@ Checking test 032 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 179.023278
+[0] The total amount of wall time                        = 178.088762
 
 Test 032 control_lseaspray PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_merra2
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_merra2
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_merra2
 Checking test 033 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,13 +1381,13 @@ Checking test 033 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 199.060319
+[0] The total amount of wall time                        = 197.061256
 
 Test 033 control_merra2 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_rrtmgp
 Checking test 034 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1398,13 +1398,13 @@ Checking test 034 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 234.284187
+[0] The total amount of wall time                        = 233.151451
 
 Test 034 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_csawmg
 Checking test 035 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1415,13 +1415,13 @@ Checking test 035 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 303.951042
+[0] The total amount of wall time                        = 325.443815
 
 Test 035 control_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_csawmgt
 Checking test 036 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1432,13 +1432,13 @@ Checking test 036 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 373.495507
+[0] The total amount of wall time                        = 392.823717
 
 Test 036 control_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_flake
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_flake
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_flake
 Checking test 037 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1449,13 +1449,13 @@ Checking test 037 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 253.786243
+[0] The total amount of wall time                        = 253.130494
 
 Test 037 control_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ugwpv1
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ugwpv1
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ugwpv1
 Checking test 038 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1466,13 +1466,13 @@ Checking test 038 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 210.566857
+[0] The total amount of wall time                        = 209.422159
 
 Test 038 control_ugwpv1 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ras
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ras
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ras
 Checking test 039 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1483,13 +1483,13 @@ Checking test 039 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 202.888283
+[0] The total amount of wall time                        = 203.351911
 
 Test 039 control_ras PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_thompson
 Checking test 040 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1500,13 +1500,13 @@ Checking test 040 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 237.683776
+[0] The total amount of wall time                        = 239.389565
 
 Test 040 control_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_thompson_no_aero
 Checking test 041 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1517,13 +1517,13 @@ Checking test 041 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 229.361052
+[0] The total amount of wall time                        = 231.196059
 
 Test 041 control_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_noahmp
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_noahmp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_noahmp
 Checking test 042 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1534,13 +1534,13 @@ Checking test 042 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 197.048332
+[0] The total amount of wall time                        = 197.452461
 
 Test 042 control_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_control
 Checking test 043 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1548,25 +1548,25 @@ Checking test 043 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 349.654789
+[0] The total amount of wall time                        = 350.555703
 
 Test 043 regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_restart
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_restart
 Checking test 044 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-[0] The total amount of wall time                        = 200.731151
+[0] The total amount of wall time                        = 200.390758
 
 Test 044 regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_quilt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_quilt
 Checking test 045 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1577,13 +1577,13 @@ Checking test 045 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 345.453026
+[0] The total amount of wall time                        = 343.666276
 
 Test 045 regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_quilt_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_quilt_2threads
 Checking test 046 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1594,13 +1594,13 @@ Checking test 046 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 190.998774
+[0] The total amount of wall time                        = 189.809497
 
 Test 046 regional_quilt_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_hafs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_quilt_hafs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_quilt_hafs
 Checking test 047 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1609,27 +1609,27 @@ Checking test 047 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 342.783384
+[0] The total amount of wall time                        = 343.488253
 
 Test 047 regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_quilt_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_quilt_netcdf_parallel
 Checking test 048 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 346.577972
+[0] The total amount of wall time                        = 345.737963
 
 Test 048 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_quilt_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_quilt_RRTMGP
 Checking test 049 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1640,13 +1640,13 @@ Checking test 049 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 468.354952
+[0] The total amount of wall time                        = 466.943454
 
 Test 049 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_gsd
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_gsd
 Checking test 050 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1735,13 +1735,13 @@ Checking test 050 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 256.031901
+[0] The total amount of wall time                        = 254.965496
 
 Test 050 fv3_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1alpha
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_rrfs_v1alpha
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_rrfs_v1alpha
 Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1806,13 +1806,13 @@ Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.712296
+[0] The total amount of wall time                        = 101.714553
 
 Test 051 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rap
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_rap
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_rap
 Checking test 052 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1877,13 +1877,13 @@ Checking test 052 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 100.765868
+[0] The total amount of wall time                        = 101.593169
 
 Test 052 fv3_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_hrrr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_hrrr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_hrrr
 Checking test 053 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1948,13 +1948,13 @@ Checking test 053 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 100.397992
+[0] The total amount of wall time                        = 99.077786
 
 Test 053 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_rrfs_v1beta
 Checking test 054 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2019,13 +2019,13 @@ Checking test 054 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 101.272006
+[0] The total amount of wall time                        = 102.234330
 
 Test 054 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2090,13 +2090,13 @@ Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 171.947486
+[0] The total amount of wall time                        = 172.094172
 
 Test 055 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2111,39 +2111,39 @@ Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 319.892474
+[0] The total amount of wall time                        = 322.066311
 
 Test 056 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_debug
 Checking test 057 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 164.908364
+[0] The total amount of wall time                        = 164.396942
 
 Test 057 control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_2threads_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_2threads_debug
 Checking test 058 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 152.877582
+[0] The total amount of wall time                        = 152.755686
 
 Test 058 control_2threads_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_CubedSphereGrid_debug
 Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2170,221 +2170,221 @@ Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 179.004931
+[0] The total amount of wall time                        = 179.211333
 
 Test 059 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_wrtGauss_netcdf_parallel_debug
 Checking test 060 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 169.062600
+[0] The total amount of wall time                        = 168.632896
 
 Test 060 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_stochy_debug
 Checking test 061 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 189.550253
+[0] The total amount of wall time                        = 188.771480
 
 Test 061 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ca_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ca_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ca_debug
 Checking test 062 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 166.909893
+[0] The total amount of wall time                        = 166.679510
 
 Test 062 control_ca_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_lndp_debug
 Checking test 063 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 169.857193
+[0] The total amount of wall time                        = 169.602168
 
 Test 063 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_lheatstrg_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_lheatstrg_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_lheatstrg_debug
 Checking test 064 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 165.359687
+[0] The total amount of wall time                        = 164.582979
 
 Test 064 control_lheatstrg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_merra2_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_merra2_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_merra2_debug
 Checking test 065 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 237.115630
+[0] The total amount of wall time                        = 237.291054
 
 Test 065 control_merra2_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_rrtmgp_debug
 Checking test 066 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 188.110818
+[0] The total amount of wall time                        = 188.031619
 
 Test 066 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_csawmg_debug
 Checking test 067 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 281.952087
+[0] The total amount of wall time                        = 280.473832
 
 Test 067 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_csawmgt_debug
 Checking test 068 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 317.473965
+[0] The total amount of wall time                        = 317.094183
 
 Test 068 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ugwpv1_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ugwpv1_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ugwpv1_debug
 Checking test 069 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 178.917485
+[0] The total amount of wall time                        = 179.057477
 
 Test 069 control_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_ras_debug
 Checking test 070 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 170.972751
+[0] The total amount of wall time                        = 171.728172
 
 Test 070 control_ras_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_noahmp_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_noahmp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_noahmp_debug
 Checking test 071 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 165.455553
+[0] The total amount of wall time                        = 165.016481
 
 Test 071 control_noahmp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 175.146492
+[0] The total amount of wall time                        = 175.029337
 
 Test 072 control_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_thompson_debug
 Checking test 073 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 193.827427
+[0] The total amount of wall time                        = 193.870592
 
 Test 073 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_thompson_no_aero_debug
 Checking test 074 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 187.491431
+[0] The total amount of wall time                        = 187.453677
 
 Test 074 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_thompson_extdiag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_thompson_extdiag_debug
 Checking test 075 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 203.415917
+[0] The total amount of wall time                        = 204.713048
 
 Test 075 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_regional_control_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/regional_control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/regional_control_debug
 Checking test 076 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2392,13 +2392,13 @@ Checking test 076 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 277.915089
+[0] The total amount of wall time                        = 276.510486
 
 Test 076 regional_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_gsd_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_gsd_debug
 Checking test 077 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2463,13 +2463,13 @@ Checking test 077 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 283.492385
+[0] The total amount of wall time                        = 281.454245
 
 Test 077 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_gsd_diag_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_gsd_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_gsd_diag_debug
 Checking test 078 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2496,13 +2496,13 @@ Checking test 078 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 431.183362
+[0] The total amount of wall time                        = 439.180452
 
 Test 078 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_rrfs_v1beta_debug
 Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2567,13 +2567,13 @@ Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 221.969523
+[0] The total amount of wall time                        = 222.382508
 
 Test 079 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_rrfs_v1alpha_debug
 Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2638,13 +2638,13 @@ Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 224.035573
+[0] The total amount of wall time                        = 222.450780
 
 Test 080 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2709,13 +2709,13 @@ Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 234.501118
+[0] The total amount of wall time                        = 234.233776
 
 Test 081 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2730,85 +2730,85 @@ Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 432.019718
+[0] The total amount of wall time                        = 433.021364
 
 Test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_control_cfsr
 Checking test 083 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 109.922352
+[0] The total amount of wall time                        = 106.476097
 
 Test 083 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_restart_cfsr
 Checking test 084 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 77.274293
+[0] The total amount of wall time                        = 76.014152
 
 Test 084 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_control_gefs
 Checking test 085 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 100.741418
+[0] The total amount of wall time                        = 97.648060
 
 Test 085 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_control_iau_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_control_iau_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_control_iau_gefs
 Checking test 086 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 105.409440
+[0] The total amount of wall time                        = 99.513958
 
 Test 086 datm_control_iau_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_bulk_cfsr
 Checking test 087 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 106.370623
+[0] The total amount of wall time                        = 101.830174
 
 Test 087 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_bulk_gefs
 Checking test 088 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.716619
+[0] The total amount of wall time                        = 97.526918
 
 Test 088 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_mx025_cfsr
 Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2817,13 +2817,13 @@ Checking test 089 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 343.453764
+[0] The total amount of wall time                        = 367.495056
 
 Test 089 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_mx025_gefs
 Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2832,85 +2832,85 @@ Checking test 090 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 340.918891
+[0] The total amount of wall time                        = 360.537344
 
 Test 090 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_debug_cfsr
 Checking test 091 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 294.886551
+[0] The total amount of wall time                        = 291.389244
 
 Test 091 datm_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_control_cfsr
 Checking test 092 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.237020
+[0] The total amount of wall time                        = 171.821653
 
 Test 092 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_restart_cfsr
 Checking test 093 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 117.666612
+[0] The total amount of wall time                        = 117.674459
 
 Test 093 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_control_gefs
 Checking test 094 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.261731
+[0] The total amount of wall time                        = 165.296611
 
 Test 094 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_bulk_cfsr
 Checking test 095 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 176.563513
+[0] The total amount of wall time                        = 172.189772
 
 Test 095 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_bulk_gefs
 Checking test 096 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.130774
+[0] The total amount of wall time                        = 165.557023
 
 Test 096 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_mx025_cfsr
 Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2919,13 +2919,13 @@ Checking test 097 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 339.955925
+[0] The total amount of wall time                        = 336.456306
 
 Test 097 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_mx025_gefs
 Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2934,35 +2934,35 @@ Checking test 098 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 338.848983
+[0] The total amount of wall time                        = 333.897005
 
 Test 098 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_multiple_files_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_multiple_files_cfsr
 Checking test 099 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 174.227760
+[0] The total amount of wall time                        = 171.972991
 
 Test 099 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/datm_cdeps_debug_cfsr
 Checking test 100 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 491.829081
+[0] The total amount of wall time                        = 491.530079
 
 Test 100 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210727/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_17434/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_8216/control_atmwav
 Checking test 101 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3005,11 +3005,11 @@ Checking test 101 control_atmwav results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 359.275306
+[0] The total amount of wall time                        = 360.593678
 
 Test 101 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jul 27 22:46:12 UTC 2021
-Elapsed time: 01h:04m:58s. Have a nice day!
+Wed Jul 28 22:18:08 UTC 2021
+Elapsed time: 01h:02m:42s. Have a nice day!


### PR DESCRIPTION
# PR Checklist

- [X] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [n/a] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

This PR only updates the submodule pointer for fv3atm for the CCPP standard name updates described in the associated PRs below (in fv3atm and ccpp-physics). No changes to the input data or the results.

## Testing

Regression tests are run on all tier-1 platforms against the existing baselines, except Cheyenne (still under maintenance):

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [-] cheyenne.intel (skip, maintenance)
- [-] cheyenne.gnu (skip, maintenance)
- [X] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [x] CI: https://github.com/ufs-community/ufs-weather-model/actions/runs/1076391676

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/715
https://github.com/NOAA-EMC/fv3atm/pull/356
https://github.com/ufs-community/ufs-weather-model/pull/719
