### PR TITLE
Fix stochastic physics restart runs, remove rayleigh damping from all suite definition files (fv3atm)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = stochy_wrapper_lisa_and_remove_rayleigh_damp_from_suites
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = stochy_wrapper_lisa_and_remove_rayleigh_damp_from_suites
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,14 +1,14 @@
-Tue Aug 17 12:33:34 MDT 2021
+Wed Aug 18 17:35:07 MDT 2021
 Start Regression test
 
-Compile 001 elapsed time 359 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 345 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 322 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 414 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 356 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 349 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 323 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 412 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 166 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -55,13 +55,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 293.992967
+0:The total amount of wall time                        = 286.103003
 
 Test 001 control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -100,13 +100,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 139.151553
+0:The total amount of wall time                        = 136.173741
 
 Test 002 control_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -145,13 +145,13 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 818.702141
+0:The total amount of wall time                        = 821.270296
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -162,13 +162,13 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 186.170002
+0:The total amount of wall time                        = 184.949940
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -179,13 +179,13 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 354.014752
+0:The total amount of wall time                        = 349.481745
 
 Test 005 control_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -196,13 +196,13 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 363.236121
+0:The total amount of wall time                        = 359.953860
 
 Test 006 control_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -213,13 +213,13 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 370.590768
+0:The total amount of wall time                        = 358.650218
 
 Test 007 control_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -230,13 +230,13 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 349.156040
+0:The total amount of wall time                        = 345.894171
 
 Test 008 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_ugwpv1
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_ugwpv1
 Checking test 009 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -247,13 +247,13 @@ Checking test 009 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 308.216676
+0:The total amount of wall time                        = 306.618733
 
 Test 009 control_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_ras
 Checking test 010 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -264,13 +264,13 @@ Checking test 010 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 295.389827
+0:The total amount of wall time                        = 289.080744
 
 Test 010 control_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_gsd
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_gsd
 Checking test 011 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -359,13 +359,13 @@ Checking test 011 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 456.887633
+0:The total amount of wall time                        = 439.833564
 
 Test 011 fv3_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_rrfs_v1alpha
 Checking test 012 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -430,13 +430,13 @@ Checking test 012 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 165.939003
+0:The total amount of wall time                        = 162.369739
 
 Test 012 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_rrfs_v1beta
 Checking test 013 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -501,13 +501,13 @@ Checking test 013 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 166.097730
+0:The total amount of wall time                        = 162.226431
 
 Test 013 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -572,13 +572,13 @@ Checking test 014 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 250.079229
+0:The total amount of wall time                        = 249.282559
 
 Test 014 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 015 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -593,39 +593,39 @@ Checking test 015 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 454.110964
+0:The total amount of wall time                        = 455.058609
 
 Test 015 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_debug
 Checking test 016 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.245728
+0:The total amount of wall time                        = 83.051471
 
 Test 016 control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_diag_debug
 Checking test 017 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.673399
+0:The total amount of wall time                        = 89.842014
 
 Test 017 control_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/regional_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/regional_control_debug
 Checking test 018 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -633,13 +633,13 @@ Checking test 018 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 130.204025
+0:The total amount of wall time                        = 129.426712
 
 Test 018 regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_rrfs_v1alpha_debug
 Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -704,13 +704,13 @@ Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 105.940549
+0:The total amount of wall time                        = 105.261457
 
 Test 019 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_rrfs_v1beta_debug
 Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -775,13 +775,13 @@ Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 107.796558
+0:The total amount of wall time                        = 105.345736
 
 Test 020 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_gsd_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_gsd_debug
 Checking test 021 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -846,13 +846,13 @@ Checking test 021 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.397225
+0:The total amount of wall time                        = 135.024514
 
 Test 021 fv3_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_gsd_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_gsd_diag_debug
 Checking test 022 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -879,104 +879,104 @@ Checking test 022 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 344.427666
+0:The total amount of wall time                        = 300.909863
 
 Test 022 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_thompson_debug
 Checking test 023 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 97.655086
+0:The total amount of wall time                        = 96.603855
 
 Test 023 control_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_thompson_no_aero_debug
 Checking test 024 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 94.136940
+0:The total amount of wall time                        = 92.686199
 
 Test 024 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_thompson_extdiag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_thompson_extdiag_debug
 Checking test 025 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 103.686610
+0:The total amount of wall time                        = 102.132897
 
 Test 025 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_rrtmgp_debug
 Checking test 026 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 91.935626
+0:The total amount of wall time                        = 91.405357
 
 Test 026 control_rrtmgp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_ugwpv1_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_ugwpv1_debug
 Checking test 027 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.073166
+0:The total amount of wall time                        = 88.317910
 
 Test 027 control_ugwpv1_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_ras_debug
 Checking test 028 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.120266
+0:The total amount of wall time                        = 86.220088
 
 Test 028 control_ras_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/control_noahmp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/control_noahmp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/control_noahmp_debug
 Checking test 029 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.928765
+0:The total amount of wall time                        = 82.505359
 
 Test 029 control_noahmp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 030 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1041,13 +1041,13 @@ Checking test 030 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 107.573233
+0:The total amount of wall time                        = 108.957409
 
 Test 030 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14469/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58861/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1062,11 +1062,11 @@ Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 213.573461
+0:The total amount of wall time                        = 214.658443
 
 Test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 13:02:48 MDT 2021
-Elapsed time: 00h:29m:14s. Have a nice day!
+Wed Aug 18 17:57:14 MDT 2021
+Elapsed time: 00h:22m:07s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,28 +1,28 @@
-Tue Aug 17 12:18:25 MDT 2021
+Wed Aug 18 17:16:04 MDT 2021
 Start Regression test
 
-Compile 001 elapsed time 984 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1095 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 352 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 717 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 908 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 750 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 838 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 738 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 265 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 240 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 220 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 812 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 826 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 373 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 188 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 392 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 195 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 704 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 983 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1108 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 348 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 705 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 903 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 747 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 822 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 734 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 266 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 230 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 232 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 229 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 796 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 816 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 381 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 189 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 396 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 198 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 711 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -72,13 +72,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.362250
+0:The total amount of wall time                        = 96.012244
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -128,13 +128,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 55.572596
+0:The total amount of wall time                        = 50.805246
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -184,13 +184,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 257.419731
+0:The total amount of wall time                        = 256.052259
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_decomp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -240,13 +240,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 97.212979
+0:The total amount of wall time                        = 94.036561
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_ca
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -296,13 +296,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-0:The total amount of wall time                        = 98.722601
+0:The total amount of wall time                        = 94.323731
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -352,13 +352,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 413.790355
+0:The total amount of wall time                        = 405.015044
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_restart_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-0:The total amount of wall time                        = 331.861297
+0:The total amount of wall time                        = 288.207140
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 936.468270
+0:The total amount of wall time                        = 862.723898
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_restart_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-0:The total amount of wall time                        = 479.837385
+0:The total amount of wall time                        = 471.301129
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_bmark_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -575,13 +575,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 745.921004
+0:The total amount of wall time                        = 686.613241
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_restart_bmark_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -624,13 +624,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 401.922391
+0:The total amount of wall time                        = 386.419475
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16_nsst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_bmark_v16_nsst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -673,13 +673,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 767.008709
+0:The total amount of wall time                        = 688.516341
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_bmark_wave_v16
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -724,13 +724,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 862.343536
+0:The total amount of wall time                        = 778.821435
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_wave
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_control_wave
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -783,13 +783,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 124.482391
+0:The total amount of wall time                        = 121.116801
 
 Test 014 cpld_control_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/cpld_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -839,13 +839,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-0:The total amount of wall time                        = 287.022113
+0:The total amount of wall time                        = 286.937193
 
 Test 015 cpld_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -892,13 +892,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.971405
+0:The total amount of wall time                        = 167.484056
 
 Test 016 control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_decomp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -941,13 +941,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 173.863822
+0:The total amount of wall time                        = 168.831123
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -990,13 +990,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 343.558981
+0:The total amount of wall time                        = 347.384361
 
 Test 018 control_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1035,13 +1035,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 75.452108
+0:The total amount of wall time                        = 73.203704
 
 Test 019 control_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_fhzero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1084,13 +1084,13 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 169.922183
+0:The total amount of wall time                        = 167.939517
 
 Test 020 control_fhzero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_CubedSphereGrid
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1117,30 +1117,30 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 147.009303
+0:The total amount of wall time                        = 141.105618
 
 Test 021 control_CubedSphereGrid PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 203.612692
+0:The total amount of wall time                        = 185.602252
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1179,13 +1179,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 420.554446
+0:The total amount of wall time                        = 417.052559
 
 Test 023 control_c48 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1196,13 +1196,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 583.690604
+0:The total amount of wall time                        = 576.909668
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1213,13 +1213,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1069.580034
+0:The total amount of wall time                        = 1063.593220
 
 Test 025 control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_c384gdas
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1262,13 +1262,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1026.356031
+0:The total amount of wall time                        = 904.999203
 
 Test 026 control_c384gdas PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1279,26 +1279,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 115.241016
+0:The total amount of wall time                        = 113.095928
 
 Test 027 control_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_stochy_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 57.891101
+0:The total amount of wall time                        = 56.518799
 
 Test 028 control_stochy_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ca
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ca
 Checking test 029 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1309,13 +1309,13 @@ Checking test 029 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 112.593906
+0:The total amount of wall time                        = 111.664084
 
 Test 029 control_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_lndp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1326,13 +1326,13 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 116.187948
+0:The total amount of wall time                        = 113.607801
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_lheatstrg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_lheatstrg
 Checking test 031 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1343,13 +1343,13 @@ Checking test 031 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 181.094351
+0:The total amount of wall time                        = 164.858937
 
 Test 031 control_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lseaspray
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_lseaspray
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_lseaspray
 Checking test 032 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1360,13 +1360,13 @@ Checking test 032 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 186.133026
+0:The total amount of wall time                        = 174.824501
 
 Test 032 control_lseaspray PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_merra2
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_merra2
 Checking test 033 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1377,13 +1377,13 @@ Checking test 033 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 209.226554
+0:The total amount of wall time                        = 202.429361
 
 Test 033 control_merra2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_rrtmgp
 Checking test 034 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1394,13 +1394,13 @@ Checking test 034 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 280.868583
+0:The total amount of wall time                        = 271.989727
 
 Test 034 control_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_csawmg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_csawmg
 Checking test 035 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1411,13 +1411,13 @@ Checking test 035 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 344.805086
+0:The total amount of wall time                        = 337.545148
 
 Test 035 control_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_csawmgt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_csawmgt
 Checking test 036 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1428,13 +1428,13 @@ Checking test 036 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 439.549862
+0:The total amount of wall time                        = 415.759380
 
 Test 036 control_csawmgt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_flake
 Checking test 037 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1445,13 +1445,13 @@ Checking test 037 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 278.278944
+0:The total amount of wall time                        = 269.494854
 
 Test 037 control_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ugwpv1
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ugwpv1
 Checking test 038 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1462,13 +1462,13 @@ Checking test 038 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 225.107711
+0:The total amount of wall time                        = 223.229010
 
 Test 038 control_ugwpv1 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ras
 Checking test 039 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1479,13 +1479,13 @@ Checking test 039 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 208.010850
+0:The total amount of wall time                        = 204.679588
 
 Test 039 control_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_thompson
 Checking test 040 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1496,13 +1496,13 @@ Checking test 040 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 279.719280
+0:The total amount of wall time                        = 257.182403
 
 Test 040 control_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_thompson_no_aero
 Checking test 041 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1513,13 +1513,13 @@ Checking test 041 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 252.964951
+0:The total amount of wall time                        = 247.933535
 
 Test 041 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_noahmp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_noahmp
 Checking test 042 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1530,13 +1530,13 @@ Checking test 042 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 198.178325
+0:The total amount of wall time                        = 196.331699
 
 Test 042 control_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_control
 Checking test 043 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1544,25 +1544,25 @@ Checking test 043 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 350.946282
+0:The total amount of wall time                        = 347.668359
 
 Test 043 regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_restart
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_restart
 Checking test 044 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-0:The total amount of wall time                        = 190.212043
+0:The total amount of wall time                        = 189.830923
 
 Test 044 regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_quilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_quilt
 Checking test 045 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1573,13 +1573,13 @@ Checking test 045 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 348.568573
+0:The total amount of wall time                        = 338.419716
 
 Test 045 regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_quilt_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_quilt_2threads
 Checking test 046 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1590,13 +1590,13 @@ Checking test 046 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 937.903647
+0:The total amount of wall time                        = 930.599424
 
 Test 046 regional_quilt_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_quilt_hafs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_quilt_hafs
 Checking test 047 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1605,27 +1605,27 @@ Checking test 047 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 339.446886
+0:The total amount of wall time                        = 346.845392
 
 Test 047 regional_quilt_hafs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_quilt_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_quilt_netcdf_parallel
 Checking test 048 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc ............ALT CHECK......OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 342.992786
+0:The total amount of wall time                        = 344.918257
 
 Test 048 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_quilt_RRTMGP
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_quilt_RRTMGP
 Checking test 049 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1636,13 +1636,13 @@ Checking test 049 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 534.664682
+0:The total amount of wall time                        = 527.058406
 
 Test 049 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_gsd
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_gsd
 Checking test 050 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1731,13 +1731,13 @@ Checking test 050 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 262.928956
+0:The total amount of wall time                        = 251.702237
 
 Test 050 fv3_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_rrfs_v1alpha
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_rrfs_v1alpha
 Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1802,13 +1802,13 @@ Checking test 051 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 102.683539
+0:The total amount of wall time                        = 99.473076
 
 Test 051 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rap
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_rap
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_rap
 Checking test 052 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1873,13 +1873,13 @@ Checking test 052 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 105.891468
+0:The total amount of wall time                        = 100.324050
 
 Test 052 fv3_rap PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_hrrr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_hrrr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_hrrr
 Checking test 053 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1944,13 +1944,13 @@ Checking test 053 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 101.534780
+0:The total amount of wall time                        = 98.804386
 
 Test 053 fv3_hrrr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_rrfs_v1beta
 Checking test 054 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2015,13 +2015,13 @@ Checking test 054 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 100.091255
+0:The total amount of wall time                        = 100.253487
 
 Test 054 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2086,13 +2086,13 @@ Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 288.950336
+0:The total amount of wall time                        = 197.659185
 
 Test 055 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2107,39 +2107,39 @@ Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 340.957278
+0:The total amount of wall time                        = 341.543729
 
 Test 056 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_debug
 Checking test 057 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.478864
+0:The total amount of wall time                        = 154.239157
 
 Test 057 control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_2threads_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_2threads_debug
 Checking test 058 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 271.649165
+0:The total amount of wall time                        = 271.161094
 
 Test 058 control_2threads_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_CubedSphereGrid_debug
 Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2166,221 +2166,221 @@ Checking test 059 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 169.493840
+0:The total amount of wall time                        = 168.120938
 
 Test 059 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_wrtGauss_netcdf_parallel_debug
 Checking test 060 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.939552
+0:The total amount of wall time                        = 156.994263
 
 Test 060 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_stochy_debug
 Checking test 061 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 177.114108
+0:The total amount of wall time                        = 176.521834
 
 Test 061 control_stochy_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ca_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ca_debug
 Checking test 062 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.636850
+0:The total amount of wall time                        = 156.097512
 
 Test 062 control_ca_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_lndp_debug
 Checking test 063 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 159.271398
+0:The total amount of wall time                        = 158.741012
 
 Test 063 control_lndp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_lheatstrg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_lheatstrg_debug
 Checking test 064 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 154.869643
+0:The total amount of wall time                        = 155.327160
 
 Test 064 control_lheatstrg_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_merra2_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_merra2_debug
 Checking test 065 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 231.871899
+0:The total amount of wall time                        = 226.038250
 
 Test 065 control_merra2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_rrtmgp_debug
 Checking test 066 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 176.983602
+0:The total amount of wall time                        = 176.117740
 
 Test 066 control_rrtmgp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_csawmg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_csawmg_debug
 Checking test 067 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 267.688165
+0:The total amount of wall time                        = 267.124446
 
 Test 067 control_csawmg_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_csawmgt_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_csawmgt_debug
 Checking test 068 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 298.732461
+0:The total amount of wall time                        = 304.232864
 
 Test 068 control_csawmgt_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ugwpv1_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ugwpv1_debug
 Checking test 069 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 168.509415
+0:The total amount of wall time                        = 167.650518
 
 Test 069 control_ugwpv1_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_ras_debug
 Checking test 070 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.901536
+0:The total amount of wall time                        = 161.104166
 
 Test 070 control_ras_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_noahmp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_noahmp_debug
 Checking test 071 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.507755
+0:The total amount of wall time                        = 153.991712
 
 Test 071 control_noahmp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 165.836524
+0:The total amount of wall time                        = 167.318805
 
 Test 072 control_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_thompson_debug
 Checking test 073 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.360643
+0:The total amount of wall time                        = 181.075656
 
 Test 073 control_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_thompson_no_aero_debug
 Checking test 074 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.749387
+0:The total amount of wall time                        = 173.657700
 
 Test 074 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_thompson_extdiag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_thompson_extdiag_debug
 Checking test 075 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 191.566747
+0:The total amount of wall time                        = 190.884206
 
 Test 075 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/regional_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/regional_control_debug
 Checking test 076 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2388,13 +2388,13 @@ Checking test 076 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 255.844054
+0:The total amount of wall time                        = 256.618132
 
 Test 076 regional_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_gsd_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_gsd_debug
 Checking test 077 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2459,13 +2459,13 @@ Checking test 077 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 263.237272
+0:The total amount of wall time                        = 266.184782
 
 Test 077 fv3_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_gsd_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_gsd_diag_debug
 Checking test 078 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2492,13 +2492,13 @@ Checking test 078 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 445.186420
+0:The total amount of wall time                        = 413.069854
 
 Test 078 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_rrfs_v1beta_debug
 Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2563,13 +2563,13 @@ Checking test 079 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.718526
+0:The total amount of wall time                        = 208.602811
 
 Test 079 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_rrfs_v1alpha_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_rrfs_v1alpha_debug
 Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2634,13 +2634,13 @@ Checking test 080 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 210.018026
+0:The total amount of wall time                        = 209.145834
 
 Test 080 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2705,13 +2705,13 @@ Checking test 081 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 220.940334
+0:The total amount of wall time                        = 217.685701
 
 Test 081 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2726,37 +2726,37 @@ Checking test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 398.484132
+0:The total amount of wall time                        = 398.692193
 
 Test 082 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/hafs_regional_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/hafs_regional_atm
 Checking test 083 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 498.458726
+0:The total amount of wall time                        = 484.847583
 
 Test 083 hafs_regional_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/hafs_regional_atm_ocn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/hafs_regional_atm_ocn
 Checking test 084 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 424.349074
+0:The total amount of wall time                        = 395.198608
 
 Test 084 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/hafs_regional_docn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/hafs_regional_docn
 Checking test 085 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2764,13 +2764,13 @@ Checking test 085 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 341.516197
+0:The total amount of wall time                        = 333.804991
 
 Test 085 hafs_regional_docn PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/hafs_regional_docn_oisst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/hafs_regional_docn_oisst
 Checking test 086 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2778,97 +2778,97 @@ Checking test 086 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 361.603903
+0:The total amount of wall time                        = 337.761177
 
 Test 086 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/hafs_regional_datm_cdeps
 Checking test 087 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1300.109460
+0:The total amount of wall time                        = 1286.825045
 
 Test 087 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_control_cfsr
 Checking test 088 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 108.623251
+0:The total amount of wall time                        = 100.590606
 
 Test 088 datm_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_restart_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_restart_cfsr
 Checking test 089 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 102.474909
+0:The total amount of wall time                        = 62.668016
 
 Test 089 datm_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_control_gefs
 Checking test 090 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 95.839421
+0:The total amount of wall time                        = 94.311638
 
 Test 090 datm_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_iau_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_control_iau_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_control_iau_gefs
 Checking test 091 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 94.860403
+0:The total amount of wall time                        = 93.184342
 
 Test 091 datm_control_iau_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_bulk_cfsr
 Checking test 092 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 96.174372
+0:The total amount of wall time                        = 96.556673
 
 Test 092 datm_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_bulk_gefs
 Checking test 093 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 95.614184
+0:The total amount of wall time                        = 94.376474
 
 Test 093 datm_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_mx025_cfsr
 Checking test 094 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2877,13 +2877,13 @@ Checking test 094 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 426.531438
+0:The total amount of wall time                        = 343.431081
 
 Test 094 datm_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_mx025_gefs
 Checking test 095 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2892,85 +2892,85 @@ Checking test 095 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 353.225560
+0:The total amount of wall time                        = 345.254226
 
 Test 095 datm_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_debug_cfsr
 Checking test 096 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 268.270520
+0:The total amount of wall time                        = 267.198680
 
 Test 096 datm_debug_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_control_cfsr
 Checking test 097 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 173.949468
+0:The total amount of wall time                        = 164.204291
 
 Test 097 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_restart_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_restart_cfsr
 Checking test 098 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 102.109555
+0:The total amount of wall time                        = 100.874111
 
 Test 098 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_control_gefs
 Checking test 099 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 209.054343
+0:The total amount of wall time                        = 158.925853
 
 Test 099 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_bulk_cfsr
 Checking test 100 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 219.103346
+0:The total amount of wall time                        = 164.623969
 
 Test 100 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_bulk_gefs
 Checking test 101 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 197.208060
+0:The total amount of wall time                        = 158.160209
 
 Test 101 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_mx025_cfsr
 Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2979,13 +2979,13 @@ Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 353.352531
+0:The total amount of wall time                        = 346.259991
 
 Test 102 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_mx025_gefs
 Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2994,35 +2994,35 @@ Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 352.672149
+0:The total amount of wall time                        = 343.037857
 
 Test 103 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_multiple_files_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_multiple_files_cfsr
 Checking test 104 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.282441
+0:The total amount of wall time                        = 164.402285
 
 Test 104 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/datm_cdeps_debug_cfsr
 Checking test 105 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 450.231445
+0:The total amount of wall time                        = 450.974527
 
 Test 105 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_14604/control_atmwav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_43322/control_atmwav
 Checking test 106 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3066,11 +3066,11 @@ Checking test 106 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 152.253341
+0:The total amount of wall time                        = 147.436004
 
 Test 106 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 13:28:42 MDT 2021
-Elapsed time: 01h:10m:17s. Have a nice day!
+Wed Aug 18 18:05:06 MDT 2021
+Elapsed time: 00h:49m:02s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,28 +1,28 @@
-Tue Aug 17 14:18:28 EDT 2021
+Wed Aug 18 19:19:02 EDT 2021
 Start Regression test
 
-Compile 001 elapsed time 767 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 804 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 299 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 662 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 689 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 657 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 779 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 800 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 275 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 668 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 699 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 668 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 007 elapsed time 668 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 671 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 275 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 219 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 217 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 706 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 718 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 292 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 187 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 295 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 184 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 651 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 676 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 234 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 233 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 224 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 700 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 712 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 291 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 182 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 299 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 186 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 664 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -72,13 +72,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 91.310999
+  0: The total amount of wall time                        = 90.594500
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -128,13 +128,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 50.843933
+  0: The total amount of wall time                        = 79.538027
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -184,13 +184,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 117.946334
+  0: The total amount of wall time                        = 113.708205
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -240,13 +240,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 90.082729
+  0: The total amount of wall time                        = 88.740953
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -296,13 +296,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 121.390458
+  0: The total amount of wall time                        = 88.454414
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -352,13 +352,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 401.357718
+  0: The total amount of wall time                        = 403.792153
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_restart_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 281.216399
+  0: The total amount of wall time                        = 302.372418
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 835.607207
+  0: The total amount of wall time                        = 837.133912
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_restart_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 443.527539
+  0: The total amount of wall time                        = 423.638846
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -575,13 +575,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 667.651749
+  0: The total amount of wall time                        = 660.970237
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_restart_bmark_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -624,13 +624,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 359.800254
+  0: The total amount of wall time                        = 336.952955
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16_nsst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_bmark_v16_nsst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -673,13 +673,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 662.440096
+  0: The total amount of wall time                        = 667.843390
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_bmark_wave_v16
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -724,13 +724,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 753.235274
+  0: The total amount of wall time                        = 752.044090
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_bmark_wave_v16_p7b
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -775,13 +775,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 881.228426
+  0: The total amount of wall time                        = 867.283134
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_wave
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_control_wave
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -834,13 +834,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 101.932863
+  0: The total amount of wall time                        = 102.185289
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/cpld_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -890,13 +890,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 266.506461
+  0: The total amount of wall time                        = 264.482720
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -943,13 +943,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.558676
+  0: The total amount of wall time                        = 162.795114
 
 Test 017 control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -992,13 +992,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.055857
+  0: The total amount of wall time                        = 166.671660
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1041,13 +1041,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 187.248305
+ 0: The total amount of wall time                        = 184.911976
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1086,13 +1086,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 67.648221
+  0: The total amount of wall time                        = 67.831157
 
 Test 020 control_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_fhzero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1135,13 +1135,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.011662
+  0: The total amount of wall time                        = 166.084863
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1168,13 +1168,13 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.157672
+  0: The total amount of wall time                        = 125.508017
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1185,13 +1185,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 232.513494
+  0: The total amount of wall time                        = 693.003744
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1230,13 +1230,13 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 351.970266
+0: The total amount of wall time                        = 350.949125
 
 Test 024 control_c48 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1247,13 +1247,13 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 537.203717
+  0: The total amount of wall time                        = 535.010440
 
 Test 025 control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1264,13 +1264,13 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 939.366621
+  0: The total amount of wall time                        = 943.719594
 
 Test 026 control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1313,13 +1313,13 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 769.989811
+  0: The total amount of wall time                        = 777.527807
 
 Test 027 control_c384gdas PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1330,26 +1330,26 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 117.548003
+  0: The total amount of wall time                        = 116.995369
 
 Test 028 control_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_stochy_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 59.886238
+  0: The total amount of wall time                        = 60.414300
 
 Test 029 control_stochy_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ca
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ca
 Checking test 030 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,13 +1360,13 @@ Checking test 030 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.431110
+  0: The total amount of wall time                        = 114.859582
 
 Test 030 control_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1377,13 +1377,13 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 119.209814
+  0: The total amount of wall time                        = 118.424395
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_lheatstrg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_lheatstrg
 Checking test 032 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1394,13 +1394,13 @@ Checking test 032 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.502762
+  0: The total amount of wall time                        = 163.434645
 
 Test 032 control_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lseaspray
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_lseaspray
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_lseaspray
 Checking test 033 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1411,13 +1411,13 @@ Checking test 033 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 173.676730
+  0: The total amount of wall time                        = 172.284010
 
 Test 033 control_lseaspray PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_merra2
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_merra2
 Checking test 034 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1428,13 +1428,13 @@ Checking test 034 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 260.668402
+  0: The total amount of wall time                        = 258.443018
 
 Test 034 control_merra2 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1445,13 +1445,13 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.465593
+  0: The total amount of wall time                        = 223.038184
 
 Test 035 control_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_csawmg
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_csawmg
 Checking test 036 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1462,13 +1462,13 @@ Checking test 036 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 355.379558
+  0: The total amount of wall time                        = 357.222246
 
 Test 036 control_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_csawmgt
 Checking test 037 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1479,13 +1479,13 @@ Checking test 037 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 420.751634
+  0: The total amount of wall time                        = 418.589526
 
 Test 037 control_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_flake
 Checking test 038 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1496,13 +1496,13 @@ Checking test 038 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 241.133226
+  0: The total amount of wall time                        = 242.611197
 
 Test 038 control_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ugwpv1
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ugwpv1
 Checking test 039 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1513,13 +1513,13 @@ Checking test 039 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 200.203595
+  0: The total amount of wall time                        = 227.309416
 
 Test 039 control_ugwpv1 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1530,13 +1530,13 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 191.392416
+  0: The total amount of wall time                        = 210.679874
 
 Test 040 control_ras PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_thompson
 Checking test 041 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1547,13 +1547,13 @@ Checking test 041 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 227.090129
+  0: The total amount of wall time                        = 236.287547
 
 Test 041 control_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_thompson_no_aero
 Checking test 042 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1564,13 +1564,13 @@ Checking test 042 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 218.563302
+  0: The total amount of wall time                        = 239.367487
 
 Test 042 control_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_noahmp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_noahmp
 Checking test 043 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1581,13 +1581,13 @@ Checking test 043 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.504440
+  0: The total amount of wall time                        = 213.437989
 
 Test 043 control_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_control
 Checking test 044 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1595,25 +1595,25 @@ Checking test 044 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 331.703296
+ 0: The total amount of wall time                        = 328.283211
 
 Test 044 regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_restart
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_restart
 Checking test 045 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 175.760649
+ 0: The total amount of wall time                        = 175.862737
 
 Test 045 regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_quilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_quilt
 Checking test 046 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1624,13 +1624,13 @@ Checking test 046 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 330.544746
+ 0: The total amount of wall time                        = 362.139418
 
 Test 046 regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_quilt_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_quilt_2threads
 Checking test 047 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1641,13 +1641,13 @@ Checking test 047 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 264.678597
+ 0: The total amount of wall time                        = 283.395476
 
 Test 047 regional_quilt_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_quilt_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_quilt_hafs
 Checking test 048 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1656,13 +1656,13 @@ Checking test 048 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 328.414560
+ 0: The total amount of wall time                        = 353.554635
 
 Test 048 regional_quilt_hafs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_quilt_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_quilt_netcdf_parallel
 Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1670,13 +1670,13 @@ Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 335.724975
+ 0: The total amount of wall time                        = 542.606307
 
 Test 049 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_quilt_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_quilt_RRTMGP
 Checking test 050 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1687,13 +1687,13 @@ Checking test 050 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 469.467941
+ 0: The total amount of wall time                        = 465.231699
 
 Test 050 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_gsd
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_gsd
 Checking test 051 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1782,13 +1782,13 @@ Checking test 051 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 237.423432
+  0: The total amount of wall time                        = 235.196882
 
 Test 051 fv3_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_rrfs_v1alpha
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_rrfs_v1alpha
 Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1853,13 +1853,13 @@ Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.094656
+  0: The total amount of wall time                        = 121.321076
 
 Test 052 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rap
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_rap
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_rap
 Checking test 053 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1924,13 +1924,13 @@ Checking test 053 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 95.165943
+  0: The total amount of wall time                        = 91.952062
 
 Test 053 fv3_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_hrrr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_hrrr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_hrrr
 Checking test 054 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1995,13 +1995,13 @@ Checking test 054 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.837092
+  0: The total amount of wall time                        = 89.656367
 
 Test 054 fv3_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_rrfs_v1beta
 Checking test 055 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2066,13 +2066,13 @@ Checking test 055 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.501635
+  0: The total amount of wall time                        = 91.689560
 
 Test 055 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2137,13 +2137,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.234221
+  0: The total amount of wall time                        = 161.619180
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2158,39 +2158,39 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 325.329723
+ 0: The total amount of wall time                        = 330.102595
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_debug
 Checking test 058 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.185683
+  0: The total amount of wall time                        = 145.513245
 
 Test 058 control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_2threads_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_2threads_debug
 Checking test 059 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 252.636793
+ 0: The total amount of wall time                        = 258.322616
 
 Test 059 control_2threads_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_CubedSphereGrid_debug
 Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2217,221 +2217,221 @@ Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.782908
+  0: The total amount of wall time                        = 155.263957
 
 Test 060 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_wrtGauss_netcdf_parallel_debug
 Checking test 061 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.497946
+  0: The total amount of wall time                        = 209.101663
 
 Test 061 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_stochy_debug
 Checking test 062 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.801479
+  0: The total amount of wall time                        = 167.986024
 
 Test 062 control_stochy_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ca_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ca_debug
 Checking test 063 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.384595
+  0: The total amount of wall time                        = 148.720740
 
 Test 063 control_ca_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.875509
+  0: The total amount of wall time                        = 150.319195
 
 Test 064 control_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_lheatstrg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_lheatstrg_debug
 Checking test 065 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.773513
+  0: The total amount of wall time                        = 145.036037
 
 Test 065 control_lheatstrg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_merra2_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_merra2_debug
 Checking test 066 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 246.730320
+  0: The total amount of wall time                        = 237.887096
 
 Test 066 control_merra2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_rrtmgp_debug
 Checking test 067 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.553893
+  0: The total amount of wall time                        = 168.240746
 
 Test 067 control_rrtmgp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_csawmg_debug
 Checking test 068 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.325752
+  0: The total amount of wall time                        = 290.197632
 
 Test 068 control_csawmg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_csawmgt_debug
 Checking test 069 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 324.755204
+  0: The total amount of wall time                        = 314.818040
 
 Test 069 control_csawmgt_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ugwpv1_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ugwpv1_debug
 Checking test 070 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.776951
+  0: The total amount of wall time                        = 158.225514
 
 Test 070 control_ugwpv1_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.713615
+  0: The total amount of wall time                        = 153.389869
 
 Test 071 control_ras_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_noahmp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_noahmp_debug
 Checking test 072 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.589778
+  0: The total amount of wall time                        = 145.470184
 
 Test 072 control_noahmp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.817507
+  0: The total amount of wall time                        = 154.828354
 
 Test 073 control_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.799383
+  0: The total amount of wall time                        = 173.487092
 
 Test 074 control_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.066521
+  0: The total amount of wall time                        = 168.238727
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_thompson_extdiag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.231985
+  0: The total amount of wall time                        = 183.775770
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/regional_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/regional_control_debug
 Checking test 077 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2439,13 +2439,13 @@ Checking test 077 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 260.065698
+ 0: The total amount of wall time                        = 255.324941
 
 Test 077 regional_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_gsd_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_gsd_debug
 Checking test 078 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2510,13 +2510,13 @@ Checking test 078 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 255.752392
+  0: The total amount of wall time                        = 251.156897
 
 Test 078 fv3_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_gsd_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_gsd_diag_debug
 Checking test 079 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2543,13 +2543,13 @@ Checking test 079 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 339.132236
+  0: The total amount of wall time                        = 337.690287
 
 Test 079 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_rrfs_v1beta_debug
 Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2614,13 +2614,13 @@ Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 200.778966
+  0: The total amount of wall time                        = 197.391005
 
 Test 080 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_rrfs_v1alpha_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_rrfs_v1alpha_debug
 Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2685,13 +2685,13 @@ Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.502238
+  0: The total amount of wall time                        = 196.747369
 
 Test 081 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2756,13 +2756,13 @@ Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 213.738679
+  0: The total amount of wall time                        = 213.416472
 
 Test 082 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2777,37 +2777,37 @@ Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 380.351418
+ 0: The total amount of wall time                        = 379.032799
 
 Test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/hafs_regional_atm
 Checking test 084 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 257.954180
+  0: The total amount of wall time                        = 303.583803
 
 Test 084 hafs_regional_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/hafs_regional_atm_ocn
 Checking test 085 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 377.273525
+  0: The total amount of wall time                        = 429.888971
 
 Test 085 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/hafs_regional_docn
 Checking test 086 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2815,13 +2815,13 @@ Checking test 086 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 334.176157
+  0: The total amount of wall time                        = 399.354480
 
 Test 086 hafs_regional_docn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/hafs_regional_docn_oisst
 Checking test 087 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2829,97 +2829,97 @@ Checking test 087 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 324.310658
+  0: The total amount of wall time                        = 396.781351
 
 Test 087 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/hafs_regional_datm_cdeps
 Checking test 088 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1031.793791
+  0: The total amount of wall time                        = 1194.440411
 
 Test 088 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_control_cfsr
 Checking test 089 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 95.862433
+  0: The total amount of wall time                        = 95.713959
 
 Test 089 datm_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_restart_cfsr
 Checking test 090 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 52.973761
+  0: The total amount of wall time                        = 53.779190
 
 Test 090 datm_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_control_gefs
 Checking test 091 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 90.095427
+  0: The total amount of wall time                        = 88.372469
 
 Test 091 datm_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_iau_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_control_iau_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_control_iau_gefs
 Checking test 092 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 95.146615
+  0: The total amount of wall time                        = 89.327511
 
 Test 092 datm_control_iau_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 90.373993
+  0: The total amount of wall time                        = 92.013540
 
 Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.784122
+  0: The total amount of wall time                        = 86.961483
 
 Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_mx025_gefs
 Checking test 095 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2928,85 +2928,85 @@ Checking test 095 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 329.837922
+  0: The total amount of wall time                        = 332.350502
 
 Test 095 datm_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_debug_cfsr
 Checking test 096 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 216.757076
+  0: The total amount of wall time                        = 273.000978
 
 Test 096 datm_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_control_cfsr
 Checking test 097 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.264057
+ 0: The total amount of wall time                        = 147.980342
 
 Test 097 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_restart_cfsr
 Checking test 098 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 84.269935
+ 0: The total amount of wall time                        = 84.714542
 
 Test 098 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_control_gefs
 Checking test 099 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.679541
+ 0: The total amount of wall time                        = 145.105182
 
 Test 099 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_bulk_cfsr
 Checking test 100 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.537527
+ 0: The total amount of wall time                        = 146.328596
 
 Test 100 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_bulk_gefs
 Checking test 101 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.936750
+ 0: The total amount of wall time                        = 142.105683
 
 Test 101 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_mx025_cfsr
 Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3015,13 +3015,13 @@ Checking test 102 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 331.999744
+  0: The total amount of wall time                        = 330.232369
 
 Test 102 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_mx025_gefs
 Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3030,35 +3030,35 @@ Checking test 103 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 326.113907
+  0: The total amount of wall time                        = 327.746861
 
 Test 103 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_multiple_files_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_multiple_files_cfsr
 Checking test 104 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.637741
+ 0: The total amount of wall time                        = 148.005381
 
 Test 104 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/datm_cdeps_debug_cfsr
 Checking test 105 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 361.111743
+ 0: The total amount of wall time                        = 360.351547
 
 Test 105 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_atmwav
 Checking test 106 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3102,13 +3102,13 @@ Checking test 106 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 139.810177
+  0: The total amount of wall time                        = 139.063479
 
 Test 106 control_atmwav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_23230/control_c384gdas_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2294/control_c384gdas_wav
 Checking test 107 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3154,11 +3154,11 @@ Checking test 107 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 832.853376
+  0: The total amount of wall time                        = 842.511414
 
 Test 107 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 16:09:38 EDT 2021
-Elapsed time: 01h:51m:10s. Have a nice day!
+Wed Aug 18 20:26:16 EDT 2021
+Elapsed time: 01h:07m:15s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,17 @@
-Wed Aug 18 15:34:01 UTC 2021
+Wed Aug 18 21:27:00 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 179 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 185 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 101 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 199 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 123 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 008 elapsed time 102 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_GFS_v16_thompson,FV3_RRFS_v1alpha,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 172 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 181 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 88 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 195 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 105 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 008 elapsed time 93 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,13 +58,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 904.682019
+  0: The total amount of wall time                        = 824.358860
 
 Test 001 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,13 +103,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 386.196342
+  0: The total amount of wall time                        = 403.097903
 
 Test 002 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,13 +148,13 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 683.542319
+0: The total amount of wall time                        = 677.675743
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -165,13 +165,13 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 654.515247
+  0: The total amount of wall time                        = 646.632143
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -182,13 +182,13 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1454.929036
+  0: The total amount of wall time                        = 1400.575957
 
 Test 005 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -199,13 +199,13 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 970.954094
+  0: The total amount of wall time                        = 871.267687
 
 Test 006 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -216,13 +216,13 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1090.126899
+  0: The total amount of wall time                        = 993.168985
 
 Test 007 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -233,13 +233,13 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1063.796073
+  0: The total amount of wall time                        = 1009.039594
 
 Test 008 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_ugwpv1
 Checking test 009 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -250,13 +250,13 @@ Checking test 009 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1247.114566
+  0: The total amount of wall time                        = 957.264601
 
 Test 009 control_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_ras
 Checking test 010 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -267,13 +267,13 @@ Checking test 010 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 906.653370
+  0: The total amount of wall time                        = 821.724713
 
 Test 010 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_gsd
 Checking test 011 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -362,13 +362,13 @@ Checking test 011 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1223.145246
+  0: The total amount of wall time                        = 1019.840701
 
 Test 011 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_rrfs_v1alpha
 Checking test 012 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -433,13 +433,13 @@ Checking test 012 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 673.864695
+  0: The total amount of wall time                        = 379.551410
 
 Test 012 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_rrfs_v1beta
 Checking test 013 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -504,13 +504,13 @@ Checking test 013 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 394.359207
+  0: The total amount of wall time                        = 358.368302
 
 Test 013 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_HAFS_v0_hwrf_thompson
 Checking test 014 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -575,13 +575,13 @@ Checking test 014 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 737.075181
+  0: The total amount of wall time                        = 638.538067
 
 Test 014 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 015 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -596,39 +596,39 @@ Checking test 015 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 469.434869
+ 0: The total amount of wall time                        = 450.414358
 
 Test 015 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_debug
 Checking test 016 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 108.658544
+  0: The total amount of wall time                        = 100.525852
 
 Test 016 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_diag_debug
 Checking test 017 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 125.106514
+  0: The total amount of wall time                        = 123.209235
 
 Test 017 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/regional_control_debug
 Checking test 018 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -636,13 +636,13 @@ Checking test 018 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 134.064354
+ 0: The total amount of wall time                        = 117.798367
 
 Test 018 regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_rrfs_v1alpha_debug
 Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -707,13 +707,13 @@ Checking test 019 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.621467
+  0: The total amount of wall time                        = 113.990597
 
 Test 019 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_rrfs_v1beta_debug
 Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -778,13 +778,13 @@ Checking test 020 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.797283
+  0: The total amount of wall time                        = 115.283340
 
 Test 020 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_gsd_debug
 Checking test 021 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -849,13 +849,13 @@ Checking test 021 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 149.325552
+  0: The total amount of wall time                        = 143.656474
 
 Test 021 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_gsd_diag_debug
 Checking test 022 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -882,104 +882,104 @@ Checking test 022 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 483.551892
+  0: The total amount of wall time                        = 510.050979
 
 Test 022 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_thompson_debug
 Checking test 023 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 112.514467
+  0: The total amount of wall time                        = 120.079716
 
 Test 023 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_thompson_no_aero_debug
 Checking test 024 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 109.498969
+  0: The total amount of wall time                        = 107.743591
 
 Test 024 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_thompson_extdiag_debug
 Checking test 025 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 128.843685
+  0: The total amount of wall time                        = 145.507590
 
 Test 025 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_rrtmgp_debug
 Checking test 026 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.321339
+  0: The total amount of wall time                        = 105.847124
 
 Test 026 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_ugwpv1_debug
 Checking test 027 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.418119
+  0: The total amount of wall time                        = 105.872676
 
 Test 027 control_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_ras_debug
 Checking test 028 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.041344
+  0: The total amount of wall time                        = 104.442798
 
 Test 028 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/control_noahmp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/control_noahmp_debug
 Checking test 029 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 99.515025
+  0: The total amount of wall time                        = 98.947465
 
 Test 029 control_noahmp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 030 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1044,13 +1044,13 @@ Checking test 030 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.200877
+  0: The total amount of wall time                        = 135.481154
 
 Test 030 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1065,13 +1065,13 @@ Checking test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 234.835170
+ 0: The total amount of wall time                        = 230.888853
 
 Test 031 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/cpld_control
 Checking test 032 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1121,13 +1121,13 @@ Checking test 032 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 668.511050
+  0: The total amount of wall time                        = 623.224875
 
 Test 032 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/GNU/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_16745/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_28669/cpld_debug
 Checking test 033 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1177,11 +1177,11 @@ Checking test 033 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.639142
+  0: The total amount of wall time                        = 347.995293
 
 Test 033 cpld_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Aug 18 16:07:34 UTC 2021
-Elapsed time: 00h:33m:33s. Have a nice day!
+Wed Aug 18 22:56:52 UTC 2021
+Elapsed time: 01h:29m:52s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,29 +1,29 @@
-Wed Aug 18 15:17:48 UTC 2021
+Wed Aug 18 21:26:09 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 593 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 640 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 177 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 569 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 617 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 549 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 543 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 552 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 171 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 171 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 140 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 265 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 594 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 593 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 175 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 113 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 176 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 123 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 529 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 624 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 597 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 776 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 229 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 733 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 607 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 768 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 595 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 622 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 444 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 262 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 294 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 678 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1142 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 538 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 327 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 599 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 174 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 526 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 677 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -73,13 +73,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 93.179533
+  0: The total amount of wall time                        = 85.927383
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -129,13 +129,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 75.259632
+  0: The total amount of wall time                        = 54.151691
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -185,13 +185,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 133.132700
+  0: The total amount of wall time                        = 96.632885
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -241,13 +241,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 89.746211
+  0: The total amount of wall time                        = 82.809221
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_ca
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -297,13 +297,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 121.227653
+  0: The total amount of wall time                        = 100.947490
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -353,13 +353,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 476.509171
+  0: The total amount of wall time                        = 368.663267
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_restart_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 311.371326
+  0: The total amount of wall time                        = 263.136807
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -468,13 +468,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 827.388807
+  0: The total amount of wall time                        = 757.523485
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_restart_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -527,13 +527,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 475.158673
+  0: The total amount of wall time                        = 463.017363
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -576,13 +576,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 646.061420
+  0: The total amount of wall time                        = 580.627990
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_restart_bmark_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -625,13 +625,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 401.480465
+  0: The total amount of wall time                        = 370.288695
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16_nsst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_bmark_v16_nsst
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -674,13 +674,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 656.984174
+  0: The total amount of wall time                        = 601.324243
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_bmark_wave_v16
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -725,13 +725,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 646.843818
+  0: The total amount of wall time                        = 631.972180
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_bmark_wave_v16_p7b
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -776,13 +776,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 715.894765
+  0: The total amount of wall time                        = 679.652934
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_wave
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_control_wave
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -835,13 +835,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 369.212984
+  0: The total amount of wall time                        = 98.722985
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/cpld_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -891,13 +891,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 269.340485
+  0: The total amount of wall time                        = 269.226148
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -944,13 +944,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 152.899235
+  0: The total amount of wall time                        = 149.606252
 
 Test 017 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -993,13 +993,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.182666
+  0: The total amount of wall time                        = 156.310476
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1042,13 +1042,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 207.756604
+ 0: The total amount of wall time                        = 160.900663
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1087,13 +1087,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 262.287290
+  0: The total amount of wall time                        = 64.384781
 
 Test 020 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_fhzero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1136,13 +1136,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.023461
+  0: The total amount of wall time                        = 150.128924
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1169,13 +1169,13 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 118.369911
+  0: The total amount of wall time                        = 115.364697
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1186,13 +1186,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.723237
+  0: The total amount of wall time                        = 181.364408
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1231,13 +1231,13 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 307.324688
+0: The total amount of wall time                        = 307.953258
 
 Test 024 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1248,13 +1248,13 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 523.480757
+  0: The total amount of wall time                        = 467.432318
 
 Test 025 control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1265,13 +1265,13 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 859.465356
+  0: The total amount of wall time                        = 788.132216
 
 Test 026 control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1314,13 +1314,13 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 729.357711
+  0: The total amount of wall time                        = 633.196326
 
 Test 027 control_c384gdas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1331,26 +1331,26 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 108.990340
+  0: The total amount of wall time                        = 104.464470
 
 Test 028 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_stochy_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 265.922842
+  0: The total amount of wall time                        = 53.813987
 
 Test 029 control_stochy_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ca
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ca
 Checking test 030 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1361,13 +1361,13 @@ Checking test 030 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 104.856907
+  0: The total amount of wall time                        = 108.987208
 
 Test 030 control_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1378,13 +1378,13 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 110.615786
+  0: The total amount of wall time                        = 105.242465
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_lheatstrg
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_lheatstrg
 Checking test 032 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1395,13 +1395,13 @@ Checking test 032 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 191.286430
+  0: The total amount of wall time                        = 146.904878
 
 Test 032 control_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lseaspray
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_lseaspray
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_lseaspray
 Checking test 033 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1412,13 +1412,13 @@ Checking test 033 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 188.447859
+  0: The total amount of wall time                        = 154.436688
 
 Test 033 control_lseaspray PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_merra2
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_merra2
 Checking test 034 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1429,13 +1429,13 @@ Checking test 034 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 203.255419
+  0: The total amount of wall time                        = 176.584650
 
 Test 034 control_merra2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1446,13 +1446,13 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 228.827740
+  0: The total amount of wall time                        = 198.880850
 
 Test 035 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_csawmg
 Checking test 036 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1463,13 +1463,13 @@ Checking test 036 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 302.526700
+  0: The total amount of wall time                        = 265.561268
 
 Test 036 control_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_csawmgt
 Checking test 037 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1480,13 +1480,13 @@ Checking test 037 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 365.677500
+  0: The total amount of wall time                        = 328.009768
 
 Test 037 control_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_flake
 Checking test 038 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1497,13 +1497,13 @@ Checking test 038 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 237.349175
+  0: The total amount of wall time                        = 238.033414
 
 Test 038 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ugwpv1
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ugwpv1
 Checking test 039 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1514,13 +1514,13 @@ Checking test 039 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 218.345618
+  0: The total amount of wall time                        = 179.800405
 
 Test 039 control_ugwpv1 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1531,13 +1531,13 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 217.844785
+  0: The total amount of wall time                        = 175.305975
 
 Test 040 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_thompson
 Checking test 041 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1548,13 +1548,13 @@ Checking test 041 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 223.713100
+  0: The total amount of wall time                        = 205.089792
 
 Test 041 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_thompson_no_aero
 Checking test 042 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1565,13 +1565,13 @@ Checking test 042 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 209.957323
+  0: The total amount of wall time                        = 198.384085
 
 Test 042 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_noahmp
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_noahmp
 Checking test 043 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1582,13 +1582,13 @@ Checking test 043 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 394.944085
+  0: The total amount of wall time                        = 176.512957
 
 Test 043 control_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_control
 Checking test 044 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1596,25 +1596,25 @@ Checking test 044 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 307.605154
+ 0: The total amount of wall time                        = 282.984866
 
 Test 044 regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_restart
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_restart
 Checking test 045 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 161.278211
+ 0: The total amount of wall time                        = 155.753169
 
 Test 045 regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_quilt
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_quilt
 Checking test 046 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1625,13 +1625,13 @@ Checking test 046 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 307.496863
+ 0: The total amount of wall time                        = 293.879917
 
 Test 046 regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_quilt_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_quilt_2threads
 Checking test 047 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1642,13 +1642,13 @@ Checking test 047 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 210.644805
+ 0: The total amount of wall time                        = 208.655212
 
 Test 047 regional_quilt_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_quilt_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_quilt_hafs
 Checking test 048 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1657,13 +1657,13 @@ Checking test 048 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 309.148264
+ 0: The total amount of wall time                        = 290.584487
 
 Test 048 regional_quilt_hafs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_quilt_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_quilt_netcdf_parallel
 Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
@@ -1671,13 +1671,13 @@ Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 300.854248
+ 0: The total amount of wall time                        = 292.891745
 
 Test 049 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_quilt_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_quilt_RRTMGP
 Checking test 050 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1688,13 +1688,13 @@ Checking test 050 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 392.725059
+ 0: The total amount of wall time                        = 387.882754
 
 Test 050 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_gsd
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_gsd
 Checking test 051 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1783,13 +1783,13 @@ Checking test 051 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 218.311591
+  0: The total amount of wall time                        = 222.058278
 
 Test 051 fv3_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_rrfs_v1alpha
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_rrfs_v1alpha
 Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1854,13 +1854,13 @@ Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 107.449701
+  0: The total amount of wall time                        = 86.159901
 
 Test 052 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rap
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_rap
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_rap
 Checking test 053 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1925,13 +1925,13 @@ Checking test 053 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 96.420318
+  0: The total amount of wall time                        = 85.106558
 
 Test 053 fv3_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_hrrr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_hrrr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_hrrr
 Checking test 054 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1996,13 +1996,13 @@ Checking test 054 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.543204
+  0: The total amount of wall time                        = 84.472672
 
 Test 054 fv3_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_rrfs_v1beta
 Checking test 055 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2067,13 +2067,13 @@ Checking test 055 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 89.234157
+  0: The total amount of wall time                        = 86.358701
 
 Test 055 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2138,13 +2138,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.995914
+  0: The total amount of wall time                        = 142.058154
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2159,39 +2159,39 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 282.877512
+ 0: The total amount of wall time                        = 292.365270
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_debug
 Checking test 058 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 140.643366
+  0: The total amount of wall time                        = 142.990948
 
 Test 058 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_2threads_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_2threads_debug
 Checking test 059 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 206.648914
+ 0: The total amount of wall time                        = 207.117427
 
 Test 059 control_2threads_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_CubedSphereGrid_debug
 Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2218,221 +2218,221 @@ Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.182553
+  0: The total amount of wall time                        = 150.347976
 
 Test 060 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_wrtGauss_netcdf_parallel_debug
 Checking test 061 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 145.301508
+  0: The total amount of wall time                        = 145.896888
 
 Test 061 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_stochy_debug
 Checking test 062 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.799568
+  0: The total amount of wall time                        = 161.324995
 
 Test 062 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ca_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ca_debug
 Checking test 063 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 143.609585
+  0: The total amount of wall time                        = 146.589284
 
 Test 063 control_ca_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.969510
+  0: The total amount of wall time                        = 144.440469
 
 Test 064 control_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_lheatstrg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_lheatstrg_debug
 Checking test 065 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 140.895144
+  0: The total amount of wall time                        = 143.656396
 
 Test 065 control_lheatstrg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_merra2_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_merra2_debug
 Checking test 066 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 196.632029
+  0: The total amount of wall time                        = 198.076375
 
 Test 066 control_merra2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_rrtmgp_debug
 Checking test 067 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.091652
+  0: The total amount of wall time                        = 168.451608
 
 Test 067 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_csawmg_debug
 Checking test 068 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 229.147499
+  0: The total amount of wall time                        = 231.865587
 
 Test 068 control_csawmg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_csawmgt_debug
 Checking test 069 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.545133
+  0: The total amount of wall time                        = 261.399220
 
 Test 069 control_csawmgt_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ugwpv1_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ugwpv1_debug
 Checking test 070 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.952215
+  0: The total amount of wall time                        = 153.922184
 
 Test 070 control_ugwpv1_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.329149
+  0: The total amount of wall time                        = 145.542326
 
 Test 071 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_noahmp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_noahmp_debug
 Checking test 072 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.672205
+  0: The total amount of wall time                        = 142.541838
 
 Test 072 control_noahmp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.673713
+  0: The total amount of wall time                        = 152.898063
 
 Test 073 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.972517
+  0: The total amount of wall time                        = 164.668419
 
 Test 074 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.578481
+  0: The total amount of wall time                        = 160.385227
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.037454
+  0: The total amount of wall time                        = 178.120637
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/regional_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/regional_control_debug
 Checking test 077 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2440,13 +2440,13 @@ Checking test 077 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 227.871072
+ 0: The total amount of wall time                        = 229.468640
 
 Test 077 regional_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_gsd_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_gsd_debug
 Checking test 078 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2511,13 +2511,13 @@ Checking test 078 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 246.581543
+  0: The total amount of wall time                        = 238.474038
 
 Test 078 fv3_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_gsd_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_gsd_diag_debug
 Checking test 079 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2544,13 +2544,13 @@ Checking test 079 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 692.051450
+  0: The total amount of wall time                        = 520.805174
 
 Test 079 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_rrfs_v1beta_debug
 Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2615,13 +2615,13 @@ Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.585531
+  0: The total amount of wall time                        = 196.037376
 
 Test 080 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_rrfs_v1alpha_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_rrfs_v1alpha_debug
 Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2686,13 +2686,13 @@ Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.589237
+  0: The total amount of wall time                        = 201.041323
 
 Test 081 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2757,13 +2757,13 @@ Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.132765
+  0: The total amount of wall time                        = 198.900806
 
 Test 082 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2778,37 +2778,37 @@ Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 391.789128
+ 0: The total amount of wall time                        = 393.622843
 
 Test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/hafs_regional_atm
 Checking test 084 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 227.684661
+  0: The total amount of wall time                        = 219.970734
 
 Test 084 hafs_regional_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/hafs_regional_atm_ocn
 Checking test 085 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 333.022832
+  0: The total amount of wall time                        = 343.913749
 
 Test 085 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/hafs_regional_docn
 Checking test 086 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2816,13 +2816,13 @@ Checking test 086 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 369.507093
+  0: The total amount of wall time                        = 303.521607
 
 Test 086 hafs_regional_docn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/hafs_regional_docn_oisst
 Checking test 087 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2830,97 +2830,97 @@ Checking test 087 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 301.833280
+  0: The total amount of wall time                        = 313.191955
 
 Test 087 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/hafs_regional_datm_cdeps
 Checking test 088 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 995.282259
+  0: The total amount of wall time                        = 952.596305
 
 Test 088 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_control_cfsr
 Checking test 089 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 96.265898
+  0: The total amount of wall time                        = 94.318224
 
 Test 089 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_restart_cfsr
 Checking test 090 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 69.243271
+  0: The total amount of wall time                        = 69.982036
 
 Test 090 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_control_gefs
 Checking test 091 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 100.438991
+  0: The total amount of wall time                        = 89.381859
 
 Test 091 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_iau_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_control_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_control_iau_gefs
 Checking test 092 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 100.200781
+  0: The total amount of wall time                        = 88.113626
 
 Test 092 datm_control_iau_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 98.257890
+  0: The total amount of wall time                        = 89.399564
 
 Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 87.769111
+  0: The total amount of wall time                        = 87.522206
 
 Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_mx025_cfsr
 Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2929,13 +2929,13 @@ Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 316.346104
+  0: The total amount of wall time                        = 314.721883
 
 Test 095 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_mx025_gefs
 Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2944,85 +2944,85 @@ Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 314.290761
+  0: The total amount of wall time                        = 308.126299
 
 Test 096 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_debug_cfsr
 Checking test 097 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 262.620947
+  0: The total amount of wall time                        = 254.355594
 
 Test 097 datm_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_control_cfsr
 Checking test 098 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.540088
+ 0: The total amount of wall time                        = 150.634485
 
 Test 098 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_restart_cfsr
 Checking test 099 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.085349
+ 0: The total amount of wall time                        = 85.614916
 
 Test 099 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_control_gefs
 Checking test 100 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.580894
+ 0: The total amount of wall time                        = 143.031015
 
 Test 100 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_bulk_cfsr
 Checking test 101 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 158.798376
+ 0: The total amount of wall time                        = 146.949261
 
 Test 101 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_bulk_gefs
 Checking test 102 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.132521
+ 0: The total amount of wall time                        = 139.663349
 
 Test 102 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_mx025_cfsr
 Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3031,13 +3031,13 @@ Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 314.946797
+  0: The total amount of wall time                        = 306.637420
 
 Test 103 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_mx025_gefs
 Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3046,35 +3046,35 @@ Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 313.979657
+  0: The total amount of wall time                        = 306.456752
 
 Test 104 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_multiple_files_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_multiple_files_cfsr
 Checking test 105 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 157.395486
+ 0: The total amount of wall time                        = 154.275713
 
 Test 105 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/datm_cdeps_debug_cfsr
 Checking test 106 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 471.510118
+ 0: The total amount of wall time                        = 437.002762
 
 Test 106 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_atmwav
 Checking test 107 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3118,13 +3118,13 @@ Checking test 107 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 167.132306
+  0: The total amount of wall time                        = 137.170425
 
 Test 107 control_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_c384gdas_wav
 Checking test 108 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3170,13 +3170,13 @@ Checking test 108 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 713.559328
+  0: The total amount of wall time                        = 648.688958
 
 Test 108 control_c384gdas_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_2327/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_139486/control_atm_aerosols
 Checking test 109 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3223,11 +3223,11 @@ Checking test 109 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 337.421439
+  0: The total amount of wall time                        = 290.854200
 
 Test 109 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Aug 18 16:11:24 UTC 2021
-Elapsed time: 00h:53m:37s. Have a nice day!
+Wed Aug 18 23:23:47 UTC 2021
+Elapsed time: 01h:57m:38s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,28 +1,28 @@
-Tue Aug 17 20:01:46 GMT 2021
+Wed Aug 18 23:16:33 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 2474 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 2532 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 228 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 2302 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 2394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 2299 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 007 elapsed time 2315 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 2380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 009 elapsed time 212 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 209 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 2333 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 2334 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 015 elapsed time 270 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 016 elapsed time 128 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 271 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 018 elapsed time 134 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 2308 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 2466 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2516 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 227 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 2293 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 2388 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 2330 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 007 elapsed time 2306 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 2328 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 009 elapsed time 227 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 204 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 205 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 2336 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 2361 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 255 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 016 elapsed time 131 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 263 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 018 elapsed time 128 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 2298 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -72,13 +72,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 123.419091
+  0: The total amount of wall time                        = 123.099628
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -128,13 +128,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 73.221051
+  0: The total amount of wall time                        = 68.582728
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -184,13 +184,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 569.137253
+  0: The total amount of wall time                        = 629.777676
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_ca
 Checking test 004 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -240,13 +240,13 @@ Checking test 004 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 121.689456
+  0: The total amount of wall time                        = 118.688258
 
 Test 004 cpld_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_control_c192
 Checking test 005 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -296,13 +296,13 @@ Checking test 005 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 531.556307
+  0: The total amount of wall time                        = 515.668703
 
 Test 005 cpld_control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_restart_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_restart_c192
 Checking test 006 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -352,13 +352,13 @@ Checking test 006 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 358.295706
+  0: The total amount of wall time                        = 358.652783
 
 Test 006 cpld_restart_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_control_c384
 Checking test 007 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -411,13 +411,13 @@ Checking test 007 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 614.905691
+  0: The total amount of wall time                        = 606.148939
 
 Test 007 cpld_control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_restart_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_restart_c384
 Checking test 008 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -470,13 +470,13 @@ Checking test 008 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 334.022488
+  0: The total amount of wall time                        = 354.505589
 
 Test 008 cpld_restart_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_bmark_v16
 Checking test 009 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -519,13 +519,13 @@ Checking test 009 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 829.707404
+  0: The total amount of wall time                        = 792.143748
 
 Test 009 cpld_bmark_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_restart_bmark_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_restart_bmark_v16
 Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -568,13 +568,13 @@ Checking test 010 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 442.595671
+  0: The total amount of wall time                        = 449.714071
 
 Test 010 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16_nsst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_bmark_v16_nsst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_bmark_v16_nsst
 Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -617,13 +617,13 @@ Checking test 011 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 810.865091
+  0: The total amount of wall time                        = 797.144285
 
 Test 011 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_bmark_wave_v16
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_bmark_wave_v16
 Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -668,13 +668,13 @@ Checking test 012 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1059.689996
+  0: The total amount of wall time                        = 1007.167863
 
 Test 012 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_bmark_wave_v16_p7b
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_bmark_wave_v16_p7b
 Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -719,13 +719,13 @@ Checking test 013 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1107.508809
+  0: The total amount of wall time                        = 1101.608447
 
 Test 013 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_wave
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_control_wave
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_control_wave
 Checking test 014 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -778,13 +778,13 @@ Checking test 014 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 1015.814740
+  0: The total amount of wall time                        = 983.125377
 
 Test 014 cpld_control_wave PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/cpld_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/cpld_debug
 Checking test 015 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -834,13 +834,13 @@ Checking test 015 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.353808
+  0: The total amount of wall time                        = 362.717334
 
 Test 015 cpld_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -887,13 +887,13 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.976179
+  0: The total amount of wall time                        = 202.723792
 
 Test 016 control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_decomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -936,13 +936,13 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 207.770990
+  0: The total amount of wall time                        = 208.354751
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -985,13 +985,13 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 833.727990
+ 0: The total amount of wall time                        = 737.248393
 
 Test 018 control_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1030,13 +1030,13 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 86.534767
+  0: The total amount of wall time                        = 87.158690
 
 Test 019 control_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_fhzero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1079,13 +1079,13 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 202.667299
+  0: The total amount of wall time                        = 202.251460
 
 Test 020 control_fhzero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1112,13 +1112,13 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 162.235021
+  0: The total amount of wall time                        = 158.278309
 
 Test 021 control_CubedSphereGrid PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1129,13 +1129,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 246.363016
+  0: The total amount of wall time                        = 255.427272
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1174,13 +1174,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 530.177792
+0: The total amount of wall time                        = 534.445106
 
 Test 023 control_c48 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,13 +1191,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 652.824583
+  0: The total amount of wall time                        = 641.325017
 
 Test 024 control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1208,13 +1208,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 838.143813
+  0: The total amount of wall time                        = 832.767351
 
 Test 025 control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1257,13 +1257,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 731.486699
+  0: The total amount of wall time                        = 722.888471
 
 Test 026 control_c384gdas PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1274,26 +1274,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 144.758450
+  0: The total amount of wall time                        = 143.270198
 
 Test 027 control_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_stochy_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 74.668162
+  0: The total amount of wall time                        = 74.837565
 
 Test 028 control_stochy_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ca
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ca
 Checking test 029 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1304,13 +1304,13 @@ Checking test 029 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 144.342758
+  0: The total amount of wall time                        = 142.418271
 
 Test 029 control_ca PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1321,13 +1321,13 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 146.846906
+  0: The total amount of wall time                        = 145.298082
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_lheatstrg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_lheatstrg
 Checking test 031 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1338,13 +1338,13 @@ Checking test 031 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 202.850697
+  0: The total amount of wall time                        = 203.321019
 
 Test 031 control_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lseaspray
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_lseaspray
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_lseaspray
 Checking test 032 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1355,13 +1355,13 @@ Checking test 032 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 216.430102
+  0: The total amount of wall time                        = 212.619269
 
 Test 032 control_lseaspray PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_merra2
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_merra2
 Checking test 033 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1372,13 +1372,13 @@ Checking test 033 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 236.636683
+  0: The total amount of wall time                        = 232.869764
 
 Test 033 control_merra2 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_rrtmgp
 Checking test 034 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1389,13 +1389,13 @@ Checking test 034 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 262.365803
+  0: The total amount of wall time                        = 260.825890
 
 Test 034 control_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_csawmg
 Checking test 035 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1406,13 +1406,13 @@ Checking test 035 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 346.364283
+  0: The total amount of wall time                        = 348.342797
 
 Test 035 control_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_csawmgt
 Checking test 036 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1423,13 +1423,13 @@ Checking test 036 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 429.034532
+  0: The total amount of wall time                        = 423.332917
 
 Test 036 control_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_flake
 Checking test 037 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1440,13 +1440,13 @@ Checking test 037 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 289.286295
+  0: The total amount of wall time                        = 284.815859
 
 Test 037 control_flake PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ugwpv1
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ugwpv1
 Checking test 038 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1457,13 +1457,13 @@ Checking test 038 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 253.231966
+  0: The total amount of wall time                        = 250.973312
 
 Test 038 control_ugwpv1 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ras
 Checking test 039 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1474,13 +1474,13 @@ Checking test 039 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 243.098652
+  0: The total amount of wall time                        = 241.723984
 
 Test 039 control_ras PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_thompson
 Checking test 040 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1491,13 +1491,13 @@ Checking test 040 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 278.431696
+  0: The total amount of wall time                        = 274.435889
 
 Test 040 control_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_thompson_no_aero
 Checking test 041 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1508,13 +1508,13 @@ Checking test 041 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 271.934942
+  0: The total amount of wall time                        = 280.656139
 
 Test 041 control_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_noahmp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_noahmp
 Checking test 042 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1525,13 +1525,13 @@ Checking test 042 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 234.893309
+  0: The total amount of wall time                        = 237.114951
 
 Test 042 control_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_control
 Checking test 043 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1539,25 +1539,25 @@ Checking test 043 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 418.087643
+ 0: The total amount of wall time                        = 416.596846
 
 Test 043 regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_restart
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_restart
 Checking test 044 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 226.256066
+ 0: The total amount of wall time                        = 227.849795
 
 Test 044 regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_quilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_quilt
 Checking test 045 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1568,13 +1568,13 @@ Checking test 045 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 412.240725
+ 0: The total amount of wall time                        = 412.518799
 
 Test 045 regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_quilt_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_quilt_hafs
 Checking test 046 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,27 +1583,27 @@ Checking test 046 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 430.265752
+ 0: The total amount of wall time                        = 410.234192
 
 Test 046 regional_quilt_hafs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_quilt_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_quilt_netcdf_parallel
 Checking test 047 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 430.332377
+ 0: The total amount of wall time                        = 411.731098
 
 Test 047 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_quilt_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_quilt_RRTMGP
 Checking test 048 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1614,13 +1614,13 @@ Checking test 048 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 547.274481
+ 0: The total amount of wall time                        = 530.208014
 
 Test 048 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_gsd
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_gsd
 Checking test 049 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1709,13 +1709,13 @@ Checking test 049 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 301.886141
+  0: The total amount of wall time                        = 317.609280
 
 Test 049 fv3_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_rrfs_v1alpha
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_rrfs_v1alpha
 Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1780,13 +1780,13 @@ Checking test 050 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 119.068050
+  0: The total amount of wall time                        = 125.240135
 
 Test 050 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rap
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_rap
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_rap
 Checking test 051 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1851,13 +1851,13 @@ Checking test 051 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.461751
+  0: The total amount of wall time                        = 126.787700
 
 Test 051 fv3_rap PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_hrrr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_hrrr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_hrrr
 Checking test 052 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1922,13 +1922,13 @@ Checking test 052 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.887757
+  0: The total amount of wall time                        = 126.958969
 
 Test 052 fv3_hrrr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_rrfs_v1beta
 Checking test 053 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1993,13 +1993,13 @@ Checking test 053 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.352994
+  0: The total amount of wall time                        = 129.507024
 
 Test 053 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_HAFS_v0_hwrf_thompson
 Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2064,13 +2064,13 @@ Checking test 054 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.481494
+  0: The total amount of wall time                        = 197.064501
 
 Test 054 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2085,39 +2085,39 @@ Checking test 055 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 364.332275
+ 0: The total amount of wall time                        = 362.839457
 
 Test 055 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_debug
 Checking test 056 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 187.380180
+  0: The total amount of wall time                        = 189.529161
 
 Test 056 control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_2threads_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_2threads_debug
 Checking test 057 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 364.698665
+ 0: The total amount of wall time                        = 362.703070
 
 Test 057 control_2threads_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_CubedSphereGrid_debug
 Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2144,221 +2144,221 @@ Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.839139
+  0: The total amount of wall time                        = 202.918389
 
 Test 058 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_wrtGauss_netcdf_parallel_debug
 Checking test 059 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.591038
+  0: The total amount of wall time                        = 191.644310
 
 Test 059 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_stochy_debug
 Checking test 060 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.911915
+  0: The total amount of wall time                        = 214.199786
 
 Test 060 control_stochy_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ca_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ca_debug
 Checking test 061 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.105111
+  0: The total amount of wall time                        = 190.351903
 
 Test 061 control_ca_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_lndp_debug
 Checking test 062 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.032978
+  0: The total amount of wall time                        = 192.780455
 
 Test 062 control_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_lheatstrg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_lheatstrg_debug
 Checking test 063 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.176015
+  0: The total amount of wall time                        = 189.300395
 
 Test 063 control_lheatstrg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_merra2_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_merra2_debug
 Checking test 064 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.712353
+  0: The total amount of wall time                        = 260.197356
 
 Test 064 control_merra2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_rrtmgp_debug
 Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 212.808464
+  0: The total amount of wall time                        = 214.946307
 
 Test 065 control_rrtmgp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_csawmg_debug
 Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 312.534733
+  0: The total amount of wall time                        = 311.849374
 
 Test 066 control_csawmg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_csawmgt_debug
 Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 353.830438
+  0: The total amount of wall time                        = 351.115405
 
 Test 067 control_csawmgt_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ugwpv1_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ugwpv1_debug
 Checking test 068 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 204.210077
+  0: The total amount of wall time                        = 204.540237
 
 Test 068 control_ugwpv1_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_ras_debug
 Checking test 069 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.033335
+  0: The total amount of wall time                        = 194.616048
 
 Test 069 control_ras_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_noahmp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_noahmp_debug
 Checking test 070 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.303508
+  0: The total amount of wall time                        = 187.142348
 
 Test 070 control_noahmp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_diag_debug
 Checking test 071 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.564797
+  0: The total amount of wall time                        = 204.994010
 
 Test 071 control_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_thompson_debug
 Checking test 072 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 222.316228
+  0: The total amount of wall time                        = 221.053608
 
 Test 072 control_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_thompson_no_aero_debug
 Checking test 073 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 211.189868
+  0: The total amount of wall time                        = 212.156440
 
 Test 073 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_thompson_extdiag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_thompson_extdiag_debug
 Checking test 074 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.791955
+  0: The total amount of wall time                        = 233.752108
 
 Test 074 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/regional_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/regional_control_debug
 Checking test 075 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2366,13 +2366,13 @@ Checking test 075 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 317.837618
+ 0: The total amount of wall time                        = 315.561214
 
 Test 075 regional_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_gsd_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_gsd_debug
 Checking test 076 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2437,13 +2437,13 @@ Checking test 076 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 317.290578
+  0: The total amount of wall time                        = 321.052972
 
 Test 076 fv3_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_gsd_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_gsd_diag_debug
 Checking test 077 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2470,13 +2470,13 @@ Checking test 077 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 558.724782
+  0: The total amount of wall time                        = 565.255123
 
 Test 077 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_rrfs_v1beta_debug
 Checking test 078 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2541,13 +2541,13 @@ Checking test 078 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.873457
+  0: The total amount of wall time                        = 255.181572
 
 Test 078 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_rrfs_v1alpha_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_rrfs_v1alpha_debug
 Checking test 079 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2612,13 +2612,13 @@ Checking test 079 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.179508
+  0: The total amount of wall time                        = 255.939426
 
 Test 079 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 080 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2683,13 +2683,13 @@ Checking test 080 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 266.157291
+  0: The total amount of wall time                        = 268.184612
 
 Test 080 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2704,37 +2704,37 @@ Checking test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 501.994888
+ 0: The total amount of wall time                        = 505.353251
 
 Test 081 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/hafs_regional_atm
 Checking test 082 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1037.369696
+  0: The total amount of wall time                        = 1063.852332
 
 Test 082 hafs_regional_atm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/hafs_regional_atm_ocn
 Checking test 083 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 442.366254
+  0: The total amount of wall time                        = 434.455242
 
 Test 083 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/hafs_regional_docn
 Checking test 084 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2742,13 +2742,13 @@ Checking test 084 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 411.689280
+  0: The total amount of wall time                        = 410.747255
 
 Test 084 hafs_regional_docn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/hafs_regional_docn_oisst
 Checking test 085 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2756,97 +2756,97 @@ Checking test 085 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 409.299836
+  0: The total amount of wall time                        = 412.061358
 
 Test 085 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/hafs_regional_datm_cdeps
 Checking test 086 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1217.111335
+  0: The total amount of wall time                        = 1215.867838
 
 Test 086 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_control_cfsr
 Checking test 087 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 128.205038
+  0: The total amount of wall time                        = 128.333393
 
 Test 087 datm_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_restart_cfsr
 Checking test 088 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 82.855232
+  0: The total amount of wall time                        = 79.392898
 
 Test 088 datm_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_control_gefs
 Checking test 089 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 122.214642
+  0: The total amount of wall time                        = 119.869050
 
 Test 089 datm_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_iau_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_control_iau_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_control_iau_gefs
 Checking test 090 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 121.096765
+  0: The total amount of wall time                        = 123.109489
 
 Test 090 datm_control_iau_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_bulk_cfsr
 Checking test 091 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 123.037189
+  0: The total amount of wall time                        = 125.544310
 
 Test 091 datm_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_bulk_gefs
 Checking test 092 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 119.564030
+  0: The total amount of wall time                        = 119.094709
 
 Test 092 datm_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_mx025_cfsr
 Checking test 093 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2855,13 +2855,13 @@ Checking test 093 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 412.457601
+  0: The total amount of wall time                        = 411.725699
 
 Test 093 datm_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_mx025_gefs
 Checking test 094 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2870,85 +2870,85 @@ Checking test 094 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 407.193024
+  0: The total amount of wall time                        = 409.438102
 
 Test 094 datm_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_debug_cfsr
 Checking test 095 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.611278
+  0: The total amount of wall time                        = 337.087446
 
 Test 095 datm_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_control_cfsr
 Checking test 096 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 198.301350
+ 0: The total amount of wall time                        = 194.745188
 
 Test 096 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_restart_cfsr
 Checking test 097 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 124.316753
+ 0: The total amount of wall time                        = 118.537276
 
 Test 097 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_control_gefs
 Checking test 098 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.725132
+ 0: The total amount of wall time                        = 190.469042
 
 Test 098 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_bulk_cfsr
 Checking test 099 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 197.405738
+ 0: The total amount of wall time                        = 196.793620
 
 Test 099 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_bulk_gefs
 Checking test 100 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.192462
+ 0: The total amount of wall time                        = 192.268833
 
 Test 100 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_mx025_cfsr
 Checking test 101 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2957,13 +2957,13 @@ Checking test 101 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 408.629206
+  0: The total amount of wall time                        = 410.550362
 
 Test 101 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_mx025_gefs
 Checking test 102 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2972,35 +2972,35 @@ Checking test 102 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 408.099827
+  0: The total amount of wall time                        = 405.149670
 
 Test 102 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_multiple_files_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_multiple_files_cfsr
 Checking test 103 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.240867
+ 0: The total amount of wall time                        = 193.851587
 
 Test 103 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/datm_cdeps_debug_cfsr
 Checking test 104 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 567.427743
+ 0: The total amount of wall time                        = 567.581046
 
 Test 104 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_265854/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_194331/control_atmwav
 Checking test 105 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3044,11 +3044,11 @@ Checking test 105 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 184.549790
+  0: The total amount of wall time                        = 189.788666
 
 Test 105 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 22:59:56 GMT 2021
-Elapsed time: 02h:58m:10s. Have a nice day!
+Thu Aug 19 02:23:59 GMT 2021
+Elapsed time: 03h:07m:26s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,28 +1,28 @@
-Tue Aug 17 14:59:53 CDT 2021
+Wed Aug 18 18:16:37 CDT 2021
 Start Regression test
 
-Compile 001 elapsed time 652 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 715 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 292 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 537 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 568 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 533 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 628 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 575 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 152 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 175 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 150 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 233 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 561 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 563 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 178 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 91 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 185 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 93 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 532 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 634 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 746 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 181 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 542 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 547 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 554 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 164 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 156 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 158 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 168 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 581 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 576 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 188 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 112 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 223 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 114 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 544 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -72,13 +72,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 96.972232
+  0: The total amount of wall time                        = 110.080227
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -128,13 +128,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 62.631158
+  0: The total amount of wall time                        = 66.409432
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -184,13 +184,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 104.009031
+  0: The total amount of wall time                        = 116.260773
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_decomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -240,13 +240,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 99.889929
+  0: The total amount of wall time                        = 110.499049
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_ca
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_ca
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -296,13 +296,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-  0: The total amount of wall time                        = 95.524215
+  0: The total amount of wall time                        = 100.907949
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -352,13 +352,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 369.960388
+  0: The total amount of wall time                        = 389.351849
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c192
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_restart_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-  0: The total amount of wall time                        = 264.710760
+  0: The total amount of wall time                        = 276.053830
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 752.151690
+  0: The total amount of wall time                        = 772.130848
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_c384
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_restart_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-  0: The total amount of wall time                        = 411.548703
+  0: The total amount of wall time                        = 423.728921
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_bmark_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -575,15 +575,62 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 633.230831
+  0: The total amount of wall time                        = 666.494637
 
 Test 010 cpld_bmark_v16 PASS
 
-Test 011 cpld_restart_bmark_v16 FAIL
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_restart_bmark_v16
+Checking test 011 cpld_restart_bmark_v16 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+
+  0: The total amount of wall time                        = 369.795412
+
+Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16_nsst
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_bmark_v16_nsst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -626,13 +673,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 624.815809
+  0: The total amount of wall time                        = 669.093433
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_bmark_wave_v16
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -677,13 +724,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 665.276728
+  0: The total amount of wall time                        = 683.791954
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_wave_v16_p7b
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_bmark_wave_v16_p7b
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -728,13 +775,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 758.648361
+  0: The total amount of wall time                        = 766.769661
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_control_wave
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_control_wave
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -787,13 +834,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 116.990545
+  0: The total amount of wall time                        = 121.677700
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/cpld_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -843,13 +890,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-  0: The total amount of wall time                        = 300.789802
+  0: The total amount of wall time                        = 314.244555
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -896,13 +943,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.810471
+  0: The total amount of wall time                        = 164.220786
 
 Test 017 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_decomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -945,13 +992,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.914016
+  0: The total amount of wall time                        = 168.259451
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -994,13 +1041,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 170.781201
+ 0: The total amount of wall time                        = 171.046349
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1039,13 +1086,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 68.483749
+  0: The total amount of wall time                        = 71.948258
 
 Test 020 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_fhzero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1088,13 +1135,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.929509
+  0: The total amount of wall time                        = 161.422654
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1121,13 +1168,13 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 122.955614
+  0: The total amount of wall time                        = 132.818715
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1138,13 +1185,13 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 194.365227
+  0: The total amount of wall time                        = 223.405280
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c48
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1183,13 +1230,13 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 306.955511
+0: The total amount of wall time                        = 306.341271
 
 Test 024 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c192
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1200,13 +1247,13 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 465.180895
+  0: The total amount of wall time                        = 473.113874
 
 Test 025 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1217,13 +1264,13 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 745.726319
+  0: The total amount of wall time                        = 763.913236
 
 Test 026 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1266,13 +1313,13 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 645.550420
+  0: The total amount of wall time                        = 634.872842
 
 Test 027 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1283,26 +1330,26 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 115.751225
+  0: The total amount of wall time                        = 121.335174
 
 Test 028 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_stochy_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 60.732732
+  0: The total amount of wall time                        = 87.401232
 
 Test 029 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ca
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ca
 Checking test 030 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1313,13 +1360,13 @@ Checking test 030 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 113.978717
+  0: The total amount of wall time                        = 116.964313
 
 Test 030 control_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1330,13 +1377,13 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 116.965381
+  0: The total amount of wall time                        = 122.142473
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_lheatstrg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_lheatstrg
 Checking test 032 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1347,13 +1394,13 @@ Checking test 032 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 156.800989
+  0: The total amount of wall time                        = 159.550524
 
 Test 032 control_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lseaspray
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_lseaspray
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_lseaspray
 Checking test 033 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1364,13 +1411,13 @@ Checking test 033 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 163.917403
+  0: The total amount of wall time                        = 166.790939
 
 Test 033 control_lseaspray PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_merra2
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_merra2
 Checking test 034 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,13 +1428,13 @@ Checking test 034 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 241.569750
+  0: The total amount of wall time                        = 235.911520
 
 Test 034 control_merra2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1398,13 +1445,13 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 202.063245
+  0: The total amount of wall time                        = 204.996586
 
 Test 035 control_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_csawmg
 Checking test 036 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1415,13 +1462,13 @@ Checking test 036 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 302.634258
+  0: The total amount of wall time                        = 305.155177
 
 Test 036 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_csawmgt
 Checking test 037 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1432,13 +1479,13 @@ Checking test 037 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 363.278442
+  0: The total amount of wall time                        = 362.142831
 
 Test 037 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_flake
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_flake
 Checking test 038 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1449,13 +1496,13 @@ Checking test 038 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 229.518432
+  0: The total amount of wall time                        = 232.775533
 
 Test 038 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ugwpv1
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ugwpv1
 Checking test 039 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1466,13 +1513,13 @@ Checking test 039 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 189.618536
+  0: The total amount of wall time                        = 192.156697
 
 Test 039 control_ugwpv1 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1483,13 +1530,13 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.199324
+  0: The total amount of wall time                        = 183.302514
 
 Test 040 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_thompson
 Checking test 041 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1500,13 +1547,13 @@ Checking test 041 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 206.775916
+  0: The total amount of wall time                        = 210.721951
 
 Test 041 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_thompson_no_aero
 Checking test 042 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1517,13 +1564,13 @@ Checking test 042 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 201.238386
+  0: The total amount of wall time                        = 228.797123
 
 Test 042 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_noahmp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_noahmp
 Checking test 043 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1534,13 +1581,13 @@ Checking test 043 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 176.404082
+  0: The total amount of wall time                        = 182.215027
 
 Test 043 control_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_control
 Checking test 044 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1548,25 +1595,25 @@ Checking test 044 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 290.641077
+ 0: The total amount of wall time                        = 290.257499
 
 Test 044 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_restart
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_restart
 Checking test 045 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
- 0: The total amount of wall time                        = 158.710180
+ 0: The total amount of wall time                        = 168.576774
 
 Test 045 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_quilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_quilt
 Checking test 046 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1577,13 +1624,13 @@ Checking test 046 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 304.966543
+ 0: The total amount of wall time                        = 304.221029
 
 Test 046 regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_quilt_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_quilt_2threads
 Checking test 047 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1594,13 +1641,13 @@ Checking test 047 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 216.022071
+ 0: The total amount of wall time                        = 213.707519
 
 Test 047 regional_quilt_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_hafs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_quilt_hafs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_quilt_hafs
 Checking test 048 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1609,13 +1656,13 @@ Checking test 048 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 302.710064
+ 0: The total amount of wall time                        = 302.158441
 
 Test 048 regional_quilt_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_netcdf_parallel
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_quilt_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_quilt_netcdf_parallel
 Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc ............ALT CHECK......OK
@@ -1623,13 +1670,13 @@ Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 306.371176
+ 0: The total amount of wall time                        = 305.269256
 
 Test 049 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_quilt_RRTMGP
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_quilt_RRTMGP
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_quilt_RRTMGP
 Checking test 050 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1640,13 +1687,13 @@ Checking test 050 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 393.310991
+ 0: The total amount of wall time                        = 393.619936
 
 Test 050 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_gsd
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_gsd
 Checking test 051 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1735,13 +1782,13 @@ Checking test 051 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.975311
+  0: The total amount of wall time                        = 231.877684
 
 Test 051 fv3_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_rrfs_v1alpha
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_rrfs_v1alpha
 Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1806,13 +1853,13 @@ Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 93.631119
+  0: The total amount of wall time                        = 98.368209
 
 Test 052 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rap
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_rap
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_rap
 Checking test 053 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1877,13 +1924,13 @@ Checking test 053 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.043242
+  0: The total amount of wall time                        = 94.639170
 
 Test 053 fv3_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_hrrr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_hrrr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_hrrr
 Checking test 054 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1948,13 +1995,13 @@ Checking test 054 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 90.407037
+  0: The total amount of wall time                        = 93.557990
 
 Test 054 fv3_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_rrfs_v1beta
 Checking test 055 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2019,13 +2066,13 @@ Checking test 055 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 94.928311
+  0: The total amount of wall time                        = 95.449035
 
 Test 055 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2090,13 +2137,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.262676
+  0: The total amount of wall time                        = 172.699536
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2111,39 +2158,39 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 290.929359
+ 0: The total amount of wall time                        = 288.931653
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_debug
 Checking test 058 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.416707
+  0: The total amount of wall time                        = 160.563467
 
 Test 058 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_2threads_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_2threads_debug
 Checking test 059 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 225.510807
+ 0: The total amount of wall time                        = 229.349991
 
 Test 059 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_CubedSphereGrid_debug
 Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2170,221 +2217,221 @@ Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.798494
+  0: The total amount of wall time                        = 169.897476
 
 Test 060 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_wrtGauss_netcdf_parallel_debug
 Checking test 061 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.079811
+  0: The total amount of wall time                        = 168.252624
 
 Test 061 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_stochy_debug
 Checking test 062 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.449939
+  0: The total amount of wall time                        = 180.926355
 
 Test 062 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ca_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ca_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ca_debug
 Checking test 063 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.218500
+  0: The total amount of wall time                        = 162.483749
 
 Test 063 control_ca_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.074007
+  0: The total amount of wall time                        = 166.187384
 
 Test 064 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_lheatstrg_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_lheatstrg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_lheatstrg_debug
 Checking test 065 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.678412
+  0: The total amount of wall time                        = 159.836618
 
 Test 065 control_lheatstrg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_merra2_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_merra2_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_merra2_debug
 Checking test 066 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.948806
+  0: The total amount of wall time                        = 244.898360
 
 Test 066 control_merra2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_rrtmgp_debug
 Checking test 067 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.153473
+  0: The total amount of wall time                        = 178.604231
 
 Test 067 control_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_csawmg_debug
 Checking test 068 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.749993
+  0: The total amount of wall time                        = 274.997688
 
 Test 068 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_csawmgt_debug
 Checking test 069 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 294.956969
+  0: The total amount of wall time                        = 309.735122
 
 Test 069 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ugwpv1_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ugwpv1_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ugwpv1_debug
 Checking test 070 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.586280
+  0: The total amount of wall time                        = 173.923255
 
 Test 070 control_ugwpv1_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.815545
+  0: The total amount of wall time                        = 162.839971
 
 Test 071 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_noahmp_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_noahmp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_noahmp_debug
 Checking test 072 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.224498
+  0: The total amount of wall time                        = 159.289719
 
 Test 072 control_noahmp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.676574
+  0: The total amount of wall time                        = 173.110440
 
 Test 073 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.921761
+  0: The total amount of wall time                        = 187.475998
 
 Test 074 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.299192
+  0: The total amount of wall time                        = 180.453877
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.634969
+  0: The total amount of wall time                        = 201.467607
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_regional_control_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/regional_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/regional_control_debug
 Checking test 077 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2392,13 +2439,13 @@ Checking test 077 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 243.399541
+ 0: The total amount of wall time                        = 245.003936
 
 Test 077 regional_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_gsd_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_gsd_debug
 Checking test 078 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2463,13 +2510,13 @@ Checking test 078 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 258.938208
+  0: The total amount of wall time                        = 258.610725
 
 Test 078 fv3_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_gsd_diag_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_gsd_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_gsd_diag_debug
 Checking test 079 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2496,13 +2543,13 @@ Checking test 079 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 471.543777
+  0: The total amount of wall time                        = 513.396904
 
 Test 079 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_rrfs_v1beta_debug
 Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2567,13 +2614,13 @@ Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 207.715660
+  0: The total amount of wall time                        = 215.264945
 
 Test 080 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/fv3_rrfs_v1alpha_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_rrfs_v1alpha_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_rrfs_v1alpha_debug
 Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2638,13 +2685,13 @@ Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.606769
+  0: The total amount of wall time                        = 209.966876
 
 Test 081 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2709,13 +2756,13 @@ Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 217.291916
+  0: The total amount of wall time                        = 217.003095
 
 Test 082 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2730,37 +2777,37 @@ Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 408.364110
+ 0: The total amount of wall time                        = 403.629807
 
 Test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/hafs_regional_atm
 Checking test 084 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 252.219879
+  0: The total amount of wall time                        = 250.002784
 
 Test 084 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/hafs_regional_atm_ocn
 Checking test 085 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 360.445121
+  0: The total amount of wall time                        = 374.698136
 
 Test 085 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/hafs_regional_docn
 Checking test 086 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2768,13 +2815,13 @@ Checking test 086 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 337.547465
+  0: The total amount of wall time                        = 373.196811
 
 Test 086 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/hafs_regional_docn_oisst
 Checking test 087 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2782,97 +2829,97 @@ Checking test 087 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 340.877403
+  0: The total amount of wall time                        = 342.319338
 
 Test 087 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/hafs_regional_datm_cdeps
 Checking test 088 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 923.724417
+  0: The total amount of wall time                        = 925.535961
 
 Test 088 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_control_cfsr
 Checking test 089 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 100.345558
+  0: The total amount of wall time                        = 100.191101
 
 Test 089 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_restart_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_restart_cfsr
 Checking test 090 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 69.158728
+  0: The total amount of wall time                        = 67.903865
 
 Test 090 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_control_gefs
 Checking test 091 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 95.168901
+  0: The total amount of wall time                        = 105.002995
 
 Test 091 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_control_iau_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_control_iau_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_control_iau_gefs
 Checking test 092 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 99.168983
+  0: The total amount of wall time                        = 93.388983
 
 Test 092 datm_control_iau_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 100.954278
+  0: The total amount of wall time                        = 98.685245
 
 Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-  0: The total amount of wall time                        = 94.023735
+  0: The total amount of wall time                        = 93.538834
 
 Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_mx025_cfsr
 Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2881,13 +2928,13 @@ Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 336.717370
+  0: The total amount of wall time                        = 339.798128
 
 Test 095 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_mx025_gefs
 Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2896,85 +2943,85 @@ Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 331.634985
+  0: The total amount of wall time                        = 352.817109
 
 Test 096 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_debug_cfsr
 Checking test 097 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 268.956059
+  0: The total amount of wall time                        = 267.842607
 
 Test 097 datm_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_control_cfsr
 Checking test 098 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.549607
+ 0: The total amount of wall time                        = 147.489755
 
 Test 098 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_restart_cfsr
 Checking test 099 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 93.603476
+ 0: The total amount of wall time                        = 92.898271
 
 Test 099 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_control_gefs
 Checking test 100 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.542960
+ 0: The total amount of wall time                        = 145.610298
 
 Test 100 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_bulk_cfsr
 Checking test 101 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.424749
+ 0: The total amount of wall time                        = 147.057827
 
 Test 101 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_bulk_gefs
 Checking test 102 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.179496
+ 0: The total amount of wall time                        = 147.529283
 
 Test 102 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_mx025_cfsr
 Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2983,13 +3030,13 @@ Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 333.640121
+  0: The total amount of wall time                        = 357.576726
 
 Test 103 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_mx025_gefs
 Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2998,35 +3045,35 @@ Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 330.629651
+  0: The total amount of wall time                        = 349.701836
 
 Test 104 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_multiple_files_cfsr
 Checking test 105 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.787931
+ 0: The total amount of wall time                        = 147.240398
 
 Test 105 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/datm_cdeps_debug_cfsr
 Checking test 106 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 442.087488
+ 0: The total amount of wall time                        = 450.269140
 
 Test 106 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_atmwav
 Checking test 107 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3070,13 +3117,13 @@ Checking test 107 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 146.760599
+  0: The total amount of wall time                        = 147.788513
 
 Test 107 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_64270/control_c384gdas_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_399665/control_c384gdas_wav
 Checking test 108 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3122,127 +3169,11 @@ Checking test 108 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 747.036537
+  0: The total amount of wall time                        = 797.587111
 
 Test 108 control_c384gdas_wav PASS
 
-FAILED TESTS: 
-Test cpld_restart_bmark_v16 011 failed failed 
-Test cpld_restart_bmark_v16 011 failed in run_test failed 
-
-REGRESSION TEST FAILED
-Tue Aug 17 16:15:31 CDT 2021
-Elapsed time: 01h:15m:38s. Have a nice day!
-
-
-
-RERUNNING FAILED TEST
-
-
-
-Tue Aug 17 16:20:40 CDT 2021
-Start Regression test
-
-Compile 001 elapsed time 659 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_389102/cpld_bmark_v16
-Checking test 001 cpld_bmark_v16 results ....
- Comparing sfcf006.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2013-04-01-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
-
-  0: The total amount of wall time                        = 628.853066
-
-Test 001 cpld_bmark_v16 PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/INTEL/cpld_bmark_v16
-working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_389102/cpld_restart_bmark_v16
-Checking test 002 cpld_restart_bmark_v16 results ....
- Comparing sfcf006.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/MOM.res_1.nc .........OK
- Comparing RESTART/MOM.res_2.nc .........OK
- Comparing RESTART/MOM.res_3.nc .........OK
- Comparing RESTART/iced.2013-04-01-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
-
-  0: The total amount of wall time                        = 343.183026
-
-Test 002 cpld_restart_bmark_v16 PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 17:02:25 CDT 2021
-Elapsed time: 00h:41m:45s. Have a nice day!
+Thu Aug 19 04:33:59 CDT 2021
+Elapsed time: 10h:17m:23s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,19 +1,19 @@
-Tue Aug 17 19:38:23 UTC 2021
+Wed Aug 18 23:13:44 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 927 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 987 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 917 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 950 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 929 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 534 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 506 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 495 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1000 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 899 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 959 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 887 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 909 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 934 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 551 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 484 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 534 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 523 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 940 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -60,13 +60,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 194.287817
+The total amount of wall time                        = 191.621238
 
 Test 001 control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_decomp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -109,13 +109,13 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 187.499362
+The total amount of wall time                        = 190.166834
 
 Test 002 control_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_restart
 Checking test 003 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -154,13 +154,13 @@ Checking test 003 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 71.464890
+The total amount of wall time                        = 71.047044
 
 Test 003 control_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_fhzero
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_fhzero
 Checking test 004 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -203,13 +203,13 @@ Checking test 004 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.848785
+The total amount of wall time                        = 223.318885
 
 Test 004 control_fhzero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_CubedSphereGrid
 Checking test 005 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -236,13 +236,13 @@ Checking test 005 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 135.146787
+The total amount of wall time                        = 137.686265
 
 Test 005 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_wrtGauss_netcdf_parallel
 Checking test 006 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -253,13 +253,13 @@ Checking test 006 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 194.926440
+The total amount of wall time                        = 209.418862
 
 Test 006 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c48
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_c48
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_c48
 Checking test 007 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -298,13 +298,13 @@ Checking test 007 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 428.372632
+The total amount of wall time                        = 429.274201
 
 Test 007 control_c48 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c192
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_c192
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_c192
 Checking test 008 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -315,13 +315,13 @@ Checking test 008 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 526.348535
+The total amount of wall time                        = 585.886177
 
 Test 008 control_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_stochy
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_stochy
 Checking test 009 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -332,26 +332,26 @@ Checking test 009 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 131.742731
+The total amount of wall time                        = 169.779295
 
 Test 009 control_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_stochy_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_stochy_restart
 Checking test 010 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 64.779280
+The total amount of wall time                        = 64.051039
 
 Test 010 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ca
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ca
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ca
 Checking test 011 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -362,13 +362,13 @@ Checking test 011 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 136.909130
+The total amount of wall time                        = 144.538400
 
 Test 011 control_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lndp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_lndp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_lndp
 Checking test 012 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -379,13 +379,13 @@ Checking test 012 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 132.309258
+The total amount of wall time                        = 137.529440
 
 Test 012 control_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lheatstrg
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_lheatstrg
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_lheatstrg
 Checking test 013 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -396,13 +396,13 @@ Checking test 013 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 185.013235
+The total amount of wall time                        = 180.441101
 
 Test 013 control_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lseaspray
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_lseaspray
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_lseaspray
 Checking test 014 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -413,13 +413,13 @@ Checking test 014 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 197.331370
+The total amount of wall time                        = 217.994778
 
 Test 014 control_lseaspray PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_merra2
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_merra2
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_merra2
 Checking test 015 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -430,13 +430,13 @@ Checking test 015 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 241.526611
+The total amount of wall time                        = 273.941559
 
 Test 015 control_merra2 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_rrtmgp
 Checking test 016 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -447,13 +447,13 @@ Checking test 016 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 225.839485
+The total amount of wall time                        = 230.035190
 
 Test 016 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmg
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_csawmg
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_csawmg
 Checking test 017 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -464,13 +464,13 @@ Checking test 017 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 338.225181
+The total amount of wall time                        = 360.902416
 
 Test 017 control_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_csawmgt
 Checking test 018 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -481,13 +481,13 @@ Checking test 018 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 409.811115
+The total amount of wall time                        = 400.073498
 
 Test 018 control_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_flake
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_flake
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_flake
 Checking test 019 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -498,13 +498,13 @@ Checking test 019 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 254.416027
+The total amount of wall time                        = 239.418061
 
 Test 019 control_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ugwpv1
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ugwpv1
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ugwpv1
 Checking test 020 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -515,13 +515,13 @@ Checking test 020 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 208.553670
+The total amount of wall time                        = 216.578875
 
 Test 020 control_ugwpv1 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ras
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ras
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ras
 Checking test 021 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -532,13 +532,13 @@ Checking test 021 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 204.551030
+The total amount of wall time                        = 204.234129
 
 Test 021 control_ras PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_noahmp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_noahmp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_noahmp
 Checking test 022 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -549,13 +549,13 @@ Checking test 022 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 199.557401
+The total amount of wall time                        = 199.108789
 
 Test 022 control_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_control
 Checking test 023 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -563,25 +563,25 @@ Checking test 023 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 366.182874
+The total amount of wall time                        = 355.241620
 
 Test 023 regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_restart
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_restart
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_restart
 Checking test 024 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-The total amount of wall time                        = 215.285839
+The total amount of wall time                        = 244.993712
 
 Test 024 regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_quilt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_quilt
 Checking test 025 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -592,13 +592,13 @@ Checking test 025 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 342.525729
+The total amount of wall time                        = 343.669014
 
 Test 025 regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_hafs
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_quilt_hafs
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_quilt_hafs
 Checking test 026 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -607,13 +607,13 @@ Checking test 026 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 339.760636
+The total amount of wall time                        = 344.316261
 
 Test 026 regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_quilt_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_quilt_netcdf_parallel
 Checking test 027 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -621,13 +621,13 @@ Checking test 027 regional_quilt_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 344.749574
+The total amount of wall time                        = 340.355632
 
 Test 027 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_quilt_RRTMGP
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_quilt_RRTMGP
 Checking test 028 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -638,13 +638,13 @@ Checking test 028 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 448.683497
+The total amount of wall time                        = 451.006572
 
 Test 028 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_gsd
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_gsd
 Checking test 029 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -733,13 +733,13 @@ Checking test 029 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 248.003343
+The total amount of wall time                        = 285.047166
 
 Test 029 fv3_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1alpha
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_rrfs_v1alpha
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_rrfs_v1alpha
 Checking test 030 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -804,13 +804,13 @@ Checking test 030 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 103.508459
+The total amount of wall time                        = 112.333276
 
 Test 030 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rap
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_rap
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_rap
 Checking test 031 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -875,13 +875,13 @@ Checking test 031 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 105.601890
+The total amount of wall time                        = 132.580342
 
 Test 031 fv3_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_hrrr
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_hrrr
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_hrrr
 Checking test 032 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -946,13 +946,13 @@ Checking test 032 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 105.019852
+The total amount of wall time                        = 152.892043
 
 Test 032 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_rrfs_v1beta
 Checking test 033 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1017,13 +1017,13 @@ Checking test 033 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 106.005237
+The total amount of wall time                        = 123.876025
 
 Test 033 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_HAFS_v0_hwrf_thompson
 Checking test 034 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1088,13 +1088,13 @@ Checking test 034 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 167.257194
+The total amount of wall time                        = 214.530413
 
 Test 034 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 035 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1109,26 +1109,26 @@ Checking test 035 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 319.681072
+The total amount of wall time                        = 347.885161
 
 Test 035 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_debug
 Checking test 036 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 142.162772
+The total amount of wall time                        = 141.343766
 
 Test 036 control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_CubedSphereGrid_debug
 Checking test 037 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1155,221 +1155,221 @@ Checking test 037 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 150.019842
+The total amount of wall time                        = 150.574239
 
 Test 037 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_wrtGauss_netcdf_parallel_debug
 Checking test 038 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 143.596168
+The total amount of wall time                        = 142.715031
 
 Test 038 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_stochy_debug
 Checking test 039 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.147099
+The total amount of wall time                        = 160.581634
 
 Test 039 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ca_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ca_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ca_debug
 Checking test 040 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.417242
+The total amount of wall time                        = 142.904911
 
 Test 040 control_ca_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_lndp_debug
 Checking test 041 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.288523
+The total amount of wall time                        = 145.332021
 
 Test 041 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lheatstrg_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_lheatstrg_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_lheatstrg_debug
 Checking test 042 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.092645
+The total amount of wall time                        = 142.619037
 
 Test 042 control_lheatstrg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_merra2_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_merra2_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_merra2_debug
 Checking test 043 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 215.505258
+The total amount of wall time                        = 213.055444
 
 Test 043 control_merra2_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_rrtmgp_debug
 Checking test 044 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.630958
+The total amount of wall time                        = 159.918280
 
 Test 044 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_csawmg_debug
 Checking test 045 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 256.001349
+The total amount of wall time                        = 252.362230
 
 Test 045 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_csawmgt_debug
 Checking test 046 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 282.581431
+The total amount of wall time                        = 281.862639
 
 Test 046 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ugwpv1_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ugwpv1_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ugwpv1_debug
 Checking test 047 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 153.165528
+The total amount of wall time                        = 154.290135
 
 Test 047 control_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_ras_debug
 Checking test 048 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.821977
+The total amount of wall time                        = 145.620677
 
 Test 048 control_ras_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_noahmp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_noahmp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_noahmp_debug
 Checking test 049 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.108349
+The total amount of wall time                        = 142.839077
 
 Test 049 control_noahmp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_diag_debug
 Checking test 050 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 150.642586
+The total amount of wall time                        = 150.108619
 
 Test 050 control_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_thompson_debug
 Checking test 051 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 167.394994
+The total amount of wall time                        = 167.593145
 
 Test 051 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_thompson_no_aero_debug
 Checking test 052 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.847140
+The total amount of wall time                        = 160.940867
 
 Test 052 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/control_thompson_extdiag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/control_thompson_extdiag_debug
 Checking test 053 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 174.776877
+The total amount of wall time                        = 174.712849
 
 Test 053 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_control_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/regional_control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/regional_control_debug
 Checking test 054 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1377,13 +1377,13 @@ Checking test 054 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 284.730216
+The total amount of wall time                        = 246.339311
 
 Test 054 regional_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_gsd_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_gsd_debug
 Checking test 055 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1448,13 +1448,13 @@ Checking test 055 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.186209
+The total amount of wall time                        = 243.605718
 
 Test 055 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd_diag_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_gsd_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_gsd_diag_debug
 Checking test 056 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1481,13 +1481,13 @@ Checking test 056 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 448.116781
+The total amount of wall time                        = 486.424648
 
 Test 056 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_rrfs_v1beta_debug
 Checking test 057 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1552,13 +1552,13 @@ Checking test 057 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 191.691106
+The total amount of wall time                        = 191.219223
 
 Test 057 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_rrfs_v1alpha_debug
 Checking test 058 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1623,13 +1623,13 @@ Checking test 058 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 191.684639
+The total amount of wall time                        = 191.923883
 
 Test 058 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 059 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1694,13 +1694,13 @@ Checking test 059 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 197.715769
+The total amount of wall time                        = 196.726799
 
 Test 059 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 060 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1715,35 +1715,35 @@ Checking test 060 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 360.890448
+The total amount of wall time                        = 354.314577
 
 Test 060 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/hafs_regional_atm
 Checking test 061 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 186.828849
+The total amount of wall time                        = 206.434211
 
 Test 061 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_34022/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_46889/hafs_regional_atm_ocn
 Checking test 062 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 360.628854
+The total amount of wall time                        = 391.778753
 
 Test 062 hafs_regional_atm_ocn PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 20:08:03 UTC 2021
-Elapsed time: 00h:29m:40s. Have a nice day!
+Wed Aug 18 23:43:17 UTC 2021
+Elapsed time: 00h:29m:33s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,28 +1,28 @@
-Tue Aug 17 19:38:10 UTC 2021
+Thu Aug 19 16:08:05 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 1727 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1994 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 490 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 004 elapsed time 1000 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1351 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 1299 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 1173 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 1021 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 009 elapsed time 316 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 263 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 308 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 385 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 013 elapsed time 1218 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 1350 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 755 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 016 elapsed time 285 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 017 elapsed time 684 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 018 elapsed time 299 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 019 elapsed time 976 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1719 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1752 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_2017_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 477 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_2017_coupled -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 004 elapsed time 1013 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1354 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1015 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 1164 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GSD_v0,FV3_RAP,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 1022 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 297 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 253 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_thompson -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 275 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn,FV3_GSD_v0,FV3_RRFS_v1beta,FV3_RRFS_v1alpha -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 255 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson,FV3_HAFS_v0_hwrf -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 013 elapsed time 1219 seconds. -DAPP=HAFS -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1248 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 729 seconds. -DAPP=NG-GODAS-NEMSDATM -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 016 elapsed time 274 seconds. -DAPP=NG-GODAS-NEMSDATM -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 017 elapsed time 791 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 018 elapsed time 360 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 019 elapsed time 1000 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_control
 Checking test 001 cpld_control results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -72,13 +72,13 @@ Checking test 001 cpld_control results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 104.490783
+[0] The total amount of wall time                        = 101.269955
 
 Test 001 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_restart
 Checking test 002 cpld_restart results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -128,13 +128,13 @@ Checking test 002 cpld_restart results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 77.558060
+[0] The total amount of wall time                        = 68.710459
 
 Test 002 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_2threads
 Checking test 003 cpld_2threads results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -184,13 +184,13 @@ Checking test 003 cpld_2threads results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 96.658278
+[0] The total amount of wall time                        = 96.221819
 
 Test 003 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_decomp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_decomp
 Checking test 004 cpld_decomp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -240,13 +240,13 @@ Checking test 004 cpld_decomp results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 103.432076
+[0] The total amount of wall time                        = 98.358029
 
 Test 004 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_ca
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_ca
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_ca
 Checking test 005 cpld_ca results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -296,13 +296,13 @@ Checking test 005 cpld_ca results ....
  Comparing RESTART/iced.2016-10-04-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-04-00000.nc .........OK
 
-[0] The total amount of wall time                        = 101.183188
+[0] The total amount of wall time                        = 99.839483
 
 Test 005 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_control_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_control_c192
 Checking test 006 cpld_control_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -352,13 +352,13 @@ Checking test 006 cpld_control_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 420.700991
+[0] The total amount of wall time                        = 408.048371
 
 Test 006 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control_c192
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_restart_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_restart_c192
 Checking test 007 cpld_restart_c192 results ....
  Comparing sfcf048.tile1.nc .........OK
  Comparing sfcf048.tile2.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_restart_c192 results ....
  Comparing RESTART/iced.2016-10-05-00000.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-05-00000.nc .........OK
 
-[0] The total amount of wall time                        = 314.231667
+[0] The total amount of wall time                        = 314.680250
 
 Test 007 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_control_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_control_c384
 Checking test 008 cpld_control_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -467,13 +467,13 @@ Checking test 008 cpld_control_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 811.868571
+[0] The total amount of wall time                        = 814.615003
 
 Test 008 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control_c384
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_restart_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_restart_c384
 Checking test 009 cpld_restart_c384 results ....
  Comparing sfcf012.tile1.nc .........OK
  Comparing sfcf012.tile2.nc .........OK
@@ -526,13 +526,13 @@ Checking test 009 cpld_restart_c384 results ....
  Comparing RESTART/iced.2016-10-03-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-43200.nc .........OK
 
-[0] The total amount of wall time                        = 470.653117
+[0] The total amount of wall time                        = 469.619125
 
 Test 009 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_bmark_v16
 Checking test 010 cpld_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -575,13 +575,13 @@ Checking test 010 cpld_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 678.166911
+[0] The total amount of wall time                        = 660.140269
 
 Test 010 cpld_bmark_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_bmark_v16
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_restart_bmark_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_restart_bmark_v16
 Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -624,13 +624,13 @@ Checking test 011 cpld_restart_bmark_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 440.964014
+[0] The total amount of wall time                        = 440.892618
 
 Test 011 cpld_restart_bmark_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_bmark_v16_nsst
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_bmark_v16_nsst
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_bmark_v16_nsst
 Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -673,13 +673,13 @@ Checking test 012 cpld_bmark_v16_nsst results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 684.103395
+[0] The total amount of wall time                        = 662.522677
 
 Test 012 cpld_bmark_v16_nsst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_bmark_wave_v16
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_bmark_wave_v16
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_bmark_wave_v16
 Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -724,13 +724,13 @@ Checking test 013 cpld_bmark_wave_v16 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 798.881506
+[0] The total amount of wall time                        = 799.772992
 
 Test 013 cpld_bmark_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_bmark_wave_v16_p7b
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_bmark_wave_v16_p7b
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_bmark_wave_v16_p7b
 Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -775,13 +775,13 @@ Checking test 014 cpld_bmark_wave_v16_p7b results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 848.975010
+[0] The total amount of wall time                        = 831.172954
 
 Test 014 cpld_bmark_wave_v16_p7b PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_control_wave
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_control_wave
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_control_wave
 Checking test 015 cpld_control_wave results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -834,13 +834,13 @@ Checking test 015 cpld_control_wave results ....
  Comparing 20161004.000000.out_pnt.points .........OK
  Comparing 20161004.000000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 131.672500
+[0] The total amount of wall time                        = 122.796866
 
 Test 015 cpld_control_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/cpld_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/cpld_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/cpld_debug
 Checking test 016 cpld_debug results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -890,13 +890,13 @@ Checking test 016 cpld_debug results ....
  Comparing RESTART/iced.2016-10-03-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2016-10-03-21600.nc .........OK
 
-[0] The total amount of wall time                        = 311.149097
+[0] The total amount of wall time                        = 308.059350
 
 Test 016 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control
 Checking test 017 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -943,13 +943,13 @@ Checking test 017 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 173.169145
+[0] The total amount of wall time                        = 169.500955
 
 Test 017 control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_decomp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_decomp
 Checking test 018 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -992,13 +992,13 @@ Checking test 018 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 174.643567
+[0] The total amount of wall time                        = 174.100955
 
 Test 018 control_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1041,13 +1041,13 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 157.568661
+[0] The total amount of wall time                        = 157.166106
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1086,13 +1086,13 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 75.950167
+[0] The total amount of wall time                        = 73.084831
 
 Test 020 control_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_fhzero
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1135,13 +1135,13 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 171.096755
+[0] The total amount of wall time                        = 169.101121
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1168,30 +1168,30 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 134.379413
+[0] The total amount of wall time                        = 134.415847
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 202.864537
+[0] The total amount of wall time                        = 199.586922
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c48
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_c48
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1230,13 +1230,13 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 434.326141
+[0] The total amount of wall time                        = 433.578256
 
 Test 024 control_c48 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c192
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1247,13 +1247,13 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 575.505605
+[0] The total amount of wall time                        = 567.058500
 
 Test 025 control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c384
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1264,13 +1264,13 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1027.159641
+[0] The total amount of wall time                        = 1023.609872
 
 Test 026 control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1313,13 +1313,13 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 917.322534
+[0] The total amount of wall time                        = 899.987947
 
 Test 027 control_c384gdas PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_stochy
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1330,26 +1330,26 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 120.981291
+[0] The total amount of wall time                        = 120.288121
 
 Test 028 control_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_stochy_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 63.814751
+[0] The total amount of wall time                        = 62.648419
 
 Test 029 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ca
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ca
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ca
 Checking test 030 control_ca results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,13 +1360,13 @@ Checking test 030 control_ca results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 119.583521
+[0] The total amount of wall time                        = 119.244525
 
 Test 030 control_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lndp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_lndp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1377,13 +1377,13 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 123.265716
+[0] The total amount of wall time                        = 122.457316
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lheatstrg
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_lheatstrg
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_lheatstrg
 Checking test 032 control_lheatstrg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1394,13 +1394,13 @@ Checking test 032 control_lheatstrg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 170.595426
+[0] The total amount of wall time                        = 171.765063
 
 Test 032 control_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lseaspray
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_lseaspray
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_lseaspray
 Checking test 033 control_lseaspray results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1411,13 +1411,13 @@ Checking test 033 control_lseaspray results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 179.192957
+[0] The total amount of wall time                        = 177.926118
 
 Test 033 control_lseaspray PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_merra2
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_merra2
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_merra2
 Checking test 034 control_merra2 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1428,13 +1428,13 @@ Checking test 034 control_merra2 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 199.885891
+[0] The total amount of wall time                        = 196.834154
 
 Test 034 control_merra2 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1445,13 +1445,13 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 234.486498
+[0] The total amount of wall time                        = 233.215716
 
 Test 035 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_csawmg
 Checking test 036 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1462,13 +1462,13 @@ Checking test 036 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 304.240227
+[0] The total amount of wall time                        = 300.710529
 
 Test 036 control_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_csawmgt
 Checking test 037 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1479,13 +1479,13 @@ Checking test 037 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 372.462858
+[0] The total amount of wall time                        = 370.853963
 
 Test 037 control_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_flake
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_flake
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_flake
 Checking test 038 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1496,13 +1496,13 @@ Checking test 038 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 252.338571
+[0] The total amount of wall time                        = 255.253110
 
 Test 038 control_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ugwpv1
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ugwpv1
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ugwpv1
 Checking test 039 control_ugwpv1 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1513,13 +1513,13 @@ Checking test 039 control_ugwpv1 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 210.022218
+[0] The total amount of wall time                        = 208.869870
 
 Test 039 control_ugwpv1 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ras
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ras
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1530,13 +1530,13 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 203.128500
+[0] The total amount of wall time                        = 201.505224
 
 Test 040 control_ras PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_thompson
 Checking test 041 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1547,13 +1547,13 @@ Checking test 041 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 238.141996
+[0] The total amount of wall time                        = 238.041330
 
 Test 041 control_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_thompson_no_aero
 Checking test 042 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1564,13 +1564,13 @@ Checking test 042 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 229.688532
+[0] The total amount of wall time                        = 228.813956
 
 Test 042 control_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_noahmp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_noahmp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_noahmp
 Checking test 043 control_noahmp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1581,13 +1581,13 @@ Checking test 043 control_noahmp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 195.481098
+[0] The total amount of wall time                        = 194.047286
 
 Test 043 control_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_control
 Checking test 044 regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1595,25 +1595,25 @@ Checking test 044 regional_control results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 354.824944
+[0] The total amount of wall time                        = 350.001318
 
 Test 044 regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_restart
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_restart
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_restart
 Checking test 045 regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
  Comparing fv3_history.nc .........OK
 
-[0] The total amount of wall time                        = 203.165609
+[0] The total amount of wall time                        = 201.020430
 
 Test 045 regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_quilt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_quilt
 Checking test 046 regional_quilt results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1624,13 +1624,13 @@ Checking test 046 regional_quilt results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 344.481869
+[0] The total amount of wall time                        = 343.649757
 
 Test 046 regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_quilt_2threads
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_quilt_2threads
 Checking test 047 regional_quilt_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1641,13 +1641,13 @@ Checking test 047 regional_quilt_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 194.716452
+[0] The total amount of wall time                        = 191.395587
 
 Test 047 regional_quilt_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_hafs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_quilt_hafs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_quilt_hafs
 Checking test 048 regional_quilt_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1656,27 +1656,27 @@ Checking test 048 regional_quilt_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 344.029569
+[0] The total amount of wall time                        = 343.742842
 
 Test 048 regional_quilt_hafs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_quilt_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_quilt_netcdf_parallel
 Checking test 049 regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 344.211549
+[0] The total amount of wall time                        = 346.708091
 
 Test 049 regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_quilt_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_quilt_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_quilt_RRTMGP
 Checking test 050 regional_quilt_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1687,13 +1687,13 @@ Checking test 050 regional_quilt_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 465.206561
+[0] The total amount of wall time                        = 465.743049
 
 Test 050 regional_quilt_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_gsd
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_gsd
 Checking test 051 fv3_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1782,13 +1782,13 @@ Checking test 051 fv3_gsd results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 257.808318
+[0] The total amount of wall time                        = 256.556974
 
 Test 051 fv3_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1alpha
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_rrfs_v1alpha
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_rrfs_v1alpha
 Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1853,13 +1853,13 @@ Checking test 052 fv3_rrfs_v1alpha results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 105.085634
+[0] The total amount of wall time                        = 103.473674
 
 Test 052 fv3_rrfs_v1alpha PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rap
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_rap
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_rap
 Checking test 053 fv3_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1924,13 +1924,13 @@ Checking test 053 fv3_rap results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 103.915033
+[0] The total amount of wall time                        = 102.322760
 
 Test 053 fv3_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_hrrr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_hrrr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_hrrr
 Checking test 054 fv3_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1995,13 +1995,13 @@ Checking test 054 fv3_hrrr results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 102.524049
+[0] The total amount of wall time                        = 101.402819
 
 Test 054 fv3_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_rrfs_v1beta
 Checking test 055 fv3_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2066,13 +2066,13 @@ Checking test 055 fv3_rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 104.779707
+[0] The total amount of wall time                        = 102.835235
 
 Test 055 fv3_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2137,13 +2137,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 173.142532
+[0] The total amount of wall time                        = 172.154057
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_esg_HAFS_v0_hwrf_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2158,39 +2158,39 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 320.781035
+[0] The total amount of wall time                        = 318.647909
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_debug
 Checking test 058 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 164.884943
+[0] The total amount of wall time                        = 164.835437
 
 Test 058 control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_2threads_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_2threads_debug
 Checking test 059 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 153.416619
+[0] The total amount of wall time                        = 153.238776
 
 Test 059 control_2threads_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_CubedSphereGrid_debug
 Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2217,221 +2217,221 @@ Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 178.839209
+[0] The total amount of wall time                        = 179.665126
 
 Test 060 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_wrtGauss_netcdf_parallel_debug
 Checking test 061 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 169.671360
+[0] The total amount of wall time                        = 169.138913
 
 Test 061 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_stochy_debug
 Checking test 062 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 189.331600
+[0] The total amount of wall time                        = 189.530415
 
 Test 062 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ca_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ca_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ca_debug
 Checking test 063 control_ca_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 167.157512
+[0] The total amount of wall time                        = 167.295142
 
 Test 063 control_ca_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 170.158362
+[0] The total amount of wall time                        = 169.860892
 
 Test 064 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_lheatstrg_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_lheatstrg_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_lheatstrg_debug
 Checking test 065 control_lheatstrg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 165.156553
+[0] The total amount of wall time                        = 165.109875
 
 Test 065 control_lheatstrg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_merra2_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_merra2_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_merra2_debug
 Checking test 066 control_merra2_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 240.450684
+[0] The total amount of wall time                        = 235.668576
 
 Test 066 control_merra2_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_rrtmgp_debug
 Checking test 067 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 188.285563
+[0] The total amount of wall time                        = 188.933437
 
 Test 067 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_csawmg_debug
 Checking test 068 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 285.109629
+[0] The total amount of wall time                        = 280.005685
 
 Test 068 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_csawmgt_debug
 Checking test 069 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 322.152757
+[0] The total amount of wall time                        = 316.999845
 
 Test 069 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ugwpv1_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ugwpv1_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ugwpv1_debug
 Checking test 070 control_ugwpv1_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 179.939708
+[0] The total amount of wall time                        = 179.535657
 
 Test 070 control_ugwpv1_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 172.359812
+[0] The total amount of wall time                        = 171.805636
 
 Test 071 control_ras_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_noahmp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_noahmp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_noahmp_debug
 Checking test 072 control_noahmp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 165.279282
+[0] The total amount of wall time                        = 165.245469
 
 Test 072 control_noahmp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 175.300929
+[0] The total amount of wall time                        = 175.796684
 
 Test 073 control_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 195.514629
+[0] The total amount of wall time                        = 193.513898
 
 Test 074 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 189.391201
+[0] The total amount of wall time                        = 187.357946
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_thompson_extdiag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 204.515516
+[0] The total amount of wall time                        = 203.214621
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_regional_control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/regional_control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/regional_control_debug
 Checking test 077 regional_control_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2439,13 +2439,13 @@ Checking test 077 regional_control_debug results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 277.417209
+[0] The total amount of wall time                        = 277.213259
 
 Test 077 regional_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_gsd_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_gsd_debug
 Checking test 078 fv3_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2510,13 +2510,13 @@ Checking test 078 fv3_gsd_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 281.933949
+[0] The total amount of wall time                        = 281.639640
 
 Test 078 fv3_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_gsd_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_gsd_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_gsd_diag_debug
 Checking test 079 fv3_gsd_diag_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2543,13 +2543,13 @@ Checking test 079 fv3_gsd_diag_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 444.157840
+[0] The total amount of wall time                        = 445.969573
 
 Test 079 fv3_gsd_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_rrfs_v1beta_debug
 Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2614,13 +2614,13 @@ Checking test 080 fv3_rrfs_v1beta_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 222.928040
+[0] The total amount of wall time                        = 223.136380
 
 Test 080 fv3_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/fv3_rrfs_v1alpha_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_rrfs_v1alpha_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_rrfs_v1alpha_debug
 Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2685,13 +2685,13 @@ Checking test 081 fv3_rrfs_v1alpha_debug results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 223.746222
+[0] The total amount of wall time                        = 222.954755
 
 Test 081 fv3_rrfs_v1alpha_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2756,13 +2756,13 @@ Checking test 082 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 234.912542
+[0] The total amount of wall time                        = 234.481117
 
 Test 082 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/fv3_esg_HAFS_v0_hwrf_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2777,37 +2777,37 @@ Checking test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 434.284914
+[0] The total amount of wall time                        = 433.743229
 
 Test 083 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/hafs_regional_atm
 Checking test 084 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 633.447480
+[0] The total amount of wall time                        = 623.285139
 
 Test 084 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/hafs_regional_atm_ocn
 Checking test 085 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 630.240050
+[0] The total amount of wall time                        = 612.072565
 
 Test 085 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/hafs_regional_docn
 Checking test 086 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2815,13 +2815,13 @@ Checking test 086 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 623.848375
+[0] The total amount of wall time                        = 611.707635
 
 Test 086 hafs_regional_docn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/hafs_regional_docn_oisst
 Checking test 087 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2829,97 +2829,97 @@ Checking test 087 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 622.069873
+[0] The total amount of wall time                        = 613.963280
 
 Test 087 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/hafs_regional_datm_cdeps
 Checking test 088 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1086.634401
+[0] The total amount of wall time                        = 1087.009427
 
 Test 088 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_control_cfsr
 Checking test 089 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 105.786475
+[0] The total amount of wall time                        = 104.787566
 
 Test 089 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_restart_cfsr
 Checking test 090 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 79.274938
+[0] The total amount of wall time                        = 75.937359
 
 Test 090 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_control_gefs
 Checking test 091 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 98.543277
+[0] The total amount of wall time                        = 98.914391
 
 Test 091 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_control_iau_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_control_iau_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_control_iau_gefs
 Checking test 092 datm_control_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 100.001765
+[0] The total amount of wall time                        = 100.281887
 
 Test 092 datm_control_iau_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 102.257804
+[0] The total amount of wall time                        = 101.342385
 
 Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 98.929927
+[0] The total amount of wall time                        = 98.634418
 
 Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_mx025_cfsr
 Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2928,13 +2928,13 @@ Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 377.311150
+[0] The total amount of wall time                        = 347.746595
 
 Test 095 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_mx025_gefs
 Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2943,85 +2943,85 @@ Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 362.836199
+[0] The total amount of wall time                        = 345.749275
 
 Test 096 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_debug_cfsr
 Checking test 097 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 292.795430
+[0] The total amount of wall time                        = 290.705843
 
 Test 097 datm_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_control_cfsr
 Checking test 098 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 175.750575
+[0] The total amount of wall time                        = 173.627508
 
 Test 098 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_restart_cfsr
 Checking test 099 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 122.988655
+[0] The total amount of wall time                        = 120.430406
 
 Test 099 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_control_gefs
 Checking test 100 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.766692
+[0] The total amount of wall time                        = 168.985224
 
 Test 100 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_bulk_cfsr
 Checking test 101 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 178.020084
+[0] The total amount of wall time                        = 174.656698
 
 Test 101 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_bulk_gefs
 Checking test 102 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.521451
+[0] The total amount of wall time                        = 168.905044
 
 Test 102 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_mx025_cfsr
 Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3030,13 +3030,13 @@ Checking test 103 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 348.951379
+[0] The total amount of wall time                        = 346.232964
 
 Test 103 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_mx025_gefs
 Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3045,35 +3045,35 @@ Checking test 104 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 351.056003
+[0] The total amount of wall time                        = 342.442340
 
 Test 104 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_multiple_files_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_multiple_files_cfsr
 Checking test 105 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 175.475234
+[0] The total amount of wall time                        = 172.365681
 
 Test 105 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/datm_cdeps_debug_cfsr
 Checking test 106 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 494.661651
+[0] The total amount of wall time                        = 493.634132
 
 Test 106 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_atmwav
 Checking test 107 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3117,13 +3117,13 @@ Checking test 107 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 154.010187
+[0] The total amount of wall time                        = 153.123951
 
 Test 107 control_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210812/control_c384gdas_wav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_18878/control_c384gdas_wav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_33006/control_c384gdas_wav
 Checking test 108 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3169,11 +3169,11 @@ Checking test 108 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-[0] The total amount of wall time                        = 1007.243566
+[0] The total amount of wall time                        = 977.208467
 
 Test 108 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Aug 17 20:39:32 UTC 2021
-Elapsed time: 01h:01m:22s. Have a nice day!
+Thu Aug 19 17:08:29 UTC 2021
+Elapsed time: 01h:00m:25s. Have a nice day!


### PR DESCRIPTION
# PR Checklist

- [X] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [X] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [X] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [X] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.


## Description

This PR only updates the submodule poiinter for fv3atm for the changes described in https://github.com/NOAA-EMC/fv3atm/pull/371: Fix stochastic physics restart runs, remove rayleigh damping from all suite definition files.

No new input data, no changes to the regression test results.

### Issue(s) addressed

Fixes https://github.com/NOAA-EMC/fv3atm/issues/340.

## Testing

Full regression tests are run on all tier-1 platforms.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [X] CI - https://github.com/ufs-community/ufs-weather-model/pull/751/commits/6257ef953dc5827e5ebb84d6802e9543de5ddae1

## Dependencies

- waiting on https://github.com/NOAA-EMC/fv3atm/pull/371
