### PR TITLE
Add a cplocn2atm namelist option to control one-way or two-way atmosphere-ocean coupling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/hafs-community/fv3atm
+  branch = feature/hafs_cplocn2atm
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
# PR Checklist

- [ ] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [ ] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsiblity to keep the PR up-to-date with the develop branch of ufs-weather-model. 

## Description

Add a cplocn2atm namelist option in FV3atm input.nml to control one-way or two-way atmosphere-ocean coupling. Similar to the cplwav2atm namelist option, the cplocn2atm namelist option turns on/off the ocean model component feedback (e.g., SST) to the atmosphere model component. This is useful to control the one-way or two-way atmosphere-ocean coupling, as well as to configure different combinations for the atmosphere-ocean-wave coupling in HAFS and/or other applications.

### Issue(s) addressed
- addresses NOAA-EMC/fv3atm/issues/372

## Testing

Regression tests ran successfully on Hera.intel. And this PR does not change baseline results.

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] CI

## Dependencies
- dependent upon noaa-emc/fv3atm/pull/376
