### PR TITLE
Wrapper for ccpp-physics #808 and 816 (roughness length over ice and NoahMP tsurf bugfix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/grantfirl/fv3atm
+  branch = wrapper_808_816
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/grantfirl/fv3atm
-  branch = wrapper_808_816
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,15 +1,15 @@
-Mon Dec 20 16:11:58 MST 2021
+Thu Dec 23 06:56:56 MST 2021
 Start Regression test
 
-Compile 001 elapsed time 411 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_HAFS_v0_hwrf_thompson,FV3_GFS_v16_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 750 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 490 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_HAFS_v0_hwrf_thompson,FV3_GFS_v16_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 387 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 751 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 492 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 006 elapsed time 274 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,13 +56,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 274.606107
+0:The total amount of wall time                        = 268.234223
 
 Test 001 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -101,13 +101,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.088866
+0:The total amount of wall time                        = 134.795219
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_c48
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_c48
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -146,13 +146,13 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 817.905969
+0:The total amount of wall time                        = 816.225111
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_stochy
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -163,13 +163,13 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 175.011528
+0:The total amount of wall time                        = 170.925185
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_flake
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -180,13 +180,13 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 338.086426
+0:The total amount of wall time                        = 326.117552
 
 Test 005 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_rrtmgp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -197,13 +197,13 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 391.944652
+0:The total amount of wall time                        = 391.302487
 
 Test 006 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -214,13 +214,13 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 364.903414
+0:The total amount of wall time                        = 364.674952
 
 Test 007 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_no_aero
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -231,13 +231,13 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 348.569901
+0:The total amount of wall time                        = 348.970887
 
 Test 008 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_ras
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -248,13 +248,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 290.674793
+0:The total amount of wall time                        = 289.828473
 
 Test 009 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_p7
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_p7
 Checking test 010 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -301,13 +301,13 @@ Checking test 010 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 280.144966
+0:The total amount of wall time                        = 285.609760
 
 Test 010 control_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/fv3_HAFS_v0_hwrf_thompson
 Checking test 011 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -372,13 +372,13 @@ Checking test 011 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 251.158245
+0:The total amount of wall time                        = 235.739358
 
 Test 011 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 012 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -393,13 +393,13 @@ Checking test 012 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 454.922945
+0:The total amount of wall time                        = 456.505399
 
 Test 012 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_control
 Checking test 013 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -446,13 +446,13 @@ Checking test 013 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 689.136751
+0:The total amount of wall time                        = 688.284855
 
 Test 013 rap_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_2threads
 Checking test 014 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -499,13 +499,13 @@ Checking test 014 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1208.625820
+0:The total amount of wall time                        = 1207.424895
 
 Test 014 rap_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_sfcdiff
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_sfcdiff
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_sfcdiff
 Checking test 015 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -552,13 +552,13 @@ Checking test 015 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 683.433942
+0:The total amount of wall time                        = 687.537389
 
 Test 015 rap_sfcdiff PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_sfcdiff_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_sfcdiff
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_sfcdiff_restart
 Checking test 016 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -597,13 +597,13 @@ Checking test 016 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 343.105834
+0:The total amount of wall time                        = 340.195339
 
 Test 016 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/hrrr_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/hrrr_control
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/hrrr_control
 Checking test 017 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -650,13 +650,13 @@ Checking test 017 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 664.731846
+0:The total amount of wall time                        = 680.754684
 
 Test 017 hrrr_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rrfs_v1beta
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -703,195 +703,195 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 678.486437
+0:The total amount of wall time                        = 678.587564
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_debug
 Checking test 019 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 80.290419
+0:The total amount of wall time                        = 79.095563
 
 Test 019 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_diag_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_diag_debug
 Checking test 020 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.270618
+0:The total amount of wall time                        = 86.019191
 
 Test 020 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/regional_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/fv3_regional_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/regional_debug
 Checking test 021 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 131.242826
+0:The total amount of wall time                        = 131.061032
 
 Test 021 regional_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_control_debug
 Checking test 022 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.989156
+0:The total amount of wall time                        = 144.826373
 
 Test 022 rap_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_diag_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_diag_debug
 Checking test 023 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 154.571709
+0:The total amount of wall time                        = 153.756177
 
 Test 023 rap_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 024 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 234.993478
+0:The total amount of wall time                        = 234.023496
 
 Test 024 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/rrfs_v1beta_debug
 Checking test 025 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.044531
+0:The total amount of wall time                        = 145.268018
 
 Test 025 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_thompson_debug
 Checking test 026 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.730001
+0:The total amount of wall time                        = 93.867201
 
 Test 026 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_no_aero_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_thompson_no_aero_debug
 Checking test 027 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.696815
+0:The total amount of wall time                        = 90.268342
 
 Test 027 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_thompson_extdiag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_debug_extdiag
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_thompson_extdiag_debug
 Checking test 028 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 101.207024
+0:The total amount of wall time                        = 101.326697
 
 Test 028 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_rrtmgp_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_rrtmgp_debug
 Checking test 029 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 92.964467
+0:The total amount of wall time                        = 92.594756
 
 Test 029 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_ras_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_ras_debug
 Checking test 030 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.418699
+0:The total amount of wall time                        = 82.474276
 
 Test 030 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_stochy_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_stochy_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_stochy_debug
 Checking test 031 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.737748
+0:The total amount of wall time                        = 90.223347
 
 Test 031 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/control_debug_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/control_debug_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/control_debug_p7
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/control_debug_p7
 Checking test 032 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.963198
+0:The total amount of wall time                        = 90.488472
 
 Test 032 control_debug_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 033 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -956,13 +956,13 @@ Checking test 033 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 107.827748
+0:The total amount of wall time                        = 107.555410
 
 Test 033 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -977,13 +977,13 @@ Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 213.603407
+0:The total amount of wall time                        = 213.806738
 
 Test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/cpld_control_c96_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/cpld_control_c96_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/cpld_control_c96_p7
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/cpld_control_c96_p7
 Checking test 035 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1033,13 +1033,13 @@ Checking test 035 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 366.559779
+0:The total amount of wall time                        = 367.353657
 
 Test 035 cpld_control_c96_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/GNU/cpld_debug_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_52823/cpld_debug_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/GNU/cpld_debug_p7
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_3247/cpld_debug_p7
 Checking test 036 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1089,11 +1089,11 @@ Checking test 036 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 337.596209
+0:The total amount of wall time                        = 332.391847
 
 Test 036 cpld_debug_p7 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 16:43:52 MST 2021
-Elapsed time: 00h:31m:55s. Have a nice day!
+Thu Dec 23 07:27:04 MST 2021
+Elapsed time: 00h:30m:09s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,23 +1,23 @@
-Mon Dec 20 14:28:11 MST 2021
+Wed Dec 22 13:56:12 MST 2021
 Start Regression test
 
-Compile 001 elapsed time 1040 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 402 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 732 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 962 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 401 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 733 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 004 elapsed time 690 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 827 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 579 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 369 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 354 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 290 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 712 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 723 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 438 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 224 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 601 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 821 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 585 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 382 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 359 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 280 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 700 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 710 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 433 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 221 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 599 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_control_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,72 +70,72 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 249.593231
+0:The total amount of wall time                        = 249.136429
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_control_p7_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc ............ALT CHECK......NOT OK
+ Comparing sfcf024.tile2.nc ............ALT CHECK......NOT OK
+ Comparing sfcf024.tile3.nc ............ALT CHECK......NOT OK
+ Comparing sfcf024.tile4.nc ............ALT CHECK......NOT OK
+ Comparing sfcf024.tile5.nc ............ALT CHECK......NOT OK
+ Comparing sfcf024.tile6.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile1.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile2.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile3.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile4.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile5.nc ............ALT CHECK......NOT OK
+ Comparing atmf024.tile6.nc ............ALT CHECK......NOT OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_grd.glo_1deg .........OK
- Comparing 20210323.060000.out_pnt.points .........OK
- Comparing 20210323.060000.restart.glo_1deg .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile2.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile4.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile5.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/phy_data.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile2.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile4.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile5.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/sfc_data.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/MOM.res.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/iced.2021-03-23-21600.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc ............ALT CHECK......NOT OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........NOT OK
+ Comparing 20210323.060000.out_pnt.points .........NOT OK
+ Comparing 20210323.060000.restart.glo_1deg .........NOT OK
 
-0:The total amount of wall time                        = 358.712565
+0:The total amount of wall time                        = 360.415052
 
-Test 002 cpld_control_p7_rrtmgp PASS
+Test 002 cpld_control_p7_rrtmgp FAIL Tries: 2
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_2threads_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -188,13 +188,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 475.684586
+0:The total amount of wall time                        = 480.066069
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_decomp_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_decomp_p7
 Checking test 004 cpld_decomp_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -247,13 +247,13 @@ Checking test 004 cpld_decomp_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 238.363292
+0:The total amount of wall time                        = 246.955967
 
 Test 004 cpld_decomp_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_mpi_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_mpi_p7
 Checking test 005 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -306,13 +306,13 @@ Checking test 005 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 210.713700
+0:The total amount of wall time                        = 213.367266
 
 Test 005 cpld_mpi_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_bmark_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -357,13 +357,13 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 964.068828
+0:The total amount of wall time                        = 969.987899
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_bmark_mpi_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_bmark_mpi_p7
 Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 952.854745
+0:The total amount of wall time                        = 953.107234
 
 Test 007 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_control_c96_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_control_c96_p7
 Checking test 008 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -464,13 +464,13 @@ Checking test 008 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 242.313368
+0:The total amount of wall time                        = 243.999444
 
 Test 008 cpld_control_c96_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_restart_c96_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_restart_c96_p7
 Checking test 009 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -520,13 +520,13 @@ Checking test 009 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 126.364500
+0:The total amount of wall time                        = 128.492657
 
 Test 009 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_control_c192_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_control_c192_p7
 Checking test 010 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -576,13 +576,13 @@ Checking test 010 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 1023.894215
+0:The total amount of wall time                        = 1027.298357
 
 Test 010 cpld_control_c192_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_restart_c192_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_restart_c192_p7
 Checking test 011 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -632,13 +632,13 @@ Checking test 011 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 653.589725
+0:The total amount of wall time                        = 651.202277
 
 Test 011 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_control_c384_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_control_c384_p7
 Checking test 012 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -681,13 +681,13 @@ Checking test 012 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 1095.716684
+0:The total amount of wall time                        = 1098.256706
 
 Test 012 cpld_control_c384_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_restart_c384_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_restart_c384_p7
 Checking test 013 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -730,13 +730,13 @@ Checking test 013 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 575.468415
+0:The total amount of wall time                        = 581.072639
 
 Test 013 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_debug_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/cpld_debug_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_debug_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/cpld_debug_p7
 Checking test 014 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -786,13 +786,13 @@ Checking test 014 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 653.396863
+0:The total amount of wall time                        = 652.428816
 
 Test 014 cpld_debug_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -839,13 +839,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 147.139556
+0:The total amount of wall time                        = 146.387626
 
 Test 015 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 150.835253
+0:The total amount of wall time                        = 151.159537
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_2threads
 Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 317.852516
+0:The total amount of wall time                        = 318.085414
 
 Test 017 control_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_restart
 Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -982,13 +982,13 @@ Checking test 018 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 75.130174
+0:The total amount of wall time                        = 75.764532
 
 Test 018 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_fhzero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_fhzero
 Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1031,13 +1031,13 @@ Checking test 019 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 139.160255
+0:The total amount of wall time                        = 138.455391
 
 Test 019 control_fhzero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_CubedSphereGrid
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1064,13 +1064,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.008605
+0:The total amount of wall time                        = 142.101085
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_latlon
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_latlon
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_latlon
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1081,13 +1081,13 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 145.706099
+0:The total amount of wall time                        = 144.969032
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1098,13 +1098,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 151.570708
+0:The total amount of wall time                        = 147.507049
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_c48
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1143,13 +1143,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 426.277832
+0:The total amount of wall time                        = 421.570186
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1160,13 +1160,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 571.196810
+0:The total amount of wall time                        = 583.989894
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1177,13 +1177,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1084.871685
+0:The total amount of wall time                        = 1093.900524
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_c384gdas
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1226,13 +1226,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 932.170530
+0:The total amount of wall time                        = 952.734727
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1243,26 +1243,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 94.122064
+0:The total amount of wall time                        = 97.480058
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_stochy_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 51.100178
+0:The total amount of wall time                        = 50.395844
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_lndp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1273,13 +1273,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 85.071652
+0:The total amount of wall time                        = 87.653913
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_p7
 Checking test 030 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1326,13 +1326,13 @@ Checking test 030 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 161.638379
+0:The total amount of wall time                        = 164.877560
 
 Test 030 control_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_p7_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_p7_rrtmgp
 Checking test 031 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1379,13 +1379,13 @@ Checking test 031 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 281.106369
+0:The total amount of wall time                        = 276.707340
 
 Test 031 control_p7_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_restart_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_restart_p7
 Checking test 032 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1424,13 +1424,13 @@ Checking test 032 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 84.128134
+0:The total amount of wall time                        = 86.382478
 
 Test 032 control_restart_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_decomp_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_decomp_p7
 Checking test 033 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1473,13 +1473,13 @@ Checking test 033 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 167.222432
+0:The total amount of wall time                        = 167.424732
 
 Test 033 control_decomp_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_2threads_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_2threads_p7
 Checking test 034 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1522,13 +1522,13 @@ Checking test 034 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 358.701386
+0:The total amount of wall time                        = 359.187593
 
 Test 034 control_2threads_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1539,26 +1539,26 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 345.542794
+0:The total amount of wall time                        = 348.947705
 
 Test 035 regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 191.669046
+0:The total amount of wall time                        = 190.500299
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_noquilt
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_noquilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_noquilt
 Checking test 037 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1566,13 +1566,13 @@ Checking test 037 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 369.049524
+0:The total amount of wall time                        = 368.749971
 
 Test 037 regional_noquilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,13 +1583,13 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 928.330207
+0:The total amount of wall time                        = 931.011850
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_hafs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_hafs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_hafs
 Checking test 039 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1598,26 +1598,26 @@ Checking test 039 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 349.252484
+0:The total amount of wall time                        = 350.771691
 
 Test 039 regional_hafs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_netcdf_parallel
 Checking test 040 regional_netcdf_parallel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 341.096256
+0:The total amount of wall time                        = 348.171474
 
 Test 040 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_RRTMGP
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_RRTMGP
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_RRTMGP
 Checking test 041 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1628,13 +1628,13 @@ Checking test 041 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 652.198462
+0:The total amount of wall time                        = 653.367577
 
 Test 041 regional_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1681,13 +1681,13 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.619505
+0:The total amount of wall time                        = 412.099623
 
 Test 042 rap_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1734,13 +1734,13 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 860.618236
+0:The total amount of wall time                        = 871.630427
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_sfcdiff
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1787,13 +1787,13 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.698869
+0:The total amount of wall time                        = 411.787094
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_sfcdiff_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_sfcdiff_restart
 Checking test 045 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1832,13 +1832,13 @@ Checking test 045 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 207.479963
+0:The total amount of wall time                        = 206.471771
 
 Test 045 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hrrr_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hrrr_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hrrr_control
 Checking test 046 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1885,13 +1885,13 @@ Checking test 046 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 394.373717
+0:The total amount of wall time                        = 393.885086
 
 Test 046 hrrr_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rrfs_v1beta
 Checking test 047 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1938,13 +1938,13 @@ Checking test 047 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 394.450374
+0:The total amount of wall time                        = 399.642399
 
 Test 047 rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_rrtmgp
 Checking test 048 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1955,13 +1955,13 @@ Checking test 048 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 314.464208
+0:The total amount of wall time                        = 314.257891
 
 Test 048 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_rrtmgp_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_rrtmgp_c192
 Checking test 049 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1972,13 +1972,13 @@ Checking test 049 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 737.293517
+0:The total amount of wall time                        = 793.165709
 
 Test 049 control_rrtmgp_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_csawmg
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_csawmg
 Checking test 050 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1989,13 +1989,13 @@ Checking test 050 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 318.107992
+0:The total amount of wall time                        = 402.024497
 
 Test 050 control_csawmg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_csawmgt
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_csawmgt
 Checking test 051 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2006,13 +2006,13 @@ Checking test 051 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 398.996238
+0:The total amount of wall time                        = 400.267827
 
 Test 051 control_csawmgt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_flake
 Checking test 052 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2023,13 +2023,13 @@ Checking test 052 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 266.383828
+0:The total amount of wall time                        = 252.143572
 
 Test 052 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_ras
 Checking test 053 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2040,13 +2040,13 @@ Checking test 053 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 201.422492
+0:The total amount of wall time                        = 206.385770
 
 Test 053 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_thompson
 Checking test 054 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2057,13 +2057,13 @@ Checking test 054 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 257.677206
+0:The total amount of wall time                        = 259.763821
 
 Test 054 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_thompson_no_aero
 Checking test 055 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2074,13 +2074,13 @@ Checking test 055 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 250.077004
+0:The total amount of wall time                        = 248.993671
 
 Test 055 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2145,13 +2145,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 202.246834
+0:The total amount of wall time                        = 201.503781
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2166,50 +2166,50 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-0:The total amount of wall time                        = 348.908985
+0:The total amount of wall time                        = 348.847024
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wam_repro
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_wam_repro
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wam_repro
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_wam_repro
 Checking test 058 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 132.763418
+0:The total amount of wall time                        = 137.483937
 
 Test 058 control_wam PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_debug
 Checking test 059 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.594344
+0:The total amount of wall time                        = 158.766756
 
 Test 059 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_2threads_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_2threads_debug
 Checking test 060 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 272.614556
+0:The total amount of wall time                        = 272.871991
 
 Test 060 control_2threads_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_CubedSphereGrid_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_CubedSphereGrid_debug
 Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2236,338 +2236,338 @@ Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 173.791886
+0:The total amount of wall time                        = 168.971478
 
 Test 061 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_wrtGauss_netcdf_parallel_debug
 Checking test 062 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf001.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 157.904924
+0:The total amount of wall time                        = 158.698543
 
 Test 062 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_stochy_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_stochy_debug
 Checking test 063 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 179.217679
+0:The total amount of wall time                        = 177.457864
 
 Test 063 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 161.568307
+0:The total amount of wall time                        = 160.014694
 
 Test 064 control_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_rrtmgp_debug
 Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 188.172089
+0:The total amount of wall time                        = 186.059423
 
 Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_csawmg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_csawmg_debug
 Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 214.444387
+0:The total amount of wall time                        = 251.516423
 
 Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_csawmgt_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_csawmgt_debug
 Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 250.071102
+0:The total amount of wall time                        = 246.330490
 
 Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_ras_debug
 Checking test 068 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 161.281479
+0:The total amount of wall time                        = 162.091338
 
 Test 068 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_diag_debug
 Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 165.142519
+0:The total amount of wall time                        = 165.083557
 
 Test 069 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_debug_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_debug_p7
 Checking test 070 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 172.027855
+0:The total amount of wall time                        = 169.535812
 
 Test 070 control_debug_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_thompson_debug
 Checking test 071 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.512681
+0:The total amount of wall time                        = 182.387965
 
 Test 071 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_thompson_no_aero_debug
 Checking test 072 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 176.006473
+0:The total amount of wall time                        = 185.682619
 
 Test 072 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_thompson_extdiag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug_extdiag
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_thompson_extdiag_debug
 Checking test 073 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 194.027964
+0:The total amount of wall time                        = 192.712005
 
 Test 073 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/regional_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/regional_debug
 Checking test 074 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 260.145053
+0:The total amount of wall time                        = 259.809075
 
 Test 074 regional_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_control_debug
 Checking test 075 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.121555
+0:The total amount of wall time                        = 283.835874
 
 Test 075 rap_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_unified_drag_suite_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_unified_drag_suite_debug
 Checking test 076 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.155204
+0:The total amount of wall time                        = 283.528798
 
 Test 076 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_diag_debug
 Checking test 077 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 301.410795
+0:The total amount of wall time                        = 297.031725
 
 Test 077 rap_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_cires_ugwp_debug
 Checking test 078 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 292.418409
+0:The total amount of wall time                        = 289.179556
 
 Test 078 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_unified_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_unified_ugwp_debug
 Checking test 079 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.841010
+0:The total amount of wall time                        = 289.780491
 
 Test 079 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_noah_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_noah_debug
 Checking test 080 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.359834
+0:The total amount of wall time                        = 280.392239
 
 Test 080 rap_noah_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_rrtmgp_debug
 Checking test 081 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 497.424188
+0:The total amount of wall time                        = 495.256015
 
 Test 081 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_lndp_debug
 Checking test 082 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.771630
+0:The total amount of wall time                        = 286.320147
 
 Test 082 rap_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_sfcdiff_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_sfcdiff_debug
 Checking test 083 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.786483
+0:The total amount of wall time                        = 284.900955
 
 Test 083 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_flake_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_flake_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_flake_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_flake_debug
 Checking test 084 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.529515
+0:The total amount of wall time                        = 283.390645
 
 Test 084 rap_flake_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 085 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 474.867919
+0:The total amount of wall time                        = 470.223252
 
 Test 085 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/rrfs_v1beta_debug
 Checking test 086 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.969547
+0:The total amount of wall time                        = 281.780824
 
 Test 086 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,24 +2632,24 @@ Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 220.902775
+0:The total amount of wall time                        = 219.752261
 
 Test 087 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_atm
 Checking test 088 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 506.128871
+0:The total amount of wall time                        = 506.680154
 
 Test 088 hafs_regional_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_atm_ocn
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_atm_ocn
 Checking test 089 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2658,26 +2658,26 @@ Checking test 089 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 411.657578
+0:The total amount of wall time                        = 410.118046
 
 Test 089 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_atm_wav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_atm_wav
 Checking test 090 hafs_regional_atm_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 962.516532
+0:The total amount of wall time                        = 942.053901
 
 Test 090 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_atm_ocn_wav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_atm_ocn_wav
 Checking test 091 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2686,57 +2686,57 @@ Checking test 091 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1018.941084
+0:The total amount of wall time                        = 1058.493600
 
 Test 091 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_1nest_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_1nest_atm
 Checking test 092 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 1006.011680
+0:The total amount of wall time                        = 1007.138809
 
 Test 092 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_telescopic_2nests_atm
 Checking test 093 hafs_regional_telescopic_2nests_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1041.250210
+0:The total amount of wall time                        = 1057.204135
 
 Test 093 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_global_1nest_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_global_1nest_atm
 Checking test 094 hafs_global_1nest_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 671.400082
+0:The total amount of wall time                        = 671.766186
 
 Test 094 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_global_multiple_4nests_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_global_multiple_4nests_atm
 Checking test 095 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1099.722254
+0:The total amount of wall time                        = 1118.169819
 
 Test 095 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_docn
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_docn
 Checking test 096 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2744,13 +2744,13 @@ Checking test 096 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 357.800915
+0:The total amount of wall time                        = 356.098701
 
 Test 096 hafs_regional_docn PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_docn_oisst
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_docn_oisst
 Checking test 097 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2758,97 +2758,97 @@ Checking test 097 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 355.379044
+0:The total amount of wall time                        = 356.791713
 
 Test 097 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/hafs_regional_datm_cdeps
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/hafs_regional_datm_cdeps
 Checking test 098 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1295.503029
+0:The total amount of wall time                        = 1297.815455
 
 Test 098 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_control_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_control_cfsr
 Checking test 099 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.126427
+0:The total amount of wall time                        = 161.271664
 
 Test 099 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_restart_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_restart_cfsr
 Checking test 100 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 99.544566
+0:The total amount of wall time                        = 98.633329
 
 Test 100 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_control_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_control_gefs
 Checking test 101 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 154.941253
+0:The total amount of wall time                        = 154.712485
 
 Test 101 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_stochy_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_stochy_gefs
 Checking test 102 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 157.842056
+0:The total amount of wall time                        = 157.380379
 
 Test 102 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_bulk_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_bulk_cfsr
 Checking test 103 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 156.351098
+0:The total amount of wall time                        = 162.693463
 
 Test 103 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_bulk_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_bulk_gefs
 Checking test 104 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 154.570911
+0:The total amount of wall time                        = 149.205022
 
 Test 104 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_mx025_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_mx025_cfsr
 Checking test 105 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2857,13 +2857,13 @@ Checking test 105 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 344.514555
+0:The total amount of wall time                        = 344.087893
 
 Test 105 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_mx025_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_mx025_gefs
 Checking test 106 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2872,35 +2872,35 @@ Checking test 106 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 336.039277
+0:The total amount of wall time                        = 326.468388
 
 Test 106 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_multiple_files_cfsr
 Checking test 107 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.960811
+0:The total amount of wall time                        = 160.936580
 
 Test 107 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/datm_cdeps_debug_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/datm_cdeps_debug_cfsr
 Checking test 108 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 451.538430
+0:The total amount of wall time                        = 451.146525
 
 Test 108 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_55000/control_atmwav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atmwav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_64479/control_atmwav
 Checking test 109 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2944,11 +2944,81 @@ Checking test 109 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 133.617202
+0:The total amount of wall time                        = 133.633691
 
 Test 109 control_atmwav PASS
 
+FAILED TESTS: 
+Test cpld_control_p7_rrtmgp 002 failed in check_result failed 
+Test cpld_control_p7_rrtmgp 002 failed in run_test failed 
+
+REGRESSION TEST FAILED
+Wed Dec 22 15:01:40 MST 2021
+Elapsed time: 01h:05m:29s. Have a nice day!
+Wed Dec 22 21:32:45 MST 2021
+Start Regression test
+
+Compile 001 elapsed time 874 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_1282/cpld_control_p7_rrtmgp
+Checking test 001 cpld_control_p7_rrtmgp results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
+
+0:The total amount of wall time                        = 354.031184
+
+Test 001 cpld_control_p7_rrtmgp PASS
+
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 15:36:39 MST 2021
-Elapsed time: 01h:08m:29s. Have a nice day!
+Wed Dec 22 21:56:44 MST 2021
+Elapsed time: 00h:24m:00s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,23 +1,25 @@
-Mon Dec 20 17:11:22 EST 2021
+Wed Dec 22 23:30:41 EST 2021
 Start Regression test
 
-Compile 001 elapsed time 590 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 227 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 461 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 461 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 484 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 959 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 230 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 474 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 484 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 981 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 143 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 432 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Test 005 compile FAIL
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_control_p7
+Compile 001 elapsed time 841 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 280 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 676 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 659 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 659 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 556 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 316 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 316 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 275 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 626 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 645 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 316 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 182 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 629 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +72,13 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 252.305610
+  0: The total amount of wall time                        = 253.216181
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_control_p7_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -129,13 +131,13 @@ Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 340.057084
+  0: The total amount of wall time                        = 347.862542
 
 Test 002 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_2threads_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -188,13 +190,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 310.587037
+  0: The total amount of wall time                        = 305.492745
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_decomp_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_decomp_p7
 Checking test 004 cpld_decomp_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -247,13 +249,13 @@ Checking test 004 cpld_decomp_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 295.958013
+  0: The total amount of wall time                        = 286.878068
 
 Test 004 cpld_decomp_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_mpi_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_mpi_p7
 Checking test 005 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -306,13 +308,13 @@ Checking test 005 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 242.783604
+  0: The total amount of wall time                        = 214.786353
 
 Test 005 cpld_mpi_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_bmark_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -357,13 +359,13 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 995.041038
+  0: The total amount of wall time                        = 988.512484
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_bmark_mpi_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_bmark_mpi_p7
 Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -408,13 +410,13 @@ Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 967.952006
+  0: The total amount of wall time                        = 980.551722
 
 Test 007 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_control_c96_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_control_c96_p7
 Checking test 008 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -464,13 +466,13 @@ Checking test 008 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 259.831362
+  0: The total amount of wall time                        = 230.144903
 
 Test 008 cpld_control_c96_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_restart_c96_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_restart_c96_p7
 Checking test 009 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -520,13 +522,13 @@ Checking test 009 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 167.193483
+  0: The total amount of wall time                        = 163.098039
 
 Test 009 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_control_c192_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_control_c192_p7
 Checking test 010 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -576,13 +578,13 @@ Checking test 010 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1022.215334
+  0: The total amount of wall time                        = 1026.098849
 
 Test 010 cpld_control_c192_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_restart_c192_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_restart_c192_p7
 Checking test 011 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -632,13 +634,13 @@ Checking test 011 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 650.576363
+  0: The total amount of wall time                        = 661.528931
 
 Test 011 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_control_c384_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_control_c384_p7
 Checking test 012 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -681,13 +683,13 @@ Checking test 012 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1087.819677
+  0: The total amount of wall time                        = 1095.527850
 
 Test 012 cpld_control_c384_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_restart_c384_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_restart_c384_p7
 Checking test 013 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -730,13 +732,13 @@ Checking test 013 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 630.679564
+  0: The total amount of wall time                        = 642.221498
 
 Test 013 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_debug_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/cpld_debug_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_debug_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/cpld_debug_p7
 Checking test 014 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -786,13 +788,13 @@ Checking test 014 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 667.311747
+  0: The total amount of wall time                        = 636.798899
 
 Test 014 cpld_debug_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -839,13 +841,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.598884
+  0: The total amount of wall time                        = 160.349362
 
 Test 015 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -888,13 +890,13 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.085143
+  0: The total amount of wall time                        = 139.277415
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_2threads
 Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +939,13 @@ Checking test 017 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 172.064939
+ 0: The total amount of wall time                        = 171.620728
 
 Test 017 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_restart
 Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -982,13 +984,13 @@ Checking test 018 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 71.312940
+  0: The total amount of wall time                        = 99.479898
 
 Test 018 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_fhzero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_fhzero
 Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1031,13 +1033,13 @@ Checking test 019 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.658601
+  0: The total amount of wall time                        = 156.567579
 
 Test 019 control_fhzero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1064,13 +1066,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.466847
+  0: The total amount of wall time                        = 127.742276
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1081,13 +1083,13 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.226039
+  0: The total amount of wall time                        = 131.738755
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1098,13 +1100,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 163.042088
+  0: The total amount of wall time                        = 141.347601
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1143,13 +1145,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 352.685152
+0: The total amount of wall time                        = 354.875937
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1160,13 +1162,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 533.920326
+  0: The total amount of wall time                        = 538.568159
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1177,13 +1179,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 918.928478
+  0: The total amount of wall time                        = 922.975401
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1226,13 +1228,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 838.261747
+  0: The total amount of wall time                        = 856.887441
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1243,26 +1245,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 88.964763
+  0: The total amount of wall time                        = 88.222041
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.603196
+  0: The total amount of wall time                        = 75.705939
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1273,13 +1275,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 98.876532
+  0: The total amount of wall time                        = 104.175495
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_p7
 Checking test 030 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1326,13 +1328,13 @@ Checking test 030 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.758644
+  0: The total amount of wall time                        = 171.321479
 
 Test 030 control_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_p7_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_p7_rrtmgp
 Checking test 031 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1379,13 +1381,13 @@ Checking test 031 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 260.970347
+  0: The total amount of wall time                        = 260.749733
 
 Test 031 control_p7_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_restart_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_restart_p7
 Checking test 032 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1424,13 +1426,13 @@ Checking test 032 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 81.592371
+  0: The total amount of wall time                        = 105.237606
 
 Test 032 control_restart_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_decomp_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_decomp_p7
 Checking test 033 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1473,13 +1475,13 @@ Checking test 033 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.262026
+  0: The total amount of wall time                        = 162.677933
 
 Test 033 control_decomp_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_2threads_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_2threads_p7
 Checking test 034 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1522,13 +1524,13 @@ Checking test 034 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 208.393956
+ 0: The total amount of wall time                        = 203.785571
 
 Test 034 control_2threads_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1539,26 +1541,26 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 337.515729
+ 0: The total amount of wall time                        = 339.970931
 
 Test 035 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 183.032292
+ 0: The total amount of wall time                        = 188.815774
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_noquilt
 Checking test 037 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1566,13 +1568,13 @@ Checking test 037 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 354.101564
+ 0: The total amount of wall time                        = 359.728120
 
 Test 037 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,13 +1585,13 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 273.538948
+ 0: The total amount of wall time                        = 268.132248
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_hafs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_hafs
 Checking test 039 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1598,26 +1600,26 @@ Checking test 039 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 341.794521
+ 0: The total amount of wall time                        = 334.549885
 
 Test 039 regional_hafs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_netcdf_parallel
 Checking test 040 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 335.967357
+ 0: The total amount of wall time                        = 347.045912
 
 Test 040 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_RRTMGP
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_RRTMGP
 Checking test 041 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1628,13 +1630,13 @@ Checking test 041 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 620.081418
+ 0: The total amount of wall time                        = 594.861263
 
 Test 041 regional_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1681,13 +1683,13 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 375.962900
+  0: The total amount of wall time                        = 410.697765
 
 Test 042 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1734,13 +1736,13 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 501.497269
+ 0: The total amount of wall time                        = 504.069290
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1787,13 +1789,13 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 379.793827
+  0: The total amount of wall time                        = 407.650673
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_sfcdiff_restart
 Checking test 045 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1832,13 +1834,13 @@ Checking test 045 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.952357
+  0: The total amount of wall time                        = 196.116990
 
 Test 045 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hrrr_control
 Checking test 046 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1885,13 +1887,13 @@ Checking test 046 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 366.931617
+  0: The total amount of wall time                        = 397.739709
 
 Test 046 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rrfs_v1beta
 Checking test 047 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1938,13 +1940,13 @@ Checking test 047 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 377.520041
+  0: The total amount of wall time                        = 405.019313
 
 Test 047 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_rrtmgp
 Checking test 048 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1955,13 +1957,13 @@ Checking test 048 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 261.766733
+  0: The total amount of wall time                        = 286.006040
 
 Test 048 control_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_rrtmgp_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_rrtmgp_c192
 Checking test 049 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1972,13 +1974,13 @@ Checking test 049 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 679.996686
+  0: The total amount of wall time                        = 713.220245
 
 Test 049 control_rrtmgp_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_csawmgt
 Checking test 050 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1989,13 +1991,13 @@ Checking test 050 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 365.183885
+  0: The total amount of wall time                        = 370.545482
 
 Test 050 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_flake
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_flake
 Checking test 051 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2006,13 +2008,13 @@ Checking test 051 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 250.861664
+  0: The total amount of wall time                        = 257.517429
 
 Test 051 control_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_ras
 Checking test 052 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2023,13 +2025,13 @@ Checking test 052 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.384453
+  0: The total amount of wall time                        = 183.469673
 
 Test 052 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_thompson
 Checking test 053 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2040,13 +2042,13 @@ Checking test 053 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 231.088458
+  0: The total amount of wall time                        = 233.970747
 
 Test 053 control_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_thompson_no_aero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_thompson_no_aero
 Checking test 054 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2057,13 +2059,13 @@ Checking test 054 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.307127
+  0: The total amount of wall time                        = 243.444006
 
 Test 054 control_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/fv3_HAFS_v0_hwrf_thompson
 Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2128,13 +2130,13 @@ Checking test 055 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.231385
+  0: The total amount of wall time                        = 199.598720
 
 Test 055 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2149,50 +2151,50 @@ Checking test 056 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 305.405826
+ 0: The total amount of wall time                        = 312.396759
 
 Test 056 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wam_repro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_wam_repro
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wam_repro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_wam_repro
 Checking test 057 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 116.329091
+  0: The total amount of wall time                        = 142.769070
 
 Test 057 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_debug
 Checking test 058 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.696573
+  0: The total amount of wall time                        = 150.202812
 
 Test 058 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_2threads_debug
 Checking test 059 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 254.920975
+ 0: The total amount of wall time                        = 258.583676
 
 Test 059 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_CubedSphereGrid_debug
 Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2219,338 +2221,338 @@ Checking test 060 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.421025
+  0: The total amount of wall time                        = 160.486640
 
 Test 060 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_wrtGauss_netcdf_parallel_debug
 Checking test 061 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.247506
+  0: The total amount of wall time                        = 161.846568
 
 Test 061 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_stochy_debug
 Checking test 062 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.460942
+  0: The total amount of wall time                        = 171.652391
 
 Test 062 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_lndp_debug
 Checking test 063 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.381538
+  0: The total amount of wall time                        = 151.318940
 
 Test 063 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_rrtmgp_debug
 Checking test 064 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 182.664120
+  0: The total amount of wall time                        = 180.094627
 
 Test 064 control_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_csawmg_debug
 Checking test 065 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 217.877465
+  0: The total amount of wall time                        = 254.853137
 
 Test 065 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_csawmgt_debug
 Checking test 066 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 248.996518
+  0: The total amount of wall time                        = 253.726164
 
 Test 066 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_ras_debug
 Checking test 067 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.290370
+  0: The total amount of wall time                        = 160.630029
 
 Test 067 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_diag_debug
 Checking test 068 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.991791
+  0: The total amount of wall time                        = 156.563622
 
 Test 068 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_debug_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_debug_p7
 Checking test 069 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.436328
+  0: The total amount of wall time                        = 172.750997
 
 Test 069 control_debug_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_thompson_debug
 Checking test 070 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.644414
+  0: The total amount of wall time                        = 179.996959
 
 Test 070 control_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_thompson_no_aero_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_thompson_no_aero_debug
 Checking test 071 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.486291
+  0: The total amount of wall time                        = 174.019737
 
 Test 071 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_thompson_extdiag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug_extdiag
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_thompson_extdiag_debug
 Checking test 072 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 184.380795
+  0: The total amount of wall time                        = 182.048032
 
 Test 072 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/regional_debug
 Checking test 073 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 264.184141
+ 0: The total amount of wall time                        = 259.084317
 
 Test 073 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_control_debug
 Checking test 074 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.936015
+  0: The total amount of wall time                        = 278.636589
 
 Test 074 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_unified_drag_suite_debug
 Checking test 075 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.102300
+  0: The total amount of wall time                        = 279.962724
 
 Test 075 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_diag_debug
 Checking test 076 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.990819
+  0: The total amount of wall time                        = 293.362051
 
 Test 076 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_cires_ugwp_debug
 Checking test 077 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.823810
+  0: The total amount of wall time                        = 282.690198
 
 Test 077 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_unified_ugwp_debug
 Checking test 078 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.541617
+  0: The total amount of wall time                        = 286.819424
 
 Test 078 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_noah_debug
 Checking test 079 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.572442
+  0: The total amount of wall time                        = 276.014201
 
 Test 079 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_rrtmgp_debug
 Checking test 080 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 488.159724
+  0: The total amount of wall time                        = 489.838326
 
 Test 080 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_lndp_debug
 Checking test 081 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.414071
+  0: The total amount of wall time                        = 285.040012
 
 Test 081 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_sfcdiff_debug
 Checking test 082 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.393228
+  0: The total amount of wall time                        = 280.090122
 
 Test 082 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_flake_debug
 Checking test 083 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.582896
+  0: The total amount of wall time                        = 279.106682
 
 Test 083 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 084 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 464.188841
+  0: The total amount of wall time                        = 468.216147
 
 Test 084 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/rrfs_v1beta_debug
 Checking test 085 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.814109
+  0: The total amount of wall time                        = 277.257931
 
 Test 085 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 086 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2615,13 +2617,13 @@ Checking test 086 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 210.114031
+  0: The total amount of wall time                        = 210.933364
 
 Test 086 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 087 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2636,24 +2638,24 @@ Checking test 087 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 383.176109
+ 0: The total amount of wall time                        = 384.155327
 
 Test 087 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_atm
 Checking test 088 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 274.320272
+  0: The total amount of wall time                        = 311.304098
 
 Test 088 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_atm_ocn
 Checking test 089 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2662,99 +2664,99 @@ Checking test 089 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 386.289580
+  0: The total amount of wall time                        = 447.232778
 
 Test 089 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_atm_wav
 Checking test 090 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 854.543627
+  0: The total amount of wall time                        = 896.901009
 
 Test 090 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_atm_ocn_wav
 Checking test 091 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 941.107000
+  0: The total amount of wall time                        = 983.511078
 
 Test 091 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_1nest_atm
 Checking test 092 hafs_regional_1nest_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 506.146354
+  0: The total amount of wall time                        = 516.265141
 
 Test 092 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_telescopic_2nests_atm
 Checking test 093 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 529.537957
+  0: The total amount of wall time                        = 549.170878
 
 Test 093 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_global_1nest_atm
 Checking test 094 hafs_global_1nest_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 238.248369
+  0: The total amount of wall time                        = 259.934415
 
 Test 094 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_global_multiple_4nests_atm
 Checking test 095 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 551.581675
+  0: The total amount of wall time                        = 554.295163
 
 Test 095 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_docn
 Checking test 096 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 347.252094
+  0: The total amount of wall time                        = 416.050494
 
 Test 096 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_docn_oisst
 Checking test 097 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2762,97 +2764,97 @@ Checking test 097 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 381.900750
+  0: The total amount of wall time                        = 409.301759
 
 Test 097 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/hafs_regional_datm_cdeps
 Checking test 098 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1047.343394
+  0: The total amount of wall time                        = 1049.134611
 
 Test 098 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_control_cfsr
 Checking test 099 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.592655
+ 0: The total amount of wall time                        = 148.781617
 
 Test 099 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_restart_cfsr
 Checking test 100 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 83.676932
+ 0: The total amount of wall time                        = 115.930024
 
 Test 100 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_control_gefs
 Checking test 101 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.559875
+ 0: The total amount of wall time                        = 143.093791
 
 Test 101 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_stochy_gefs
 Checking test 102 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 206.959267
+ 0: The total amount of wall time                        = 148.819729
 
 Test 102 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_bulk_cfsr
 Checking test 103 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.917225
+ 0: The total amount of wall time                        = 146.722900
 
 Test 103 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_bulk_gefs
 Checking test 104 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.571091
+ 0: The total amount of wall time                        = 146.321850
 
 Test 104 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_mx025_cfsr
 Checking test 105 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2861,13 +2863,13 @@ Checking test 105 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 340.426540
+  0: The total amount of wall time                        = 348.726150
 
 Test 105 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_mx025_gefs
 Checking test 106 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2876,35 +2878,35 @@ Checking test 106 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 338.464941
+  0: The total amount of wall time                        = 370.324378
 
 Test 106 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_multiple_files_cfsr
 Checking test 107 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.193313
+ 0: The total amount of wall time                        = 145.333926
 
 Test 107 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/datm_cdeps_debug_cfsr
 Checking test 108 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 361.033260
+ 0: The total amount of wall time                        = 361.808647
 
 Test 108 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_atmwav
 Checking test 109 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2948,13 +2950,13 @@ Checking test 109 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 118.956255
+  0: The total amount of wall time                        = 114.925422
 
 Test 109 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_2290/control_c384gdas_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_1817/control_c384gdas_wav
 Checking test 110 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3000,11 +3002,11 @@ Checking test 110 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 1409.034793
+  0: The total amount of wall time                        = 1499.874604
 
 Test 110 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 18:38:44 EST 2021
-Elapsed time: 01h:27m:23s. Have a nice day!
+Thu Dec 23 01:01:21 EST 2021
+Elapsed time: 01h:30m:41s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,19 @@
-Mon Dec 20 22:58:38 UTC 2021
+Thu Dec 23 03:42:39 UTC 2021
 Start Regression test
 
 Test 004 compile FAIL
 
-Compile 001 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_HAFS_v0_hwrf_thompson,FV3_GFS_v16_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 278 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 97 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 224 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 115 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Test 003 compile FAIL
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control
+Compile 001 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_HAFS_v0_hwrf_thompson,FV3_GFS_v16_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 195 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 283 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 95 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 224 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 119 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,13 +60,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 847.741875
+  0: The total amount of wall time                        = 912.665117
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -103,13 +105,13 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 392.072323
+  0: The total amount of wall time                        = 396.545681
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,13 +150,13 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 679.439483
+0: The total amount of wall time                        = 780.464390
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -165,13 +167,13 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 639.422343
+  0: The total amount of wall time                        = 727.126769
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -182,13 +184,13 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1449.918886
+  0: The total amount of wall time                        = 1468.770790
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -199,13 +201,13 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 873.153726
+  0: The total amount of wall time                        = 976.811307
 
 Test 006 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -216,13 +218,13 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1020.996672
+  0: The total amount of wall time                        = 1113.386755
 
 Test 007 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -233,13 +235,13 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 962.666960
+  0: The total amount of wall time                        = 1078.041528
 
 Test 008 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -250,13 +252,13 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 800.326255
+  0: The total amount of wall time                        = 929.041072
 
 Test 009 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_p7
 Checking test 010 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -303,13 +305,13 @@ Checking test 010 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 794.096801
+  0: The total amount of wall time                        = 934.318246
 
 Test 010 control_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/fv3_HAFS_v0_hwrf_thompson
 Checking test 011 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -374,13 +376,13 @@ Checking test 011 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 655.531224
+  0: The total amount of wall time                        = 744.272703
 
 Test 011 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 012 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -395,13 +397,13 @@ Checking test 012 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 449.184318
+ 0: The total amount of wall time                        = 550.049253
 
 Test 012 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_control
 Checking test 013 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -448,13 +450,13 @@ Checking test 013 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1451.880363
+  0: The total amount of wall time                        = 1465.657932
 
 Test 013 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_2threads
 Checking test 014 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -501,13 +503,13 @@ Checking test 014 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1371.499234
+ 0: The total amount of wall time                        = 1549.739489
 
 Test 014 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_sfcdiff
 Checking test 015 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -554,13 +556,13 @@ Checking test 015 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1465.436752
+  0: The total amount of wall time                        = 1467.306772
 
 Test 015 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_sfcdiff_restart
 Checking test 016 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -599,13 +601,13 @@ Checking test 016 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 671.682920
+  0: The total amount of wall time                        = 671.286931
 
 Test 016 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/hrrr_control
 Checking test 017 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -652,13 +654,13 @@ Checking test 017 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1375.682916
+  0: The total amount of wall time                        = 1476.727073
 
 Test 017 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rrfs_v1beta
 Checking test 018 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -705,195 +707,195 @@ Checking test 018 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1434.820325
+  0: The total amount of wall time                        = 1476.837057
 
 Test 018 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_debug
 Checking test 019 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 99.938407
+  0: The total amount of wall time                        = 103.915897
 
 Test 019 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_diag_debug
 Checking test 020 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 121.996144
+  0: The total amount of wall time                        = 128.241607
 
 Test 020 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/regional_debug
 Checking test 021 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 125.336801
+ 0: The total amount of wall time                        = 132.414064
 
 Test 021 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_control_debug
 Checking test 022 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.611295
+  0: The total amount of wall time                        = 174.891366
 
 Test 022 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_diag_debug
 Checking test 023 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 206.292198
+  0: The total amount of wall time                        = 218.832863
 
 Test 023 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 024 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.963756
+  0: The total amount of wall time                        = 278.215479
 
 Test 024 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/rrfs_v1beta_debug
 Checking test 025 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.480063
+  0: The total amount of wall time                        = 169.320620
 
 Test 025 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_thompson_debug
 Checking test 026 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.503118
+  0: The total amount of wall time                        = 129.636092
 
 Test 026 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_thompson_no_aero_debug
 Checking test 027 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 109.109781
+  0: The total amount of wall time                        = 128.106940
 
 Test 027 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_thompson_extdiag_debug
 Checking test 028 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 137.378309
+  0: The total amount of wall time                        = 140.178424
 
 Test 028 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_rrtmgp_debug
 Checking test 029 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.840926
+  0: The total amount of wall time                        = 115.098447
 
 Test 029 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_ras_debug
 Checking test 030 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 102.516423
+  0: The total amount of wall time                        = 151.504198
 
 Test 030 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_stochy_debug
 Checking test 031 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 119.239698
+  0: The total amount of wall time                        = 143.696426
 
 Test 031 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/control_debug_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/control_debug_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/control_debug_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/control_debug_p7
 Checking test 032 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 107.261507
+  0: The total amount of wall time                        = 143.435539
 
 Test 032 control_debug_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 033 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -958,13 +960,13 @@ Checking test 033 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.626511
+  0: The total amount of wall time                        = 136.817380
 
 Test 033 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -979,13 +981,13 @@ Checking test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 235.691686
+ 0: The total amount of wall time                        = 239.861192
 
 Test 034 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/cpld_control_c96_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/cpld_control_c96_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/cpld_control_c96_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/cpld_control_c96_p7
 Checking test 035 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1035,13 +1037,13 @@ Checking test 035 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1090.370348
+  0: The total amount of wall time                        = 1188.195229
 
 Test 035 cpld_control_c96_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/GNU/cpld_debug_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26714/cpld_debug_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/GNU/cpld_debug_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Jun.Wang/FV3_RT/rt_23203/cpld_debug_p7
 Checking test 036 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1091,11 +1093,11 @@ Checking test 036 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 562.117206
+  0: The total amount of wall time                        = 572.985050
 
 Test 036 cpld_debug_p7 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Dec 21 00:50:28 UTC 2021
-Elapsed time: 01h:51m:51s. Have a nice day!
+Thu Dec 23 04:53:28 UTC 2021
+Elapsed time: 01h:10m:50s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,24 +1,24 @@
-Mon Dec 20 21:15:06 UTC 2021
+Thu Dec 23 03:37:04 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 450 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 179 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 367 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 356 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 384 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 336 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 175 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 282 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 176 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 384 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 396 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 430 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 175 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 363 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 404 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 334 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 187 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 180 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 149 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 432 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 462 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 012 elapsed time 183 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 94 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 353 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 399 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 101 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 372 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 387 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_control_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -71,13 +71,13 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 209.638534
+  0: The total amount of wall time                        = 245.945344
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_control_p7_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -130,13 +130,13 @@ Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 280.195534
+  0: The total amount of wall time                        = 455.012902
 
 Test 002 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_2threads_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -189,13 +189,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 242.403666
+  0: The total amount of wall time                        = 269.889955
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_decomp_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_decomp_p7
 Checking test 004 cpld_decomp_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -248,13 +248,13 @@ Checking test 004 cpld_decomp_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 208.900087
+  0: The total amount of wall time                        = 237.400023
 
 Test 004 cpld_decomp_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_mpi_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_mpi_p7
 Checking test 005 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -307,13 +307,13 @@ Checking test 005 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 175.475957
+  0: The total amount of wall time                        = 218.195209
 
 Test 005 cpld_mpi_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_bmark_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -358,13 +358,13 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 890.983722
+  0: The total amount of wall time                        = 1345.414854
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_bmark_mpi_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_bmark_mpi_p7
 Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -409,13 +409,13 @@ Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 852.558713
+  0: The total amount of wall time                        = 1093.482948
 
 Test 007 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_control_c96_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_control_c96_p7
 Checking test 008 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -465,13 +465,13 @@ Checking test 008 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 200.941752
+  0: The total amount of wall time                        = 209.310907
 
 Test 008 cpld_control_c96_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_restart_c96_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_restart_c96_p7
 Checking test 009 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -521,13 +521,13 @@ Checking test 009 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 109.593342
+  0: The total amount of wall time                        = 122.496867
 
 Test 009 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_control_c192_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_control_c192_p7
 Checking test 010 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -577,13 +577,13 @@ Checking test 010 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 840.305696
+  0: The total amount of wall time                        = 1020.684682
 
 Test 010 cpld_control_c192_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_restart_c192_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_restart_c192_p7
 Checking test 011 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -633,13 +633,13 @@ Checking test 011 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 581.429209
+  0: The total amount of wall time                        = 565.942363
 
 Test 011 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_control_c384_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_control_c384_p7
 Checking test 012 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -682,13 +682,13 @@ Checking test 012 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1024.326587
+  0: The total amount of wall time                        = 1479.163127
 
 Test 012 cpld_control_c384_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_restart_c384_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_restart_c384_p7
 Checking test 013 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -731,13 +731,13 @@ Checking test 013 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 556.219775
+  0: The total amount of wall time                        = 567.230662
 
 Test 013 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_debug_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/cpld_debug_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_debug_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/cpld_debug_p7
 Checking test 014 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -787,13 +787,13 @@ Checking test 014 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 611.341097
+  0: The total amount of wall time                        = 681.461953
 
 Test 014 cpld_debug_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -840,13 +840,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.327906
+  0: The total amount of wall time                        = 130.926420
 
 Test 015 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -889,13 +889,13 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.699161
+  0: The total amount of wall time                        = 137.387446
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_2threads
 Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -938,13 +938,13 @@ Checking test 017 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 148.330449
+ 0: The total amount of wall time                        = 160.383292
 
 Test 017 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_restart
 Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -983,13 +983,13 @@ Checking test 018 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 62.966970
+  0: The total amount of wall time                        = 65.126269
 
 Test 018 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_fhzero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_fhzero
 Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1032,13 +1032,13 @@ Checking test 019 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.662777
+  0: The total amount of wall time                        = 121.285069
 
 Test 019 control_fhzero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1065,13 +1065,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 114.358635
+  0: The total amount of wall time                        = 122.528466
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1082,15 +1082,15 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 117.026396
+  0: The total amount of wall time                        = 130.705111
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
@@ -1099,13 +1099,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 119.556738
+  0: The total amount of wall time                        = 135.168436
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1144,13 +1144,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 310.828227
+0: The total amount of wall time                        = 310.783814
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1161,13 +1161,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 457.604093
+  0: The total amount of wall time                        = 474.668684
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1178,13 +1178,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 772.524169
+  0: The total amount of wall time                        = 1054.694946
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1227,13 +1227,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 672.189373
+  0: The total amount of wall time                        = 856.961516
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1244,26 +1244,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.304977
+  0: The total amount of wall time                        = 87.464470
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 43.140742
+  0: The total amount of wall time                        = 43.938354
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1274,13 +1274,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 72.401361
+  0: The total amount of wall time                        = 77.471905
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_p7
 Checking test 030 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1327,13 +1327,13 @@ Checking test 030 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 136.215057
+  0: The total amount of wall time                        = 142.114041
 
 Test 030 control_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_p7_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_p7_rrtmgp
 Checking test 031 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1380,13 +1380,13 @@ Checking test 031 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 209.267535
+  0: The total amount of wall time                        = 224.090278
 
 Test 031 control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_restart_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_restart_p7
 Checking test 032 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1425,13 +1425,13 @@ Checking test 032 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 72.830247
+  0: The total amount of wall time                        = 240.351467
 
 Test 032 control_restart_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_decomp_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_decomp_p7
 Checking test 033 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1474,13 +1474,13 @@ Checking test 033 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 140.029444
+  0: The total amount of wall time                        = 152.571717
 
 Test 033 control_decomp_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_2threads_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_2threads_p7
 Checking test 034 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1523,13 +1523,13 @@ Checking test 034 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 163.950355
+ 0: The total amount of wall time                        = 175.753786
 
 Test 034 control_2threads_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1540,26 +1540,26 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 295.385833
+ 0: The total amount of wall time                        = 305.803097
 
 Test 035 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 166.705803
+ 0: The total amount of wall time                        = 233.731151
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_noquilt
 Checking test 037 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1567,13 +1567,13 @@ Checking test 037 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 307.583399
+ 0: The total amount of wall time                        = 317.789141
 
 Test 037 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1584,13 +1584,13 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 212.272215
+ 0: The total amount of wall time                        = 222.738077
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_hafs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_hafs
 Checking test 039 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1599,26 +1599,26 @@ Checking test 039 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 292.966145
+ 0: The total amount of wall time                        = 298.333326
 
 Test 039 regional_hafs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_netcdf_parallel
 Checking test 040 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 291.933238
+ 0: The total amount of wall time                        = 296.358772
 
 Test 040 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_RRTMGP
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_RRTMGP
 Checking test 041 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1629,13 +1629,13 @@ Checking test 041 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 467.720513
+ 0: The total amount of wall time                        = 481.474312
 
 Test 041 regional_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1682,13 +1682,13 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 339.677702
+  0: The total amount of wall time                        = 499.185402
 
 Test 042 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1735,13 +1735,13 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 422.129592
+ 0: The total amount of wall time                        = 574.725395
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1788,13 +1788,13 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.571076
+  0: The total amount of wall time                        = 495.152049
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_sfcdiff_restart
 Checking test 045 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1833,13 +1833,13 @@ Checking test 045 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.511861
+  0: The total amount of wall time                        = 173.820094
 
 Test 045 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hrrr_control
 Checking test 046 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1886,13 +1886,13 @@ Checking test 046 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.808261
+  0: The total amount of wall time                        = 495.248180
 
 Test 046 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rrfs_v1beta
 Checking test 047 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1939,13 +1939,13 @@ Checking test 047 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 335.936856
+  0: The total amount of wall time                        = 493.370219
 
 Test 047 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_rrtmgp
 Checking test 048 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1956,13 +1956,13 @@ Checking test 048 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 223.378409
+  0: The total amount of wall time                        = 384.795457
 
 Test 048 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_rrtmgp_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_rrtmgp_c192
 Checking test 049 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1973,13 +1973,13 @@ Checking test 049 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 591.792168
+  0: The total amount of wall time                        = 757.524960
 
 Test 049 control_rrtmgp_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_csawmg
 Checking test 050 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1990,13 +1990,13 @@ Checking test 050 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 241.292728
+  0: The total amount of wall time                        = 345.563805
 
 Test 050 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_csawmgt
 Checking test 051 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2007,13 +2007,13 @@ Checking test 051 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 299.639439
+  0: The total amount of wall time                        = 336.826165
 
 Test 051 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_flake
 Checking test 052 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2024,13 +2024,13 @@ Checking test 052 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.214727
+  0: The total amount of wall time                        = 352.598368
 
 Test 052 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_ras
 Checking test 053 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2041,13 +2041,13 @@ Checking test 053 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 163.212171
+  0: The total amount of wall time                        = 321.990502
 
 Test 053 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_thompson
 Checking test 054 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2058,13 +2058,13 @@ Checking test 054 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.073885
+  0: The total amount of wall time                        = 239.321516
 
 Test 054 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_thompson_no_aero
 Checking test 055 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2075,13 +2075,13 @@ Checking test 055 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.609903
+  0: The total amount of wall time                        = 236.958155
 
 Test 055 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2146,13 +2146,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 146.334264
+  0: The total amount of wall time                        = 152.527205
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2167,50 +2167,50 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 291.855983
+ 0: The total amount of wall time                        = 293.998818
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wam_repro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_wam_repro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wam_repro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_wam_repro
 Checking test 058 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 108.275348
+  0: The total amount of wall time                        = 115.823186
 
 Test 058 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_debug
 Checking test 059 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.889682
+  0: The total amount of wall time                        = 144.808021
 
 Test 059 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_2threads_debug
 Checking test 060 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 214.233859
+ 0: The total amount of wall time                        = 221.582269
 
 Test 060 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_CubedSphereGrid_debug
 Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2237,338 +2237,338 @@ Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.541336
+  0: The total amount of wall time                        = 163.235074
 
 Test 061 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_wrtGauss_netcdf_parallel_debug
 Checking test 062 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 145.241611
+  0: The total amount of wall time                        = 148.853962
 
 Test 062 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_stochy_debug
 Checking test 063 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.631597
+  0: The total amount of wall time                        = 175.073492
 
 Test 063 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 147.901709
+  0: The total amount of wall time                        = 151.283923
 
 Test 064 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_rrtmgp_debug
 Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.850221
+  0: The total amount of wall time                        = 197.590530
 
 Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_csawmg_debug
 Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.465785
+  0: The total amount of wall time                        = 285.547429
 
 Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_csawmgt_debug
 Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.735955
+  0: The total amount of wall time                        = 231.183752
 
 Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_ras_debug
 Checking test 068 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.749757
+  0: The total amount of wall time                        = 161.067548
 
 Test 068 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_diag_debug
 Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.625685
+  0: The total amount of wall time                        = 157.444503
 
-Test 069 control_diag_debug PASS
+Test 069 control_diag_debug PASS Tries: 2
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_debug_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_debug_p7
 Checking test 070 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.178944
+  0: The total amount of wall time                        = 173.664621
 
 Test 070 control_debug_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_thompson_debug
 Checking test 071 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.124128
+  0: The total amount of wall time                        = 179.345495
 
 Test 071 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_thompson_no_aero_debug
 Checking test 072 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.472747
+  0: The total amount of wall time                        = 167.921664
 
 Test 072 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_thompson_extdiag_debug
 Checking test 073 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.405180
+  0: The total amount of wall time                        = 210.038850
 
 Test 073 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/regional_debug
 Checking test 074 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 239.785113
+ 0: The total amount of wall time                        = 250.626431
 
 Test 074 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_control_debug
 Checking test 075 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.919992
+  0: The total amount of wall time                        = 265.827222
 
 Test 075 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_unified_drag_suite_debug
 Checking test 076 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 258.479555
+  0: The total amount of wall time                        = 265.610692
 
 Test 076 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_diag_debug
 Checking test 077 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.251733
+  0: The total amount of wall time                        = 287.248505
 
 Test 077 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_cires_ugwp_debug
 Checking test 078 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.009600
+  0: The total amount of wall time                        = 265.635418
 
 Test 078 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_unified_ugwp_debug
 Checking test 079 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.188417
+  0: The total amount of wall time                        = 268.194489
 
 Test 079 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_noah_debug
 Checking test 080 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.792066
+  0: The total amount of wall time                        = 264.971468
 
 Test 080 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_rrtmgp_debug
 Checking test 081 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 449.692982
+  0: The total amount of wall time                        = 448.280171
 
 Test 081 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_lndp_debug
 Checking test 082 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.485507
+  0: The total amount of wall time                        = 264.913643
 
 Test 082 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_sfcdiff_debug
 Checking test 083 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.219261
+  0: The total amount of wall time                        = 262.656081
 
 Test 083 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_flake_debug
 Checking test 084 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.208388
+  0: The total amount of wall time                        = 268.870591
 
 Test 084 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 085 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 429.422743
+  0: The total amount of wall time                        = 430.873292
 
 Test 085 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/rrfs_v1beta_debug
 Checking test 086 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 258.549635
+  0: The total amount of wall time                        = 258.684717
 
 Test 086 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2633,13 +2633,13 @@ Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.060547
+  0: The total amount of wall time                        = 197.358071
 
 Test 087 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2654,24 +2654,24 @@ Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 400.437764
+ 0: The total amount of wall time                        = 401.355420
 
 Test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_atm
 Checking test 089 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 267.675184
+  0: The total amount of wall time                        = 274.262632
 
 Test 089 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_atm_ocn
 Checking test 090 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2680,26 +2680,26 @@ Checking test 090 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 371.982524
+  0: The total amount of wall time                        = 370.882664
 
 Test 090 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_atm_wav
 Checking test 091 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 727.186081
+  0: The total amount of wall time                        = 730.969974
 
 Test 091 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_atm_ocn_wav
 Checking test 092 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2708,57 +2708,57 @@ Checking test 092 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 824.704357
+  0: The total amount of wall time                        = 831.034298
 
 Test 092 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_1nest_atm
 Checking test 093 hafs_regional_1nest_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 395.450834
+  0: The total amount of wall time                        = 395.735603
 
 Test 093 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_telescopic_2nests_atm
 Checking test 094 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 419.148071
+  0: The total amount of wall time                        = 418.864582
 
 Test 094 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_global_1nest_atm
 Checking test 095 hafs_global_1nest_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 195.191104
+  0: The total amount of wall time                        = 194.672536
 
 Test 095 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_global_multiple_4nests_atm
 Checking test 096 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 432.542597
+  0: The total amount of wall time                        = 427.262669
 
 Test 096 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_docn
 Checking test 097 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2766,111 +2766,111 @@ Checking test 097 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 357.096898
+  0: The total amount of wall time                        = 350.594800
 
 Test 097 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_docn_oisst
 Checking test 098 hafs_regional_docn_oisst results ....
- Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 351.786570
+  0: The total amount of wall time                        = 352.312091
 
 Test 098 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/hafs_regional_datm_cdeps
 Checking test 099 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 949.738664
+  0: The total amount of wall time                        = 957.937744
 
 Test 099 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_control_cfsr
 Checking test 100 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.438912
+ 0: The total amount of wall time                        = 146.718633
 
 Test 100 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_restart_cfsr
 Checking test 101 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.496380
+ 0: The total amount of wall time                        = 92.690632
 
 Test 101 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_control_gefs
 Checking test 102 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.290826
+ 0: The total amount of wall time                        = 138.801539
 
 Test 102 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_stochy_gefs
 Checking test 103 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.635705
+ 0: The total amount of wall time                        = 146.172028
 
 Test 103 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_bulk_cfsr
 Checking test 104 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.162757
+ 0: The total amount of wall time                        = 143.012096
 
 Test 104 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_bulk_gefs
 Checking test 105 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.665623
+ 0: The total amount of wall time                        = 136.718414
 
 Test 105 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_mx025_cfsr
 Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2879,13 +2879,13 @@ Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 306.949334
+  0: The total amount of wall time                        = 310.563883
 
 Test 106 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_mx025_gefs
 Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2894,35 +2894,35 @@ Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 306.596831
+  0: The total amount of wall time                        = 320.056707
 
 Test 107 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_multiple_files_cfsr
 Checking test 108 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.520664
+ 0: The total amount of wall time                        = 141.423771
 
 Test 108 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/datm_cdeps_debug_cfsr
 Checking test 109 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 444.305287
+ 0: The total amount of wall time                        = 441.803902
 
 Test 109 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_atmwav
 Checking test 110 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2966,13 +2966,13 @@ Checking test 110 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 79.096216
+  0: The total amount of wall time                        = 78.238081
 
 Test 110 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_c384gdas_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_c384gdas_wav
 Checking test 111 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3018,13 +3018,13 @@ Checking test 111 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 682.763887
+  0: The total amount of wall time                        = 676.359044
 
 Test 111 control_c384gdas_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_31044/control_atm_aerosols
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_17331/control_atm_aerosols
 Checking test 112 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3071,11 +3071,11 @@ Checking test 112 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.089543
+  0: The total amount of wall time                        = 273.048949
 
 Test 112 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 22:09:04 UTC 2021
-Elapsed time: 00h:53m:58s. Have a nice day!
+Thu Dec 23 05:03:30 UTC 2021
+Elapsed time: 01h:26m:26s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,23 +1,23 @@
-Mon Dec 20 22:09:11 GMT 2021
+Thu Dec 23 03:30:06 GMT 2021
 Start Regression test
 
-Compile 001 elapsed time 1620 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 227 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1431 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 1424 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 824 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 238 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 232 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1451 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1457 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 280 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 013 elapsed time 128 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 1405 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 1592 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 261 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1444 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 1439 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1559 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 849 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 242 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 225 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 214 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1466 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1480 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 291 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 013 elapsed time 136 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 1427 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_control_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 294.852455
+  0: The total amount of wall time                        = 297.691148
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_control_p7_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -129,13 +129,13 @@ Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 386.081831
+  0: The total amount of wall time                        = 413.856733
 
 Test 002 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_2threads_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -188,13 +188,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 1010.352733
+  0: The total amount of wall time                        = 966.832860
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_mpi_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_mpi_p7
 Checking test 004 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -247,13 +247,13 @@ Checking test 004 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 254.197430
+  0: The total amount of wall time                        = 265.114164
 
 Test 004 cpld_mpi_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_bmark_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_bmark_p7
 Checking test 005 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -298,13 +298,13 @@ Checking test 005 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1175.949220
+  0: The total amount of wall time                        = 1200.524257
 
 Test 005 cpld_bmark_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_bmark_mpi_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_bmark_mpi_p7
 Checking test 006 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -349,13 +349,13 @@ Checking test 006 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1165.226661
+  0: The total amount of wall time                        = 1220.706432
 
 Test 006 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_control_c96_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_control_c96_p7
 Checking test 007 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -405,13 +405,13 @@ Checking test 007 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 280.944889
+  0: The total amount of wall time                        = 298.324249
 
 Test 007 cpld_control_c96_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_restart_c96_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_restart_c96_p7
 Checking test 008 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -461,13 +461,13 @@ Checking test 008 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 155.038979
+  0: The total amount of wall time                        = 177.021207
 
 Test 008 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_control_c192_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_control_c192_p7
 Checking test 009 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -517,13 +517,13 @@ Checking test 009 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1201.412406
+  0: The total amount of wall time                        = 1211.472821
 
 Test 009 cpld_control_c192_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_restart_c192_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_restart_c192_p7
 Checking test 010 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -573,13 +573,13 @@ Checking test 010 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 792.494716
+  0: The total amount of wall time                        = 823.612140
 
 Test 010 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_control_c384_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_control_c384_p7
 Checking test 011 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -622,13 +622,13 @@ Checking test 011 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1345.468621
+  0: The total amount of wall time                        = 1359.714268
 
 Test 011 cpld_control_c384_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_restart_c384_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_restart_c384_p7
 Checking test 012 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -671,13 +671,13 @@ Checking test 012 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 739.978999
+  0: The total amount of wall time                        = 775.434711
 
 Test 012 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_debug_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/cpld_debug_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_debug_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/cpld_debug_p7
 Checking test 013 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -727,13 +727,13 @@ Checking test 013 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 805.265612
+  0: The total amount of wall time                        = 813.448262
 
 Test 013 cpld_debug_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control
 Checking test 014 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -780,13 +780,13 @@ Checking test 014 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.286852
+  0: The total amount of wall time                        = 180.647853
 
 Test 014 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_decomp
 Checking test 015 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -829,13 +829,13 @@ Checking test 015 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 182.563137
+  0: The total amount of wall time                        = 186.721969
 
 Test 015 control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -878,13 +878,13 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 853.080965
+ 0: The total amount of wall time                        = 796.771759
 
 Test 016 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -923,13 +923,13 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 90.988342
+  0: The total amount of wall time                        = 96.812685
 
 Test 017 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_fhzero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -972,13 +972,13 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.501764
+  0: The total amount of wall time                        = 170.096354
 
 Test 018 control_fhzero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1005,13 +1005,13 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.198025
+  0: The total amount of wall time                        = 170.751219
 
 Test 019 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_latlon
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1022,13 +1022,13 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.240171
+  0: The total amount of wall time                        = 164.552228
 
 Test 020 control_latlon PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1039,13 +1039,13 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 169.687658
+  0: The total amount of wall time                        = 174.820388
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1084,13 +1084,13 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 541.464913
+0: The total amount of wall time                        = 541.711705
 
 Test 022 control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1101,13 +1101,13 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 659.499121
+  0: The total amount of wall time                        = 665.265722
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1118,13 +1118,13 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 821.108984
+  0: The total amount of wall time                        = 842.424848
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1167,13 +1167,13 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 752.633449
+  0: The total amount of wall time                        = 762.190263
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1184,26 +1184,26 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 110.822749
+  0: The total amount of wall time                        = 121.258106
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 62.888579
+  0: The total amount of wall time                        = 64.538037
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1214,13 +1214,13 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 100.233505
+  0: The total amount of wall time                        = 109.036226
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_p7
 Checking test 029 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1267,13 +1267,13 @@ Checking test 029 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.835826
+  0: The total amount of wall time                        = 200.458975
 
 Test 029 control_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_p7_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_p7_rrtmgp
 Checking test 030 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1320,13 +1320,13 @@ Checking test 030 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 290.323547
+  0: The total amount of wall time                        = 292.070834
 
 Test 030 control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_restart_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_restart_p7
 Checking test 031 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1365,13 +1365,13 @@ Checking test 031 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 105.007946
+  0: The total amount of wall time                        = 106.603027
 
 Test 031 control_restart_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_decomp_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_decomp_p7
 Checking test 032 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1414,13 +1414,13 @@ Checking test 032 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 197.482843
+  0: The total amount of wall time                        = 201.938321
 
 Test 032 control_decomp_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_2threads_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_2threads_p7
 Checking test 033 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1463,13 +1463,13 @@ Checking test 033 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 891.598664
+ 0: The total amount of wall time                        = 891.587618
 
 Test 033 control_2threads_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_control
 Checking test 034 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1480,26 +1480,26 @@ Checking test 034 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 416.307448
+ 0: The total amount of wall time                        = 437.233713
 
 Test 034 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_restart
 Checking test 035 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 242.128014
+ 0: The total amount of wall time                        = 239.758945
 
 Test 035 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_noquilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_noquilt
 Checking test 036 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1507,13 +1507,13 @@ Checking test 036 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 450.487266
+ 0: The total amount of wall time                        = 461.226207
 
 Test 036 regional_noquilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_hafs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_hafs
 Checking test 037 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1522,26 +1522,26 @@ Checking test 037 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 414.207308
+ 0: The total amount of wall time                        = 426.891968
 
 Test 037 regional_hafs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_netcdf_parallel
 Checking test 038 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 415.227482
+ 0: The total amount of wall time                        = 421.207076
 
 Test 038 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_RRTMGP
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_RRTMGP
 Checking test 039 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1552,13 +1552,13 @@ Checking test 039 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 674.335095
+ 0: The total amount of wall time                        = 730.172584
 
 Test 039 regional_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_control
 Checking test 040 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1605,13 +1605,13 @@ Checking test 040 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 484.676352
+  0: The total amount of wall time                        = 486.950411
 
 Test 040 rap_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_sfcdiff
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_sfcdiff
 Checking test 041 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1658,13 +1658,13 @@ Checking test 041 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.588720
+  0: The total amount of wall time                        = 485.355765
 
 Test 041 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_sfcdiff_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_sfcdiff_restart
 Checking test 042 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1703,13 +1703,13 @@ Checking test 042 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 240.939576
+  0: The total amount of wall time                        = 244.732076
 
 Test 042 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hrrr_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hrrr_control
 Checking test 043 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1756,13 +1756,13 @@ Checking test 043 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.845197
+  0: The total amount of wall time                        = 474.028717
 
 Test 043 hrrr_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rrfs_v1beta
 Checking test 044 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1809,13 +1809,13 @@ Checking test 044 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 474.653891
+  0: The total amount of wall time                        = 476.870448
 
 Test 044 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_rrtmgp
 Checking test 045 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1826,13 +1826,13 @@ Checking test 045 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 307.903015
+  0: The total amount of wall time                        = 316.667144
 
 Test 045 control_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_rrtmgp_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_rrtmgp_c192
 Checking test 046 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1843,13 +1843,13 @@ Checking test 046 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 798.564644
+  0: The total amount of wall time                        = 805.029687
 
 Test 046 control_rrtmgp_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_csawmg
 Checking test 047 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1860,13 +1860,13 @@ Checking test 047 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 339.107454
+  0: The total amount of wall time                        = 431.358312
 
 Test 047 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_csawmgt
 Checking test 048 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1877,13 +1877,13 @@ Checking test 048 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 424.680691
+  0: The total amount of wall time                        = 428.605996
 
 Test 048 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_flake
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_flake
 Checking test 049 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1894,13 +1894,13 @@ Checking test 049 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 285.790651
+  0: The total amount of wall time                        = 282.724844
 
 Test 049 control_flake PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_ras
 Checking test 050 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1911,13 +1911,13 @@ Checking test 050 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 237.865458
+  0: The total amount of wall time                        = 227.818717
 
 Test 050 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_thompson
 Checking test 051 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1928,13 +1928,13 @@ Checking test 051 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 296.592953
+  0: The total amount of wall time                        = 286.054546
 
 Test 051 control_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_thompson_no_aero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_thompson_no_aero
 Checking test 052 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1945,13 +1945,13 @@ Checking test 052 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 283.639028
+  0: The total amount of wall time                        = 274.917317
 
 Test 052 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/fv3_HAFS_v0_hwrf_thompson
 Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2016,13 +2016,13 @@ Checking test 053 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.558202
+  0: The total amount of wall time                        = 199.808062
 
 Test 053 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2037,50 +2037,50 @@ Checking test 054 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 377.704243
+ 0: The total amount of wall time                        = 373.698633
 
 Test 054 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wam_repro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_wam_repro
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wam_repro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_wam_repro
 Checking test 055 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 151.356857
+  0: The total amount of wall time                        = 155.035459
 
 Test 055 control_wam PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_debug
 Checking test 056 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.622397
+  0: The total amount of wall time                        = 189.470668
 
 Test 056 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_2threads_debug
 Checking test 057 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 362.980307
+ 0: The total amount of wall time                        = 366.574052
 
 Test 057 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_CubedSphereGrid_debug
 Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2107,338 +2107,338 @@ Checking test 058 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.530708
+  0: The total amount of wall time                        = 205.249772
 
 Test 058 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_wrtGauss_netcdf_parallel_debug
 Checking test 059 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.773778
+  0: The total amount of wall time                        = 192.432971
 
 Test 059 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_stochy_debug
 Checking test 060 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 215.398007
+  0: The total amount of wall time                        = 216.784518
 
 Test 060 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_lndp_debug
 Checking test 061 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.491128
+  0: The total amount of wall time                        = 195.647512
 
 Test 061 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_rrtmgp_debug
 Checking test 062 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 225.479313
+  0: The total amount of wall time                        = 225.898864
 
 Test 062 control_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_csawmg_debug
 Checking test 063 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.517478
+  0: The total amount of wall time                        = 306.433682
 
 Test 063 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_csawmgt_debug
 Checking test 064 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 297.469193
+  0: The total amount of wall time                        = 302.451278
 
 Test 064 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_ras_debug
 Checking test 065 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.530609
+  0: The total amount of wall time                        = 210.195950
 
 Test 065 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_diag_debug
 Checking test 066 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.808182
+  0: The total amount of wall time                        = 204.273376
 
 Test 066 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_debug_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_debug_p7
 Checking test 067 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.586038
+  0: The total amount of wall time                        = 208.276031
 
 Test 067 control_debug_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_thompson_debug
 Checking test 068 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.701284
+  0: The total amount of wall time                        = 226.641463
 
 Test 068 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_thompson_no_aero_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_thompson_no_aero_debug
 Checking test 069 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 213.898182
+  0: The total amount of wall time                        = 229.113670
 
 Test 069 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_thompson_extdiag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_thompson_extdiag_debug
 Checking test 070 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 235.363836
+  0: The total amount of wall time                        = 236.262443
 
 Test 070 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/regional_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/regional_debug
 Checking test 071 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 320.711871
+ 0: The total amount of wall time                        = 323.451562
 
 Test 071 regional_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_control_debug
 Checking test 072 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.547402
+  0: The total amount of wall time                        = 353.342867
 
 Test 072 rap_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_unified_drag_suite_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_unified_drag_suite_debug
 Checking test 073 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.968085
+  0: The total amount of wall time                        = 347.053027
 
 Test 073 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_diag_debug
 Checking test 074 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 367.657477
+  0: The total amount of wall time                        = 368.906546
 
 Test 074 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_cires_ugwp_debug
 Checking test 075 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.506204
+  0: The total amount of wall time                        = 355.769513
 
 Test 075 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_unified_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_unified_ugwp_debug
 Checking test 076 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.435347
+  0: The total amount of wall time                        = 356.126410
 
 Test 076 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_noah_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_noah_debug
 Checking test 077 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.558693
+  0: The total amount of wall time                        = 344.722504
 
 Test 077 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_rrtmgp_debug
 Checking test 078 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 602.385095
+  0: The total amount of wall time                        = 604.481111
 
 Test 078 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_lndp_debug
 Checking test 079 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.996872
+  0: The total amount of wall time                        = 349.742242
 
 Test 079 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_sfcdiff_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_sfcdiff_debug
 Checking test 080 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.435074
+  0: The total amount of wall time                        = 345.995569
 
 Test 080 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_flake_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_flake_debug
 Checking test 081 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.098863
+  0: The total amount of wall time                        = 347.575719
 
 Test 081 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 082 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 573.551974
+  0: The total amount of wall time                        = 578.937536
 
 Test 082 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/rrfs_v1beta_debug
 Checking test 083 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.679216
+  0: The total amount of wall time                        = 344.974374
 
 Test 083 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 084 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2503,13 +2503,13 @@ Checking test 084 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 266.914287
+  0: The total amount of wall time                        = 269.265058
 
 Test 084 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 085 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2524,24 +2524,24 @@ Checking test 085 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 505.454529
+ 0: The total amount of wall time                        = 509.318530
 
 Test 085 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_atm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_atm
 Checking test 086 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1135.272529
+  0: The total amount of wall time                        = 1122.842471
 
 Test 086 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_atm_ocn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_atm_ocn
 Checking test 087 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2550,26 +2550,26 @@ Checking test 087 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 450.872978
+  0: The total amount of wall time                        = 483.276083
 
 Test 087 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_atm_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_atm_wav
 Checking test 088 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 932.247860
+  0: The total amount of wall time                        = 945.604733
 
 Test 088 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_atm_ocn_wav
 Checking test 089 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2578,125 +2578,125 @@ Checking test 089 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1022.435049
+  0: The total amount of wall time                        = 1053.256773
 
 Test 089 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_docn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_docn
 Checking test 090 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 442.211459
+  0: The total amount of wall time                        = 442.574664
 
 Test 090 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_docn_oisst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_docn_oisst
 Checking test 091 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 439.688952
+  0: The total amount of wall time                        = 483.586440
 
 Test 091 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/hafs_regional_datm_cdeps
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/hafs_regional_datm_cdeps
 Checking test 092 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1220.526814
+  0: The total amount of wall time                        = 1218.077827
 
 Test 092 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_control_cfsr
 Checking test 093 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.403582
+ 0: The total amount of wall time                        = 194.250348
 
 Test 093 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_restart_cfsr
 Checking test 094 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 115.917796
+ 0: The total amount of wall time                        = 117.172577
 
 Test 094 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_control_gefs
 Checking test 095 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 187.601772
+ 0: The total amount of wall time                        = 189.907100
 
 Test 095 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_stochy_gefs
 Checking test 096 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.723403
+ 0: The total amount of wall time                        = 191.044541
 
 Test 096 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_bulk_cfsr
 Checking test 097 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.788665
+ 0: The total amount of wall time                        = 192.908768
 
 Test 097 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_bulk_gefs
 Checking test 098 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 186.722009
+ 0: The total amount of wall time                        = 187.288213
 
 Test 098 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_mx025_cfsr
 Checking test 099 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2705,13 +2705,13 @@ Checking test 099 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 404.352079
+  0: The total amount of wall time                        = 416.252338
 
 Test 099 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_mx025_gefs
 Checking test 100 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2720,35 +2720,35 @@ Checking test 100 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 404.212872
+  0: The total amount of wall time                        = 414.664034
 
 Test 100 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_multiple_files_cfsr
 Checking test 101 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.738792
+ 0: The total amount of wall time                        = 192.266341
 
 Test 101 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/datm_cdeps_debug_cfsr
 Checking test 102 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 567.032293
+ 0: The total amount of wall time                        = 568.939115
 
 Test 102 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_53372/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_97570/control_atmwav
 Checking test 103 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2792,11 +2792,11 @@ Checking test 103 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 118.219853
+  0: The total amount of wall time                        = 116.876616
 
 Test 103 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Dec 21 00:47:07 GMT 2021
-Elapsed time: 02h:37m:56s. Have a nice day!
+Thu Dec 23 05:30:32 GMT 2021
+Elapsed time: 02h:00m:27s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,23 +1,23 @@
-Mon Dec 20 15:11:39 CST 2021
+Wed Dec 22 21:13:55 CST 2021
 Start Regression test
 
-Compile 001 elapsed time 521 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 191 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 396 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 426 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 360 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 204 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 502 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 183 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 418 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 388 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 180 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 008 elapsed time 176 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 167 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 424 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 417 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 228 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 99 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 400 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 009 elapsed time 165 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 416 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 491 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 205 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 105 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 425 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_control_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 217.694397
+  0: The total amount of wall time                        = 215.240462
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_control_p7_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7_rrtmgp
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -129,13 +129,13 @@ Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 288.706026
+  0: The total amount of wall time                        = 280.359459
 
 Test 002 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_2threads_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -188,13 +188,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 252.466712
+  0: The total amount of wall time                        = 240.433412
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_decomp_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_decomp_p7
 Checking test 004 cpld_decomp_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -247,13 +247,13 @@ Checking test 004 cpld_decomp_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 219.980194
+  0: The total amount of wall time                        = 212.189365
 
 Test 004 cpld_decomp_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_mpi_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_mpi_p7
 Checking test 005 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -306,13 +306,13 @@ Checking test 005 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 187.135723
+  0: The total amount of wall time                        = 186.088955
 
 Test 005 cpld_mpi_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_bmark_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -357,13 +357,13 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 901.420851
+  0: The total amount of wall time                        = 899.704565
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_bmark_mpi_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_bmark_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_bmark_mpi_p7
 Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 860.053701
+  0: The total amount of wall time                        = 860.272646
 
 Test 007 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_control_c96_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_control_c96_p7
 Checking test 008 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -464,13 +464,13 @@ Checking test 008 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 208.455288
+  0: The total amount of wall time                        = 206.424077
 
 Test 008 cpld_control_c96_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c96_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_restart_c96_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c96_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_restart_c96_p7
 Checking test 009 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -520,13 +520,13 @@ Checking test 009 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 118.294985
+  0: The total amount of wall time                        = 118.855924
 
 Test 009 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_control_c192_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_control_c192_p7
 Checking test 010 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -576,13 +576,13 @@ Checking test 010 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 854.214838
+  0: The total amount of wall time                        = 860.145270
 
 Test 010 cpld_control_c192_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c192_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_restart_c192_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c192_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_restart_c192_p7
 Checking test 011 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -632,13 +632,13 @@ Checking test 011 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 611.406846
+  0: The total amount of wall time                        = 616.937716
 
 Test 011 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_control_c384_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_control_c384_p7
 Checking test 012 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -681,13 +681,13 @@ Checking test 012 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1019.215590
+  0: The total amount of wall time                        = 1018.919344
 
 Test 012 cpld_control_c384_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_control_c384_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_restart_c384_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_control_c384_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_restart_c384_p7
 Checking test 013 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -730,13 +730,13 @@ Checking test 013 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 548.336672
+  0: The total amount of wall time                        = 555.451139
 
 Test 013 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/cpld_debug_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/cpld_debug_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/cpld_debug_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/cpld_debug_p7
 Checking test 014 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -786,13 +786,13 @@ Checking test 014 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 640.470685
+  0: The total amount of wall time                        = 635.974166
 
 Test 014 cpld_debug_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -839,13 +839,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 145.110090
+  0: The total amount of wall time                        = 179.525388
 
 Test 015 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.882452
+  0: The total amount of wall time                        = 128.683611
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_2threads
 Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 158.219343
+ 0: The total amount of wall time                        = 142.661308
 
 Test 017 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_restart
 Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -982,13 +982,13 @@ Checking test 018 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 67.061073
+  0: The total amount of wall time                        = 66.774709
 
 Test 018 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_fhzero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_fhzero
 Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1031,13 +1031,13 @@ Checking test 019 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.262960
+  0: The total amount of wall time                        = 115.609184
 
 Test 019 control_fhzero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1064,13 +1064,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.910629
+  0: The total amount of wall time                        = 118.679168
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_latlon
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1081,13 +1081,13 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.954108
+  0: The total amount of wall time                        = 119.667141
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1098,13 +1098,13 @@ Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 140.853027
+  0: The total amount of wall time                        = 124.046243
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c48
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1143,13 +1143,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 313.715346
+0: The total amount of wall time                        = 309.076124
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c192
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1160,13 +1160,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 478.228451
+  0: The total amount of wall time                        = 463.481909
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1177,13 +1177,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 795.261024
+  0: The total amount of wall time                        = 806.410156
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1226,13 +1226,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 690.292874
+  0: The total amount of wall time                        = 677.251458
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1243,26 +1243,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.183366
+  0: The total amount of wall time                        = 115.212568
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.871747
+  0: The total amount of wall time                        = 46.107686
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1273,13 +1273,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 74.331011
+  0: The total amount of wall time                        = 74.397053
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_p7
 Checking test 030 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1326,13 +1326,13 @@ Checking test 030 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.851604
+  0: The total amount of wall time                        = 135.470041
 
 Test 030 control_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_p7_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7_rrtmgp
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_p7_rrtmgp
 Checking test 031 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1379,13 +1379,13 @@ Checking test 031 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.760240
+  0: The total amount of wall time                        = 289.489463
 
 Test 031 control_p7_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_restart_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_restart_p7
 Checking test 032 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1424,13 +1424,13 @@ Checking test 032 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 76.812753
+  0: The total amount of wall time                        = 75.889258
 
 Test 032 control_restart_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_decomp_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_decomp_p7
 Checking test 033 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1473,13 +1473,13 @@ Checking test 033 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 143.412518
+  0: The total amount of wall time                        = 143.492002
 
 Test 033 control_decomp_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_2threads_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_2threads_p7
 Checking test 034 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1522,13 +1522,13 @@ Checking test 034 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 163.374249
+ 0: The total amount of wall time                        = 166.525844
 
 Test 034 control_2threads_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1539,26 +1539,26 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 297.978142
+ 0: The total amount of wall time                        = 299.985108
 
 Test 035 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 171.249207
+ 0: The total amount of wall time                        = 171.516357
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_noquilt
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_noquilt
 Checking test 037 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1566,13 +1566,13 @@ Checking test 037 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 299.469104
+ 0: The total amount of wall time                        = 302.493711
 
 Test 037 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,13 +1583,13 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 213.928544
+ 0: The total amount of wall time                        = 212.509223
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_hafs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_hafs
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_hafs
 Checking test 039 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1598,26 +1598,26 @@ Checking test 039 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 297.514391
+ 0: The total amount of wall time                        = 298.680132
 
 Test 039 regional_hafs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_netcdf_parallel
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_netcdf_parallel
 Checking test 040 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 297.121079
+ 0: The total amount of wall time                        = 299.240720
 
 Test 040 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_RRTMGP
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_RRTMGP
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_RRTMGP
 Checking test 041 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1628,13 +1628,13 @@ Checking test 041 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 470.248565
+ 0: The total amount of wall time                        = 466.561743
 
 Test 041 regional_RRTMGP PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1681,13 +1681,13 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 341.445249
+  0: The total amount of wall time                        = 340.490832
 
 Test 042 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1734,13 +1734,13 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 414.605080
+ 0: The total amount of wall time                        = 415.955993
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1787,13 +1787,13 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 341.418007
+  0: The total amount of wall time                        = 341.435317
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_sfcdiff_restart
 Checking test 045 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1832,13 +1832,13 @@ Checking test 045 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.032161
+  0: The total amount of wall time                        = 176.912648
 
 Test 045 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hrrr_control
 Checking test 046 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1885,13 +1885,13 @@ Checking test 046 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.504854
+  0: The total amount of wall time                        = 330.695395
 
 Test 046 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rrfs_v1beta
 Checking test 047 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1938,13 +1938,13 @@ Checking test 047 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 336.952670
+  0: The total amount of wall time                        = 339.392477
 
 Test 047 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_rrtmgp
 Checking test 048 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1955,13 +1955,13 @@ Checking test 048 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 222.214743
+  0: The total amount of wall time                        = 220.875099
 
 Test 048 control_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_rrtmgp_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_c192
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_rrtmgp_c192
 Checking test 049 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1972,13 +1972,13 @@ Checking test 049 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 586.278529
+  0: The total amount of wall time                        = 798.765527
 
 Test 049 control_rrtmgp_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_csawmg
 Checking test 050 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1989,13 +1989,13 @@ Checking test 050 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 245.841692
+  0: The total amount of wall time                        = 305.714248
 
 Test 050 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_csawmgt
 Checking test 051 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2006,13 +2006,13 @@ Checking test 051 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 303.076637
+  0: The total amount of wall time                        = 302.549545
 
 Test 051 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_flake
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_flake
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_flake
 Checking test 052 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2023,13 +2023,13 @@ Checking test 052 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 217.844487
+  0: The total amount of wall time                        = 215.608877
 
 Test 052 control_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_ras
 Checking test 053 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2040,13 +2040,13 @@ Checking test 053 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 166.557016
+  0: The total amount of wall time                        = 165.716196
 
 Test 053 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_thompson
 Checking test 054 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2057,13 +2057,13 @@ Checking test 054 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 207.798392
+  0: The total amount of wall time                        = 206.340091
 
 Test 054 control_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_thompson_no_aero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_thompson_no_aero
 Checking test 055 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2074,13 +2074,13 @@ Checking test 055 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 199.159998
+  0: The total amount of wall time                        = 197.548951
 
 Test 055 control_thompson_no_aero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2145,13 +2145,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 148.211383
+  0: The total amount of wall time                        = 146.404842
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2166,50 +2166,50 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 290.722511
+ 0: The total amount of wall time                        = 289.137401
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wam_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_wam_repro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wam_repro
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_wam_repro
 Checking test 058 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 113.908940
+  0: The total amount of wall time                        = 112.678828
 
 Test 058 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_debug
 Checking test 059 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.732280
+  0: The total amount of wall time                        = 155.413201
 
 Test 059 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_2threads_debug
 Checking test 060 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 236.165790
+ 0: The total amount of wall time                        = 230.140783
 
 Test 060 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_CubedSphereGrid_debug
 Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2236,338 +2236,338 @@ Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.499935
+  0: The total amount of wall time                        = 174.251403
 
 Test 061 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_wrtGauss_netcdf_parallel_debug
 Checking test 062 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.709500
+  0: The total amount of wall time                        = 155.156968
 
 Test 062 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_stochy_debug
 Checking test 063 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.117626
+  0: The total amount of wall time                        = 176.764732
 
 Test 063 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.708215
+  0: The total amount of wall time                        = 159.725958
 
 Test 064 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_rrtmgp_debug
 Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.258323
+  0: The total amount of wall time                        = 188.943428
 
 Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_csawmg_debug
 Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 203.437667
+  0: The total amount of wall time                        = 238.639802
 
 Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_csawmgt_debug
 Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 239.624163
+  0: The total amount of wall time                        = 235.491141
 
 Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_ras_debug
 Checking test 068 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 161.188271
+  0: The total amount of wall time                        = 159.928085
 
 Test 068 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_diag_debug
 Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.034088
+  0: The total amount of wall time                        = 168.092901
 
 Test 069 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_debug_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_debug_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_debug_p7
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_debug_p7
 Checking test 070 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 215.079373
+  0: The total amount of wall time                        = 163.614278
 
 Test 070 control_debug_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_thompson_debug
 Checking test 071 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.453555
+  0: The total amount of wall time                        = 179.456034
 
 Test 071 control_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_thompson_no_aero_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_thompson_no_aero_debug
 Checking test 072 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 178.652482
+  0: The total amount of wall time                        = 173.125836
 
 Test 072 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_thompson_extdiag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_thompson_debug_extdiag
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_thompson_extdiag_debug
 Checking test 073 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.240304
+  0: The total amount of wall time                        = 189.937568
 
 Test 073 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/fv3_regional_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/regional_debug
 Checking test 074 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 276.766985
+ 0: The total amount of wall time                        = 250.907195
 
 Test 074 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_control_debug
 Checking test 075 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.820217
+  0: The total amount of wall time                        = 275.061413
 
 Test 075 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_unified_drag_suite_debug
 Checking test 076 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.192543
+  0: The total amount of wall time                        = 277.194144
 
 Test 076 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_diag_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_diag_debug
 Checking test 077 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 322.115197
+  0: The total amount of wall time                        = 292.485595
 
 Test 077 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_cires_ugwp_debug
 Checking test 078 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.314526
+  0: The total amount of wall time                        = 285.873963
 
 Test 078 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_unified_ugwp_debug
 Checking test 079 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.363907
+  0: The total amount of wall time                        = 278.914499
 
 Test 079 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_noah_debug
 Checking test 080 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.336549
+  0: The total amount of wall time                        = 270.225696
 
 Test 080 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_rrtmgp_debug
 Checking test 081 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 499.207622
+  0: The total amount of wall time                        = 486.529137
 
 Test 081 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_lndp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_lndp_debug
 Checking test 082 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.112813
+  0: The total amount of wall time                        = 279.758971
 
 Test 082 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_sfcdiff_debug
 Checking test 083 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.513011
+  0: The total amount of wall time                        = 271.110274
 
 Test 083 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_flake_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_flake_debug
 Checking test 084 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 302.875234
+  0: The total amount of wall time                        = 277.799156
 
 Test 084 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 085 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 445.657649
+  0: The total amount of wall time                        = 465.038042
 
 Test 085 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/rrfs_v1beta_debug
 Checking test 086 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.418697
+  0: The total amount of wall time                        = 276.090458
 
 Test 086 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/HAFS_v0_HWRF_thompson_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,13 +2632,13 @@ Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 211.336063
+  0: The total amount of wall time                        = 208.400456
 
 Test 087 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2653,24 +2653,24 @@ Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
- 0: The total amount of wall time                        = 400.446221
+ 0: The total amount of wall time                        = 398.655953
 
 Test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_atm
 Checking test 089 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 263.986699
+  0: The total amount of wall time                        = 249.948283
 
 Test 089 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_atm_ocn
 Checking test 090 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2679,26 +2679,26 @@ Checking test 090 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 367.498030
+  0: The total amount of wall time                        = 355.961108
 
 Test 090 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_atm_wav
 Checking test 091 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 769.822153
+  0: The total amount of wall time                        = 755.184538
 
 Test 091 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_atm_ocn_wav
 Checking test 092 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2707,57 +2707,57 @@ Checking test 092 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 856.314541
+  0: The total amount of wall time                        = 841.413971
 
 Test 092 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_1nest_atm
 Checking test 093 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 440.964692
+  0: The total amount of wall time                        = 422.585097
 
 Test 093 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_telescopic_2nests_atm
 Checking test 094 hafs_regional_telescopic_2nests_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 412.220425
+  0: The total amount of wall time                        = 405.577364
 
 Test 094 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_global_1nest_atm
 Checking test 095 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 190.840131
+  0: The total amount of wall time                        = 188.170967
 
 Test 095 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_global_multiple_4nests_atm
 Checking test 096 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 426.857133
+  0: The total amount of wall time                        = 417.240891
 
 Test 096 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_docn
 Checking test 097 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2765,13 +2765,13 @@ Checking test 097 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.333005
+  0: The total amount of wall time                        = 340.385265
 
 Test 097 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_docn_oisst
 Checking test 098 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2779,97 +2779,97 @@ Checking test 098 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 339.866205
+  0: The total amount of wall time                        = 442.047657
 
 Test 098 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/hafs_regional_datm_cdeps
 Checking test 099 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 918.953718
+  0: The total amount of wall time                        = 916.591510
 
 Test 099 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_control_cfsr
 Checking test 100 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.913192
+ 0: The total amount of wall time                        = 142.187670
 
 Test 100 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_restart_cfsr
 Checking test 101 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 98.668129
+ 0: The total amount of wall time                        = 98.900446
 
 Test 101 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_control_gefs
 Checking test 102 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.923326
+ 0: The total amount of wall time                        = 138.081966
 
 Test 102 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_stochy_gefs
 Checking test 103 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.179145
+ 0: The total amount of wall time                        = 138.948379
 
 Test 103 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_bulk_cfsr
 Checking test 104 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.687534
+ 0: The total amount of wall time                        = 143.683277
 
 Test 104 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_bulk_gefs
 Checking test 105 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.293132
+ 0: The total amount of wall time                        = 138.010842
 
 Test 105 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_mx025_cfsr
 Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2878,13 +2878,13 @@ Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 299.287211
+  0: The total amount of wall time                        = 296.332767
 
 Test 106 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_mx025_gefs
 Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2893,35 +2893,35 @@ Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 300.565879
+  0: The total amount of wall time                        = 296.212563
 
 Test 107 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_multiple_files_cfsr
 Checking test 108 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.107535
+ 0: The total amount of wall time                        = 139.074646
 
 Test 108 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/datm_cdeps_debug_cfsr
 Checking test 109 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 463.454970
+ 0: The total amount of wall time                        = 441.309791
 
 Test 109 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_atmwav
 Checking test 110 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2965,13 +2965,13 @@ Checking test 110 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 81.540485
+  0: The total amount of wall time                        = 81.648557
 
 Test 110 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_325982/control_c384gdas_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/INTEL/control_c384gdas_wav
+working dir  = /work/noaa/stmp/junwang/stmp/junwang/FV3_RT/rt_239849/control_c384gdas_wav
 Checking test 111 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3017,11 +3017,11 @@ Checking test 111 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 690.820587
+  0: The total amount of wall time                        = 694.385402
 
 Test 111 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 18:06:24 CST 2021
-Elapsed time: 02h:54m:46s. Have a nice day!
+Wed Dec 22 22:12:52 CST 2021
+Elapsed time: 00h:58m:57s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,17 +1,17 @@
-Mon Dec 20 23:11:56 UTC 2021
+Wed Dec 22 20:38:21 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 749 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 727 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 774 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 725 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 005 elapsed time 516 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 496 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 473 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 761 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 766 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 732 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 762 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 724 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 005 elapsed time 513 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 512 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 474 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 789 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,13 +58,13 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 143.409724
+The total amount of wall time                        = 145.116987
 
 Test 001 control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_decomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -107,13 +107,13 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 146.883914
+The total amount of wall time                        = 148.595630
 
 Test 002 control_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_restart
 Checking test 003 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -152,13 +152,13 @@ Checking test 003 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 77.770352
+The total amount of wall time                        = 78.059959
 
 Test 003 control_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_fhzero
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_fhzero
 Checking test 004 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -201,13 +201,13 @@ Checking test 004 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 135.601812
+The total amount of wall time                        = 134.362779
 
 Test 004 control_fhzero PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_CubedSphereGrid
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_CubedSphereGrid
 Checking test 005 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -234,13 +234,13 @@ Checking test 005 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 136.894569
+The total amount of wall time                        = 135.704774
 
 Test 005 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_latlon
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_latlon
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_latlon
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_latlon
 Checking test 006 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -251,13 +251,13 @@ Checking test 006 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 139.564741
+The total amount of wall time                        = 138.904392
 
 Test 006 control_latlon PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_wrtGauss_netcdf_parallel
 Checking test 007 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -268,13 +268,13 @@ Checking test 007 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 141.183559
+The total amount of wall time                        = 141.515556
 
 Test 007 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c48
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_c48
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c48
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_c48
 Checking test 008 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -313,13 +313,13 @@ Checking test 008 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 430.255138
+The total amount of wall time                        = 430.536025
 
 Test 008 control_c48 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c192
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c192
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_c192
 Checking test 009 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -330,13 +330,13 @@ Checking test 009 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 535.041245
+The total amount of wall time                        = 537.748203
 
 Test 009 control_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_stochy
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_stochy
 Checking test 010 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -347,26 +347,26 @@ Checking test 010 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 96.124756
+The total amount of wall time                        = 96.637946
 
 Test 010 control_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_stochy_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_stochy_restart
 Checking test 011 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 63.858644
+The total amount of wall time                        = 54.028821
 
 Test 011 control_stochy_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_lndp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_lndp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_lndp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_lndp
 Checking test 012 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -377,13 +377,13 @@ Checking test 012 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 88.482777
+The total amount of wall time                        = 88.889148
 
 Test 012 control_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_p7
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_p7
 Checking test 013 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -430,13 +430,13 @@ Checking test 013 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 161.007885
+The total amount of wall time                        = 165.220248
 
 Test 013 control_p7 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7_rrtmgp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_p7_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7_rrtmgp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_p7_rrtmgp
 Checking test 014 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -483,13 +483,13 @@ Checking test 014 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 245.525134
+The total amount of wall time                        = 252.169367
 
 Test 014 control_p7_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_restart_p7
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_restart_p7
 Checking test 015 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -528,13 +528,13 @@ Checking test 015 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 96.102251
+The total amount of wall time                        = 97.431788
 
 Test 015 control_restart_p7 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_decomp_p7
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_decomp_p7
 Checking test 016 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -577,13 +577,13 @@ Checking test 016 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 165.648500
+The total amount of wall time                        = 171.404992
 
 Test 016 control_decomp_p7 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_control
 Checking test 017 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -594,26 +594,26 @@ Checking test 017 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 355.917150
+The total amount of wall time                        = 360.388958
 
 Test 017 regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_restart
 Checking test 018 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 211.651021
+The total amount of wall time                        = 230.015139
 
 Test 018 regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_noquilt
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_noquilt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_noquilt
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_noquilt
 Checking test 019 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -621,13 +621,13 @@ Checking test 019 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 388.024294
+The total amount of wall time                        = 387.038738
 
 Test 019 regional_noquilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_hafs
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_hafs
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_hafs
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_hafs
 Checking test 020 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -636,26 +636,26 @@ Checking test 020 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 349.557086
+The total amount of wall time                        = 351.999762
 
 Test 020 regional_hafs PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_netcdf_parallel
 Checking test 021 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 349.163293
+The total amount of wall time                        = 351.072877
 
 Test 021 regional_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_RRTMGP
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_RRTMGP
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_RRTMGP
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_RRTMGP
 Checking test 022 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -666,13 +666,13 @@ Checking test 022 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 566.738018
+The total amount of wall time                        = 569.601181
 
 Test 022 regional_RRTMGP PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_control
 Checking test 023 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -719,13 +719,13 @@ Checking test 023 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 384.323950
+The total amount of wall time                        = 403.969861
 
 Test 023 rap_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_sfcdiff
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_sfcdiff
 Checking test 024 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -772,13 +772,13 @@ Checking test 024 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 384.715576
+The total amount of wall time                        = 409.984045
 
 Test 024 rap_sfcdiff PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_sfcdiff_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_sfcdiff_restart
 Checking test 025 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -817,13 +817,13 @@ Checking test 025 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.860161
+The total amount of wall time                        = 205.041734
 
 Test 025 rap_sfcdiff_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hrrr_control
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hrrr_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hrrr_control
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hrrr_control
 Checking test 026 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -870,13 +870,13 @@ Checking test 026 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 371.657314
+The total amount of wall time                        = 376.565931
 
 Test 026 hrrr_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rrfs_v1beta
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rrfs_v1beta
 Checking test 027 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -923,13 +923,13 @@ Checking test 027 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 377.788779
+The total amount of wall time                        = 381.019809
 
 Test 027 rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_rrtmgp
 Checking test 028 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -940,13 +940,13 @@ Checking test 028 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 261.275360
+The total amount of wall time                        = 262.179450
 
 Test 028 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp_c192
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_rrtmgp_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp_c192
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_rrtmgp_c192
 Checking test 029 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -957,13 +957,13 @@ Checking test 029 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 672.009219
+The total amount of wall time                        = 673.348897
 
 Test 029 control_rrtmgp_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmg
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_csawmg
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmg
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_csawmg
 Checking test 030 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -974,13 +974,13 @@ Checking test 030 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 283.905789
+The total amount of wall time                        = 361.102474
 
 Test 030 control_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_csawmgt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_csawmgt
 Checking test 031 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -991,13 +991,13 @@ Checking test 031 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 351.431654
+The total amount of wall time                        = 356.899450
 
 Test 031 control_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_flake
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_flake
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_flake
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_flake
 Checking test 032 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1008,13 +1008,13 @@ Checking test 032 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 228.877543
+The total amount of wall time                        = 234.316061
 
 Test 032 control_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_ras
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_ras
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_ras
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_ras
 Checking test 033 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1025,13 +1025,13 @@ Checking test 033 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 191.208940
+The total amount of wall time                        = 191.774646
 
 Test 033 control_ras PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/fv3_HAFS_v0_hwrf_thompson
 Checking test 034 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1096,13 +1096,13 @@ Checking test 034 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 168.223820
+The total amount of wall time                        = 171.179968
 
 Test 034 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 035 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1117,37 +1117,37 @@ Checking test 035 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 324.007083
+The total amount of wall time                        = 317.548435
 
 Test 035 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wam_repro
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_wam_repro
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wam_repro
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_wam_repro
 Checking test 036 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 119.502577
+The total amount of wall time                        = 120.257522
 
 Test 036 control_wam PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_debug
 Checking test 037 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.954411
+The total amount of wall time                        = 143.363693
 
 Test 037 control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_CubedSphereGrid_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_CubedSphereGrid_debug
 Checking test 038 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,338 +1174,338 @@ Checking test 038 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 150.256694
+The total amount of wall time                        = 151.702807
 
 Test 038 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_wrtGauss_netcdf_parallel_debug
 Checking test 039 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 143.239466
+The total amount of wall time                        = 144.177314
 
 Test 039 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_stochy_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_stochy_debug
 Checking test 040 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.529550
+The total amount of wall time                        = 162.284857
 
 Test 040 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_lndp_debug
 Checking test 041 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.793215
+The total amount of wall time                        = 146.311355
 
 Test 041 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_rrtmgp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_rrtmgp_debug
 Checking test 042 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.302272
+The total amount of wall time                        = 170.081529
 
 Test 042 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_csawmg_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_csawmg_debug
 Checking test 043 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 194.649917
+The total amount of wall time                        = 230.412143
 
 Test 043 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_csawmgt_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_csawmgt_debug
 Checking test 044 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 225.844795
+The total amount of wall time                        = 227.038147
 
 Test 044 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_ras_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_ras_debug
 Checking test 045 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 148.215152
+The total amount of wall time                        = 147.857674
 
 Test 045 control_ras_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_diag_debug
 Checking test 046 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 151.380391
+The total amount of wall time                        = 151.530037
 
 Test 046 control_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_debug_p7
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_debug_p7
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_debug_p7
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_debug_p7
 Checking test 047 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 154.222448
+The total amount of wall time                        = 156.816614
 
 Test 047 control_debug_p7 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_thompson_debug
 Checking test 048 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.186109
+The total amount of wall time                        = 170.761675
 
 Test 048 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_thompson_no_aero_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_thompson_no_aero_debug
 Checking test 049 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.934428
+The total amount of wall time                        = 160.446167
 
 Test 049 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/control_thompson_extdiag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_debug_extdiag
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/control_thompson_extdiag_debug
 Checking test 050 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 178.550733
+The total amount of wall time                        = 178.625098
 
 Test 050 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/regional_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/regional_debug
 Checking test 051 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 248.640743
+The total amount of wall time                        = 249.137248
 
 Test 051 regional_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_control_debug
 Checking test 052 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.602368
+The total amount of wall time                        = 265.410782
 
 Test 052 rap_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_unified_drag_suite_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_unified_drag_suite_debug
 Checking test 053 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.758351
+The total amount of wall time                        = 263.594525
 
 Test 053 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_diag_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_diag_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_diag_debug
 Checking test 054 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 282.806338
+The total amount of wall time                        = 285.400646
 
 Test 054 rap_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_cires_ugwp_debug
 Checking test 055 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 272.473856
+The total amount of wall time                        = 273.243376
 
 Test 055 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_unified_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_unified_ugwp_debug
 Checking test 056 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 276.198568
+The total amount of wall time                        = 271.558959
 
 Test 056 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_noah_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_noah_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_noah_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_noah_debug
 Checking test 057 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 261.200540
+The total amount of wall time                        = 261.064915
 
 Test 057 rap_noah_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_rrtmgp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_rrtmgp_debug
 Checking test 058 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 458.974894
+The total amount of wall time                        = 458.531995
 
 Test 058 rap_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_lndp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_lndp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_lndp_debug
 Checking test 059 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.823959
+The total amount of wall time                        = 267.949479
 
 Test 059 rap_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_sfcdiff_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_sfcdiff_debug
 Checking test 060 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.966585
+The total amount of wall time                        = 266.552397
 
 Test 060 rap_sfcdiff_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_flake_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_flake_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_flake_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_flake_debug
 Checking test 061 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.367901
+The total amount of wall time                        = 266.104608
 
 Test 061 rap_flake_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 062 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 436.356533
+The total amount of wall time                        = 436.450513
 
 Test 062 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/rrfs_v1beta_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/rrfs_v1beta_debug
 Checking test 063 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.426056
+The total amount of wall time                        = 262.251035
 
 Test 063 rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 064 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1570,13 +1570,13 @@ Checking test 064 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-The total amount of wall time                        = 196.611115
+The total amount of wall time                        = 197.449090
 
 Test 064 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 065 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1591,24 +1591,24 @@ Checking test 065 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-The total amount of wall time                        = 365.673829
+The total amount of wall time                        = 372.914048
 
 Test 065 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_atm
 Checking test 066 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 324.357128
+The total amount of wall time                        = 386.210975
 
 Test 066 hafs_regional_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_atm_ocn
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_atm_ocn
 Checking test 067 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1617,26 +1617,26 @@ Checking test 067 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 503.203582
+The total amount of wall time                        = 583.260828
 
 Test 067 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_wav
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_atm_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_wav
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_atm_wav
 Checking test 068 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 901.889556
+The total amount of wall time                        = 1007.745512
 
 Test 068 hafs_regional_atm_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_atm_ocn_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_atm_ocn_wav
 Checking test 069 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1645,44 +1645,44 @@ Checking test 069 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 974.944949
+The total amount of wall time                        = 1039.186609
 
 Test 069 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_1nest_atm
 Checking test 070 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 347.511854
+The total amount of wall time                        = 377.640030
 
 Test 070 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_regional_telescopic_2nests_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_regional_telescopic_2nests_atm
 Checking test 071 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 367.521069
+The total amount of wall time                        = 380.689586
 
 Test 071 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_global_1nest_atm
-working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_42490/hafs_global_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_global_1nest_atm
+working dir  = /gpfs/hps3/stmp/Jun.Wang/FV3_RT/rt_8802/hafs_global_1nest_atm
 Checking test 072 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 163.754984
+The total amount of wall time                        = 173.428817
 
 Test 072 hafs_global_1nest_atm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 20 23:48:12 UTC 2021
-Elapsed time: 00h:36m:17s. Have a nice day!
+Wed Dec 22 21:16:00 UTC 2021
+Elapsed time: 00h:37m:40s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,23 +1,23 @@
-Tue Dec 21 00:38:27 UTC 2021
+Wed Dec 22 19:33:47 UTC 2021
 Start Regression test
 
-Compile 001 elapsed time 1656 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 526 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1143 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1923 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 523 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1144 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_nsstNoahmpUGWPv1,FV3_GFS_v16_p7_rrtmgp -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 004 elapsed time 1080 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1337 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 877 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 449 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 423 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 283 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1151 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1218 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 793 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 321 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 917 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1341 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp,FV3_HAFS_v0_hwrf_thompson -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 869 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 447 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_nsstNoahmpUGWPv1 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 427 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_HAFS_v0_hwrf_thompson -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1159 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1201 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 790 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 442 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 908 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_control_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_control_p7
 Checking test 001 cpld_control_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -70,13 +70,13 @@ Checking test 001 cpld_control_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 247.992203
+[0] The total amount of wall time                        = 244.907755
 
 Test 001 cpld_control_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_control_p7_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_control_p7_rrtmgp
 Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -129,13 +129,13 @@ Checking test 002 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 332.845984
+[0] The total amount of wall time                        = 331.778987
 
 Test 002 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_2threads_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_2threads_p7
 Checking test 003 cpld_2threads_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -188,13 +188,13 @@ Checking test 003 cpld_2threads_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 233.923872
+[0] The total amount of wall time                        = 232.579336
 
 Test 003 cpld_2threads_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_decomp_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_decomp_p7
 Checking test 004 cpld_decomp_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -247,13 +247,13 @@ Checking test 004 cpld_decomp_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 248.363020
+[0] The total amount of wall time                        = 247.776346
 
 Test 004 cpld_decomp_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_mpi_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_mpi_p7
 Checking test 005 cpld_mpi_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -306,13 +306,13 @@ Checking test 005 cpld_mpi_p7 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 213.968899
+[0] The total amount of wall time                        = 210.753243
 
 Test 005 cpld_mpi_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_bmark_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_bmark_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_bmark_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -357,13 +357,13 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1049.778788
+[0] The total amount of wall time                        = 1032.372664
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_bmark_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_bmark_mpi_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_bmark_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_bmark_mpi_p7
 Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -408,13 +408,13 @@ Checking test 007 cpld_bmark_mpi_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1043.072032
+[0] The total amount of wall time                        = 1012.930736
 
 Test 007 cpld_bmark_mpi_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c96_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_control_c96_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c96_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_control_c96_p7
 Checking test 008 cpld_control_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -464,13 +464,13 @@ Checking test 008 cpld_control_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 236.297444
+[0] The total amount of wall time                        = 234.889744
 
 Test 008 cpld_control_c96_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c96_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_restart_c96_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c96_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_restart_c96_p7
 Checking test 009 cpld_restart_c96_p7 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -520,13 +520,13 @@ Checking test 009 cpld_restart_c96_p7 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 129.056057
+[0] The total amount of wall time                        = 126.111591
 
 Test 009 cpld_restart_c96_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c192_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_control_c192_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c192_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_control_c192_p7
 Checking test 010 cpld_control_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -576,13 +576,13 @@ Checking test 010 cpld_control_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 997.026120
+[0] The total amount of wall time                        = 993.926874
 
 Test 010 cpld_control_c192_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c192_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_restart_c192_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c192_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_restart_c192_p7
 Checking test 011 cpld_restart_c192_p7 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -632,13 +632,13 @@ Checking test 011 cpld_restart_c192_p7 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 620.181887
+[0] The total amount of wall time                        = 622.487501
 
 Test 011 cpld_restart_c192_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c384_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_control_c384_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c384_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_control_c384_p7
 Checking test 012 cpld_control_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -681,13 +681,13 @@ Checking test 012 cpld_control_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 1114.741140
+[0] The total amount of wall time                        = 1107.869619
 
 Test 012 cpld_control_c384_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_control_c384_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_restart_c384_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_control_c384_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_restart_c384_p7
 Checking test 013 cpld_restart_c384_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -730,13 +730,13 @@ Checking test 013 cpld_restart_c384_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 602.823290
+[0] The total amount of wall time                        = 602.813475
 
 Test 013 cpld_restart_c384_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/cpld_debug_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/cpld_debug_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/cpld_debug_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/cpld_debug_p7
 Checking test 014 cpld_debug_p7 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -786,13 +786,13 @@ Checking test 014 cpld_debug_p7 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 708.927432
+[0] The total amount of wall time                        = 709.520883
 
 Test 014 cpld_debug_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -839,13 +839,13 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 139.938191
+[0] The total amount of wall time                        = 140.146311
 
 Test 015 control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_decomp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -888,13 +888,13 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 146.510769
+[0] The total amount of wall time                        = 146.674663
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_2threads
 Checking test 017 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -937,13 +937,13 @@ Checking test 017 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 129.589069
+[0] The total amount of wall time                        = 129.378501
 
 Test 017 control_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_restart
 Checking test 018 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -982,13 +982,13 @@ Checking test 018 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 74.875214
+[0] The total amount of wall time                        = 75.210505
 
 Test 018 control_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_fhzero
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_fhzero
 Checking test 019 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1031,13 +1031,13 @@ Checking test 019 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 133.814342
+[0] The total amount of wall time                        = 132.958100
 
 Test 019 control_fhzero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_CubedSphereGrid
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_CubedSphereGrid
 Checking test 020 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1064,13 +1064,13 @@ Checking test 020 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 136.177792
+[0] The total amount of wall time                        = 135.878282
 
 Test 020 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_latlon
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_latlon
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_latlon
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_latlon
 Checking test 021 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1081,30 +1081,30 @@ Checking test 021 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 139.711171
+[0] The total amount of wall time                        = 139.817810
 
 Test 021 control_latlon PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_wrtGauss_netcdf_parallel
 Checking test 022 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 143.695264
+[0] The total amount of wall time                        = 143.544063
 
 Test 022 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c48
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_c48
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c48
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_c48
 Checking test 023 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1143,13 +1143,13 @@ Checking test 023 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 442.345305
+[0] The total amount of wall time                        = 441.167184
 
 Test 023 control_c48 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c192
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c192
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_c192
 Checking test 024 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1160,13 +1160,13 @@ Checking test 024 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 552.465154
+[0] The total amount of wall time                        = 559.107445
 
 Test 024 control_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c384
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_c384
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c384
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_c384
 Checking test 025 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1177,13 +1177,13 @@ Checking test 025 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1036.215958
+[0] The total amount of wall time                        = 1032.850079
 
 Test 025 control_c384 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_c384gdas
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_c384gdas
 Checking test 026 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1226,13 +1226,13 @@ Checking test 026 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 948.061075
+[0] The total amount of wall time                        = 910.706505
 
 Test 026 control_c384gdas PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_stochy
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_stochy
 Checking test 027 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1243,26 +1243,26 @@ Checking test 027 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 92.840988
+[0] The total amount of wall time                        = 92.748277
 
 Test 027 control_stochy PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_stochy_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_stochy_restart
 Checking test 028 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 51.523306
+[0] The total amount of wall time                        = 50.311564
 
 Test 028 control_stochy_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_lndp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_lndp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_lndp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_lndp
 Checking test 029 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1273,13 +1273,13 @@ Checking test 029 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 85.060916
+[0] The total amount of wall time                        = 85.823810
 
 Test 029 control_lndp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_p7
 Checking test 030 control_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1326,13 +1326,13 @@ Checking test 030 control_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 156.424344
+[0] The total amount of wall time                        = 154.867940
 
 Test 030 control_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_p7_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_p7_rrtmgp
 Checking test 031 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1379,13 +1379,13 @@ Checking test 031 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 248.900674
+[0] The total amount of wall time                        = 247.542129
 
 Test 031 control_p7_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_restart_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_restart_p7
 Checking test 032 control_restart_p7 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1424,13 +1424,13 @@ Checking test 032 control_restart_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 86.884488
+[0] The total amount of wall time                        = 84.018406
 
 Test 032 control_restart_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_decomp_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_decomp_p7
 Checking test 033 control_decomp_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1473,13 +1473,13 @@ Checking test 033 control_decomp_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 162.213767
+[0] The total amount of wall time                        = 160.267477
 
 Test 033 control_decomp_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_2threads_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_2threads_p7
 Checking test 034 control_2threads_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1522,13 +1522,13 @@ Checking test 034 control_2threads_p7 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 147.000237
+[0] The total amount of wall time                        = 146.023061
 
 Test 034 control_2threads_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_control
 Checking test 035 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1539,26 +1539,26 @@ Checking test 035 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 344.171000
+[0] The total amount of wall time                        = 346.766264
 
 Test 035 regional_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_restart
 Checking test 036 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 191.930040
+[0] The total amount of wall time                        = 192.316118
 
 Test 036 regional_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_noquilt
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_noquilt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_noquilt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_noquilt
 Checking test 037 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1566,13 +1566,13 @@ Checking test 037 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 372.288809
+[0] The total amount of wall time                        = 375.364035
 
 Test 037 regional_noquilt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_2threads
 Checking test 038 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1583,13 +1583,13 @@ Checking test 038 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 196.638238
+[0] The total amount of wall time                        = 196.248575
 
 Test 038 regional_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_hafs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_hafs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_hafs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_hafs
 Checking test 039 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1598,26 +1598,26 @@ Checking test 039 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 346.537789
+[0] The total amount of wall time                        = 345.651153
 
 Test 039 regional_hafs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_netcdf_parallel
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_netcdf_parallel
 Checking test 040 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 347.003062
+[0] The total amount of wall time                        = 347.676247
 
 Test 040 regional_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_RRTMGP
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_RRTMGP
 Checking test 041 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1628,13 +1628,13 @@ Checking test 041 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 589.097070
+[0] The total amount of wall time                        = 584.606821
 
 Test 041 regional_RRTMGP PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_control
 Checking test 042 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1681,13 +1681,13 @@ Checking test 042 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 399.105446
+[0] The total amount of wall time                        = 395.602802
 
 Test 042 rap_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_2threads
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1734,13 +1734,13 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 374.013209
+[0] The total amount of wall time                        = 373.457521
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_sfcdiff
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_sfcdiff
 Checking test 044 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1787,13 +1787,13 @@ Checking test 044 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 394.760148
+[0] The total amount of wall time                        = 395.434050
 
 Test 044 rap_sfcdiff PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_sfcdiff_restart
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_sfcdiff_restart
 Checking test 045 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1832,13 +1832,13 @@ Checking test 045 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 204.899774
+[0] The total amount of wall time                        = 203.984010
 
 Test 045 rap_sfcdiff_restart PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hrrr_control
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hrrr_control
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hrrr_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hrrr_control
 Checking test 046 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1885,13 +1885,13 @@ Checking test 046 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 384.797084
+[0] The total amount of wall time                        = 383.132875
 
 Test 046 hrrr_control PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rrfs_v1beta
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rrfs_v1beta
 Checking test 047 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1938,13 +1938,13 @@ Checking test 047 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 388.743855
+[0] The total amount of wall time                        = 389.857606
 
 Test 047 rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_rrtmgp
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_rrtmgp
 Checking test 048 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1955,13 +1955,13 @@ Checking test 048 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 271.027200
+[0] The total amount of wall time                        = 270.909267
 
 Test 048 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp_c192
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_rrtmgp_c192
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp_c192
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_rrtmgp_c192
 Checking test 049 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1972,13 +1972,13 @@ Checking test 049 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 700.382318
+[0] The total amount of wall time                        = 701.197180
 
 Test 049 control_rrtmgp_c192 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_csawmg
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_csawmg
 Checking test 050 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1989,13 +1989,13 @@ Checking test 050 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 290.864944
+[0] The total amount of wall time                        = 366.872210
 
 Test 050 control_csawmg PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_csawmgt
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_csawmgt
 Checking test 051 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2006,13 +2006,13 @@ Checking test 051 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 366.944026
+[0] The total amount of wall time                        = 364.276628
 
 Test 051 control_csawmgt PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_flake
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_flake
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_flake
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_flake
 Checking test 052 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2023,13 +2023,13 @@ Checking test 052 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 241.532519
+[0] The total amount of wall time                        = 244.585794
 
 Test 052 control_flake PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_ras
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_ras
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_ras
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_ras
 Checking test 053 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2040,13 +2040,13 @@ Checking test 053 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 191.713309
+[0] The total amount of wall time                        = 191.387692
 
 Test 053 control_ras PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_thompson
 Checking test 054 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2057,13 +2057,13 @@ Checking test 054 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 240.973306
+[0] The total amount of wall time                        = 240.750235
 
 Test 054 control_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_thompson_no_aero
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_thompson_no_aero
 Checking test 055 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2074,13 +2074,13 @@ Checking test 055 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 229.999095
+[0] The total amount of wall time                        = 231.536340
 
 Test 055 control_thompson_no_aero PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/fv3_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/fv3_HAFS_v0_hwrf_thompson
 Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2145,13 +2145,13 @@ Checking test 056 fv3_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 176.891410
+[0] The total amount of wall time                        = 177.088617
 
 Test 056 fv3_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/ESG_HAFS_v0_HWRF_thompson
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/fv3_esg_HAFS_v0_hwrf_thompson
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/ESG_HAFS_v0_HWRF_thompson
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/fv3_esg_HAFS_v0_hwrf_thompson
 Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2166,50 +2166,50 @@ Checking test 057 fv3_esg_HAFS_v0_hwrf_thompson results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 325.889764
+[0] The total amount of wall time                        = 324.065491
 
 Test 057 fv3_esg_HAFS_v0_hwrf_thompson PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wam_repro
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_wam_repro
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wam_repro
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_wam_repro
 Checking test 058 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 127.027801
+[0] The total amount of wall time                        = 128.101172
 
 Test 058 control_wam PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_debug
 Checking test 059 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 167.794586
+[0] The total amount of wall time                        = 167.059955
 
 Test 059 control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_2threads_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_2threads_debug
 Checking test 060 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 155.446535
+[0] The total amount of wall time                        = 155.209822
 
 Test 060 control_2threads_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_CubedSphereGrid_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_CubedSphereGrid_debug
 Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2236,338 +2236,338 @@ Checking test 061 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 182.928141
+[0] The total amount of wall time                        = 182.421452
 
 Test 061 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_wrtGauss_netcdf_parallel_debug
 Checking test 062 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc .........OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 171.298275
+[0] The total amount of wall time                        = 170.242339
 
 Test 062 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_stochy_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_stochy_debug
 Checking test 063 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 191.995845
+[0] The total amount of wall time                        = 192.203435
 
 Test 063 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_lndp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_lndp_debug
 Checking test 064 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 173.345692
+[0] The total amount of wall time                        = 172.607641
 
 Test 064 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_rrtmgp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_rrtmgp_debug
 Checking test 065 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 201.040148
+[0] The total amount of wall time                        = 200.639028
 
 Test 065 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_csawmg_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_csawmg_debug
 Checking test 066 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 228.820692
+[0] The total amount of wall time                        = 269.639945
 
 Test 066 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_csawmgt_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_csawmgt_debug
 Checking test 067 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 265.218108
+[0] The total amount of wall time                        = 265.819825
 
 Test 067 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_ras_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_ras_debug
 Checking test 068 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 175.261055
+[0] The total amount of wall time                        = 174.253603
 
 Test 068 control_ras_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_diag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_diag_debug
 Checking test 069 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 177.584167
+[0] The total amount of wall time                        = 177.369071
 
 Test 069 control_diag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_debug_p7
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_debug_p7
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_debug_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_debug_p7
 Checking test 070 control_debug_p7 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 183.920350
+[0] The total amount of wall time                        = 184.374576
 
 Test 070 control_debug_p7 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_thompson_debug
 Checking test 071 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 197.254500
+[0] The total amount of wall time                        = 197.612094
 
 Test 071 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_thompson_no_aero_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_thompson_no_aero_debug
 Checking test 072 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.267878
+[0] The total amount of wall time                        = 190.868035
 
 Test 072 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_thompson_extdiag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_thompson_debug_extdiag
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_thompson_extdiag_debug
 Checking test 073 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 207.137054
+[0] The total amount of wall time                        = 207.330681
 
 Test 073 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/fv3_regional_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/regional_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/fv3_regional_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/regional_debug
 Checking test 074 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-[0] The total amount of wall time                        = 283.216738
+[0] The total amount of wall time                        = 283.668349
 
 Test 074 regional_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_control_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_control_debug
 Checking test 075 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.466153
+[0] The total amount of wall time                        = 305.627784
 
 Test 075 rap_control_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_unified_drag_suite_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_unified_drag_suite_debug
 Checking test 076 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.946219
+[0] The total amount of wall time                        = 305.841461
 
 Test 076 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_diag_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_diag_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_diag_debug
 Checking test 077 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 323.438454
+[0] The total amount of wall time                        = 322.530821
 
 Test 077 rap_diag_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_cires_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_cires_ugwp_debug
 Checking test 078 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 312.627321
+[0] The total amount of wall time                        = 312.188734
 
 Test 078 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_unified_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_unified_ugwp_debug
 Checking test 079 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 312.015840
+[0] The total amount of wall time                        = 312.136828
 
 Test 079 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_noah_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_noah_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_noah_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_noah_debug
 Checking test 080 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 302.667331
+[0] The total amount of wall time                        = 302.857893
 
 Test 080 rap_noah_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_rrtmgp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_rrtmgp_debug
 Checking test 081 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 534.776693
+[0] The total amount of wall time                        = 534.773729
 
 Test 081 rap_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_lndp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_lndp_debug
 Checking test 082 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 308.407751
+[0] The total amount of wall time                        = 309.121395
 
 Test 082 rap_lndp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_sfcdiff_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_sfcdiff_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_sfcdiff_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_sfcdiff_debug
 Checking test 083 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.988703
+[0] The total amount of wall time                        = 305.863732
 
 Test 083 rap_sfcdiff_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_flake_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_flake_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_flake_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_flake_debug
 Checking test 084 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 306.093503
+[0] The total amount of wall time                        = 305.205726
 
 Test 084 rap_flake_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 085 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 508.996269
+[0] The total amount of wall time                        = 510.241396
 
 Test 085 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/rrfs_v1beta_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/rrfs_v1beta_debug
 Checking test 086 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.012505
+[0] The total amount of wall time                        = 304.576294
 
 Test 086 rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/fv3_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/fv3_HAFS_v0_hwrf_thompson_debug
 Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,13 +2632,13 @@ Checking test 087 fv3_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/phy_data.tile5.nc .........OK
  Comparing RESTART/phy_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 237.860283
+[0] The total amount of wall time                        = 237.558763
 
 Test 087 fv3_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/ESG_HAFS_v0_HWRF_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/fv3_esg_HAFS_v0_hwrf_thompson_debug
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/ESG_HAFS_v0_HWRF_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/fv3_esg_HAFS_v0_hwrf_thompson_debug
 Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2653,125 +2653,125 @@ Checking test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing RESTART/sfc_data.nc .........OK
  Comparing RESTART/phy_data.nc .........OK
 
-[0] The total amount of wall time                        = 437.177233
+[0] The total amount of wall time                        = 437.758383
 
 Test 088 fv3_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_atm
 Checking test 089 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 603.578409
+[0] The total amount of wall time                        = 602.015325
 
 Test 089 hafs_regional_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_atm_ocn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_atm_ocn
 Checking test 090 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 592.818012
+[0] The total amount of wall time                        = 595.781386
 
 Test 090 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_atm_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_atm_wav
 Checking test 091 hafs_regional_atm_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 975.261758
+[0] The total amount of wall time                        = 975.964373
 
 Test 091 hafs_regional_atm_wav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_atm_ocn_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_atm_ocn_wav
 Checking test 092 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 1030.667242
+[0] The total amount of wall time                        = 1036.721174
 
 Test 092 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_1nest_atm
 Checking test 093 hafs_regional_1nest_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 388.045733
+[0] The total amount of wall time                        = 385.950107
 
 Test 093 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_telescopic_2nests_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_telescopic_2nests_atm
 Checking test 094 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 669.482487
+[0] The total amount of wall time                        = 667.291073
 
 Test 094 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_global_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_global_1nest_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_global_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_global_1nest_atm
 Checking test 095 hafs_global_1nest_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 648.607635
+[0] The total amount of wall time                        = 649.685470
 
 Test 095 hafs_global_1nest_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_global_multiple_4nests_atm
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_global_multiple_4nests_atm
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_global_multiple_4nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_global_multiple_4nests_atm
 Checking test 096 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 661.852907
+[0] The total amount of wall time                        = 660.779448
 
 Test 096 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_docn
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_docn
 Checking test 097 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 591.139137
+[0] The total amount of wall time                        = 594.459015
 
 Test 097 hafs_regional_docn PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_docn_oisst
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_docn_oisst
 Checking test 098 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2779,97 +2779,97 @@ Checking test 098 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 592.675790
+[0] The total amount of wall time                        = 591.660278
 
 Test 098 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/hafs_regional_datm_cdeps
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/hafs_regional_datm_cdeps
 Checking test 099 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1087.559456
+[0] The total amount of wall time                        = 1084.340267
 
 Test 099 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_control_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_control_cfsr
 Checking test 100 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.285109
+[0] The total amount of wall time                        = 171.912631
 
 Test 100 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_restart_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_restart_cfsr
 Checking test 101 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 117.606097
+[0] The total amount of wall time                        = 115.977438
 
 Test 101 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_control_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_control_gefs
 Checking test 102 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 164.076049
+[0] The total amount of wall time                        = 164.834996
 
 Test 102 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_stochy_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_stochy_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_stochy_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_stochy_gefs
 Checking test 103 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 165.372139
+[0] The total amount of wall time                        = 167.552972
 
 Test 103 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_bulk_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_bulk_cfsr
 Checking test 104 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.368863
+[0] The total amount of wall time                        = 171.126213
 
 Test 104 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_bulk_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_bulk_gefs
 Checking test 105 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 166.016057
+[0] The total amount of wall time                        = 165.809695
 
 Test 105 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_mx025_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_mx025_cfsr
 Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2878,13 +2878,13 @@ Checking test 106 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 360.005712
+[0] The total amount of wall time                        = 350.907195
 
 Test 106 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_mx025_gefs
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_mx025_gefs
 Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2893,35 +2893,35 @@ Checking test 107 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 363.456793
+[0] The total amount of wall time                        = 341.894356
 
 Test 107 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_multiple_files_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_multiple_files_cfsr
 Checking test 108 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 171.576288
+[0] The total amount of wall time                        = 169.042855
 
 Test 108 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/datm_cdeps_debug_cfsr
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/datm_cdeps_debug_cfsr
 Checking test 109 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 497.696872
+[0] The total amount of wall time                        = 495.800600
 
 Test 109 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_atmwav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_atmwav
 Checking test 110 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2965,13 +2965,13 @@ Checking test 110 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 94.006930
+[0] The total amount of wall time                        = 92.460271
 
 Test 110 control_atmwav PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211221/control_c384gdas_wav
-working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_11973/control_c384gdas_wav
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20211222/control_c384gdas_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_33255/control_c384gdas_wav
 Checking test 111 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3017,11 +3017,11 @@ Checking test 111 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-[0] The total amount of wall time                        = 608.763522
+[0] The total amount of wall time                        = 620.853422
 
 Test 111 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Dec 21 02:27:57 UTC 2021
-Elapsed time: 01h:49m:32s. Have a nice day!
+Wed Dec 22 21:17:43 UTC 2021
+Elapsed time: 01h:44m:00s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -465,7 +465,7 @@ if [[ $TESTS_FILE =~ '35d' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20211221
+BL_DATE=20211222
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]] || [[ $MACHINE_ID = s4.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 else

--- a/tests/tests/control_csawmg
+++ b/tests/tests/control_csawmg
@@ -29,7 +29,7 @@ export OUTPUT_GRID='gaussian_grid'
 export NSTF_NAME='2,0,0,0,0'
 export WRITE_DOPOST=.true.
 
-export DT_ATMOS=600
+export DT_ATMOS=450
 export IAER=1011
 export DIAG_TABLE='diag_table_aod'
 export FIELD_TABLE='field_table_csawmgshoc'

--- a/tests/tests/control_csawmg_debug
+++ b/tests/tests/control_csawmg_debug
@@ -25,7 +25,7 @@ export NSTF_NAME='2,0,0,0,0'
 export FHMAX=01
 export OUTPUT_FH="0 1"
 
-export DT_ATMOS=600
+export DT_ATMOS=450
 export IAER=1011
 export DIAG_TABLE='diag_table_aod'
 export FIELD_TABLE='field_table_csawmgshoc'


### PR DESCRIPTION
# PR Checklist

- [x] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description

This PR combines:

-   https://github.com/NCAR/ccpp-physics/pull/808
-   https://github.com/NCAR/ccpp-physics/pull/816

808 addresses an error in the momentum roughness length over tiles with ice. 816 fixes an occasional segfault bug related to the tsurf variable in NoahMP and updates to "improve snow simulation in NoahMP for P8". Both ccpp-physics 808 and 816 change results and require new baselines.

### Issue(s) addressed

No GitHub issues are addressed, but https://github.com/NCAR/ccpp-physics/pull/816 addresses occasional segfaults when using NoahMP. See that PR for details.

## Testing

ccpp-physics 808 should cause all tests that use sfc_diff.f to fail due to change in results .
ccpp-physics 816 should cause all tests that use NoahMP to fail due to change in results.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [x] CI: https://github.com/ufs-community/ufs-weather-model/actions/runs/1609443592

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/818
- waiting on https://github.com/NOAA-EMC/fv3atm/pull/452
