### PR TITLE
Modify opnReqTest related scripts for fv3_gsd test

### DIFF
--- a/tests/fv3_conf/gsd_run.IN
+++ b/tests/fv3_conf/gsd_run.IN
@@ -1,12 +1,25 @@
 rm -fr INPUT RESTART
 mkdir INPUT RESTART
+
+OPNREQ_TEST=${OPNREQ_TEST:-false}
+SUFFIX=${RT_SUFFIX}
 if [ $WARM_START = .false. ]; then
   cp -r @[INPUTDATA_ROOT]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/* INPUT/
 else
+  if [[ ${OPNREQ_TEST} == true ]]; then
+    SUFFIX=${BL_SUFFIX}
+  fi
+
   cp -r @[INPUTDATA_ROOT]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/grid_spec*.nc INPUT/
   cp -r @[INPUTDATA_ROOT]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/C96_grid*.nc INPUT/
   cp -r @[INPUTDATA_ROOT]/FV3_input_data_gsd/FV3_input_data_C96_with_aerosols/oro_data*.nc INPUT/
-  cp ../fv3_gsd_coldstart${RT_SUFFIX}/RESTART/* INPUT/
+  #cp ../fv3_gsd_coldstart${RT_SUFFIX}/RESTART/* INPUT/
+  cp -r ../${DEP_RUN}${SUFFIX}/RESTART/${RESTART_FILE_PREFIX}.* ./INPUT
+  for RFILE in INPUT/${RESTART_FILE_PREFIX}.*; do
+    [ -e $RFILE ] || exit 1
+    RFILE_OLD=$(basename $RFILE)
+    mv -f $RFILE INPUT/"${RFILE_OLD//${RESTART_FILE_PREFIX}./}"
+  done
 fi
 
 cp    @[INPUTDATA_ROOT]/FV3_input_data/INPUT/aerosol.dat .

--- a/tests/opnReqTests/dbg.sh
+++ b/tests/opnReqTests/dbg.sh
@@ -4,7 +4,16 @@ source $PATHRT/opnReqTests/std.sh
 if [[ $application == 'global' ]]; then
   FHMAX=1
   OUTPUT_FH="0 1"
-  LIST_FILES="sfcf000.nc sfcf001.nc atmf000.nc atmf001.nc"
+
+  FHMAX_2D=$(printf "%02d" $FHMAX)
+  if [[ $TEST_NAME == 'fv3_gsd' ]]; then
+    LIST_FILES="sfcf0$FHMAX_2D.tile1.nc sfcf0$FHMAX_2D.tile2.nc sfcf0$FHMAX_2D.tile3.nc \
+                sfcf0$FHMAX_2D.tile4.nc sfcf0$FHMAX_2D.tile5.nc sfcf0$FHMAX_2D.tile6.nc \
+                atmf0$FHMAX_2D.tile1.nc atmf0$FHMAX_2D.tile2.nc atmf0$FHMAX_2D.tile3.nc \
+                atmf0$FHMAX_2D.tile4.nc atmf0$FHMAX_2D.tile5.nc atmf0$FHMAX_2D.tile6.nc"
+  else
+    LIST_FILES="sfcf0$FHMAX_2D.nc sfcf0$FHMAX_2D.nc"
+  fi
 elif [[ $application == 'regional' ]]; then
   echo "Regional application not yet implemented for debug"
   exit 1

--- a/tests/opnReqTests/dcp.sh
+++ b/tests/opnReqTests/dcp.sh
@@ -2,9 +2,11 @@ set -eu
 source $PATHRT/opnReqTests/std.sh
 
 if [[ $application == 'global' ]]; then
-  temp=$INPES
-  INPES=$JNPES
-  JNPES=$temp
+  #temp=$INPES
+  #INPES=$JNPES
+  #JNPES=$temp
+  INPES=6
+  JNPES=4
 elif [[ $application == 'regional' ]]; then
   if [[ $CI_TEST == 'true' ]]; then
     INPES=10

--- a/tests/opnReqTests/rst.sh
+++ b/tests/opnReqTests/rst.sh
@@ -4,18 +4,17 @@ source $PATHRT/opnReqTests/std.sh
 DEP_RUN=${TEST_NAME}
 
 if [[ $application == 'global' ]]; then
-  FHROT=12
+  FHROT=$(( FHMAX/2 ))
   OUTPUT_FH="3 -1"
-  RESTART_FILE_PREFIX="${SYEAR}${SMONTH}${SDAY}.$(printf "%02d" $(( SHOUR + FHROT  )))0000"
+  if [[ $(( SHOUR + FHROT )) -lt 24 ]]; then
+    RESTART_FILE_PREFIX="${SYEAR}${SMONTH}$(printf "%02d" ${SDAY}).$(printf "%02d" $(( SHOUR + FHROT  )))0000"
+  else
+    RESTART_FILE_PREFIX="${SYEAR}${SMONTH}$(printf "%02d" $((SDAY+1))).$(printf "%02d" $(( SHOUR + FHROT - 24 )))0000"
+  fi
 elif [[ $application == 'regional' ]]; then
   echo "Regional application not yet implemented for restart"
   exit 1
 elif [[ $application == 'cpld' ]]; then
-  #if [[ $TEST_NAME == 'cpld_control' ]]; then
-  #  FHROT=12
-  #elif [[ $TEST_NAME == 'cpld_bmark_v16' ]]; then
-  #  FHROT=3
-  #fi
   FHROT=$(( FHMAX/2 ))
 
   CICERUNTYPE='continue'
@@ -36,11 +35,14 @@ MAKE_NH=.F.
 MOUNTAIN=.T.
 NA_INIT=0
 
-LIST_FILES=$(echo -n $LIST_FILES | sed -E "s/phyf00(00|21)\.(tile.\.nc|nemsio|nc) ?//g" \
-                                 | sed -E "s/dynf00(00|21)\.(tile.\.nc|nemsio|nc) ?//g" \
-                                 | sed -E "s/sfcf0(00|21).nc ?//g" | sed -E "s/atmf0(00|21).nc ?//g" \
-                                 | sed -E "s/GFSFLX.GrbF(00|21) ?//g" | sed -E "s/GFSPRS.GrbF(00|21) ?//g" \
+FHMAX_2D=$(printf "%02d" $FHMAX)
+LIST_FILES=$(echo -n $LIST_FILES | sed -E "s/phyf00[0-9][0-9]/phyf00$FHMAX_2D/g" \
+                                 | sed -E "s/dynf00[0-9][0-9]/dynf00$FHMAX_2D/g" \
+                                 | sed -E "s/sfcf0[0-9][0-9]/sfcf0$FHMAX_2D/g" | sed -E "s/atmf0[0-9][0-9]/atmf0$FHMAX_2D/g" \
+                                 | sed -E "s/GFSFLX.GrbF[0-9][0-9]/GFSFLX.GrbF$FHMAX_2D/g" | sed -E "s/GFSPRS.GrbF[0-9][0-9]/GFSPRS.GrbF$FHMAX_2D/g" \
                                  | sed -E "s/atmos_4xdaily\.tile[1-6]\.nc ?//g" | sed -e "s/^ *//" -e "s/ *$//")
+LIST_FILES=$(echo $LIST_FILES | xargs -n1 | sort -u | xargs)
+
 
 (test $CI_TEST == 'true') && source $PATHRT/opnReqTests/cmp_proc_bind.sh
 source $PATHRT/opnReqTests/wrt_env.sh

--- a/tests/opnReqTests/std.sh
+++ b/tests/opnReqTests/std.sh
@@ -8,6 +8,8 @@ if [[ $application == 'global' ]]; then
     WRTTASK_PER_GROUP=12
     TASKS=$((INPES*JNPES*6 + WRITE_GROUP*WRTTASK_PER_GROUP))
   fi
+  RESTART_N=$(( FHMAX/2 ))
+  RESTART_INTERVAL="${RESTART_N} -1"
 elif [[ $application == 'regional' ]]; then
   if [[ $CI_TEST == 'true' ]]; then
     INPES=4


### PR DESCRIPTION
# PR Checklist

- [x] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsiblity to keep the PR up-to-date with the develop branch of ufs-weather-model. 

## Description

Modify operation requirement test related scripts for the `fv3_gsd` test as requested by @climbfuji 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues must always be created before starting work on a PR branch!) 
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>

## Testing

The `opnReqTest` script works for the `fv3_control` test: `thr`, `rst`, `dcp`, `mpi`, `bit`, `dbg`. Note that failure to reproduce is a different matter.

The following existing `opnReqTest`s have been run to make sure that existing tests do not break:
- `cpld_control_p7`: `thr`, `rst`, `dcp`, `dbg`
- `control`: `thr`, `rst`, `dcp`, `mpi`, `bit`, `dbg`
- `regional_control`: `thr`, `dcp`

This PR does not change results.

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] CI

## Dependencies

None