### PR TITLE
Set ACCNR in rt.sh, not detect_machine.sh. Add some comments explaini…

### DIFF
--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Default account "nems"
-export ACCNR=${ACCNR:-nems}
+# Do not set ACCNR here or it will break the per-system defaults in rt.sh.
 
 case $(hostname -f) in
 
@@ -117,5 +116,3 @@ if [ $MACHINE_ID = orion ] || [ $MACHINE_ID = hera ] || [ $MACHINE_ID = cheyenne
    [ $MACHINE_ID = gaea ] || [ $MACHINE_ID = stampede ] || [ $MACHINE_ID = s4 ] || [ $MACHINE_ID = expanse ] ; then
     MACHINE_ID=${MACHINE_ID}.${RT_COMPILER}
 fi
-
-echo "Machine: " $MACHINE_ID "    Account: " $ACCNR

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -115,7 +115,7 @@ fi
 # Default compiler "intel"
 export RT_COMPILER=${RT_COMPILER:-intel}
 
-source detect_machine.sh
+source detect_machine.sh # Note: this does not set ACCNR. The "if" block below does.
 source rt_utils.sh
 
 source module-setup.sh
@@ -141,7 +141,7 @@ if [[ $MACHINE_ID = wcoss_cray ]]; then
   QUEUE=debug
   COMPILE_QUEUE=dev
   PARTITION=
-  ACCNR=GFS-DEV
+  ACCNR="${ACCNR:-GFS-DEV}"
   if [[ -d /gpfs/hps3/ptmp ]] ; then
       STMP=/gpfs/hps3/stmp
       PTMP=/gpfs/hps3/stmp
@@ -174,7 +174,7 @@ elif [[ $MACHINE_ID = wcoss_dell_p3 ]]; then
   QUEUE=debug
   COMPILE_QUEUE=dev_transfer
   PARTITION=
-  ACCNR=GFS-DEV
+  ACCNR="${ACCNR:-GFS-DEV}"
   STMP=/gpfs/dell2/stmp
   PTMP=/gpfs/dell2/ptmp
   SCHEDULER=lsf
@@ -204,7 +204,7 @@ elif [[ $MACHINE_ID = wcoss2 ]]; then
   QUEUE=dev
   COMPILE_QUEUE=dev
   PARTITION=
-  ACCNR=GFS-DEV
+  ACCNR="${ACCNR:-GFS-DEV}"
   STMP=/lfs/h1/emc/ptmp
   PTMP=/lfs/h1/emc/ptmp
   SCHEDULER=pbs
@@ -221,7 +221,7 @@ elif [[ $MACHINE_ID = gaea.* ]]; then
   DISKNM=/lustre/f2/pdata/ncep_shared/emc.nemspara/RT
   QUEUE=normal
   COMPILE_QUEUE=normal
-#  ACCNR=cmp
+#  ACCNR="${ACCNR:-cmp}"
   PARTITION=c4
   STMP=/lustre/f2/scratch
   PTMP=/lustre/f2/scratch
@@ -248,7 +248,7 @@ elif [[ $MACHINE_ID = hera.* ]]; then
   QUEUE=batch
   COMPILE_QUEUE=batch
 
-  #ACCNR=fv3-cpu
+  #ACCNR="${ACCNR:-fv3-cpu}  
   PARTITION=
   dprefix=/scratch1/NCEPDEV
   DISKNM=$dprefix/nems/emc.nemspara/RT
@@ -274,7 +274,6 @@ elif [[ $MACHINE_ID = orion.* ]]; then
 
   QUEUE=batch
   COMPILE_QUEUE=batch
-#  ACCNR= # detected in detect_machine.sh
   PARTITION=orion
   dprefix=/work/noaa/stmp/${USER}
   DISKNM=/work/noaa/nems/emc.nemspara/RT
@@ -300,7 +299,7 @@ elif [[ $MACHINE_ID = jet.* ]]; then
 
   QUEUE=batch
   COMPILE_QUEUE=batch
-  ACCNR=${ACCNR:-h-nems}
+  ACCNR="${ACCNR:-h-nems}"
   PARTITION=xjet
   DISKNM=/lfs4/HFIP/h-nems/emc.nemspara/RT
   dprefix=${dprefix:-/lfs4/HFIP/$ACCNR/$USER}
@@ -327,7 +326,7 @@ elif [[ $MACHINE_ID = s4.* ]]; then
   QUEUE=s4
   COMPILE_QUEUE=s4
 
-  ACCNR=star
+  ACCNR="${ACCNR:-star}"
   PARTITION=s4
   dprefix=/data/users/dhuber/save
   DISKNM=$dprefix/nems/emc.nemspara/RT
@@ -363,7 +362,7 @@ elif [[ $MACHINE_ID = stampede.* ]]; then
   QUEUE=skx-normal
   COMPILE_QUEUE=skx-dev
   PARTITION=
-  ACCNR=TG-EES200015
+  ACCNR="${ACCNR:-TG-EES200015}"
   dprefix=$SCRATCH/ufs-weather-model/run
   DISKNM=/work2/07736/minsukji/stampede2/ufs-weather-model/RT
   STMP=$dprefix
@@ -380,7 +379,7 @@ elif [[ $MACHINE_ID = expanse.* ]]; then
   QUEUE=compute
   COMPILE_QUEUE=shared
   PARTITION=
-  ACCNR=TG-EES200015
+  ACCNR="${ACCNR:-TG-EES200015}"
   dprefix=/expanse/lustre/scratch/$USER/temp_project/run
   DISKNM=/expanse/lustre/scratch/domh/temp_project/RT
   STMP=$dprefix
@@ -391,6 +390,13 @@ elif [[ $MACHINE_ID = expanse.* ]]; then
 else
   die "Unknown machine ID, please edit detect_machine.sh file"
 fi
+
+# If account is unspecified, assume the machine has a "nems"
+# accounting code.
+export ACCNR="${ACCNR:-nems}"
+
+# Display the machine and account using the format detect_machine.sh used:
+echo "Machine: " $MACHINE_ID "    Account: " $ACCNR
 
 mkdir -p ${STMP}/${USER}
 

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -5,6 +5,10 @@ if [[ "$0" = "${BASH_SOURCE[0]}" ]]; then
   exit 1
 fi
 
+# Note: this file must only contain subroutines, and variables that
+# are not dependent on the caller. Most regression test variables
+# (such as ACCNR) are not set until after rt.sh sources this file.
+
 OPNREQ_TEST=${OPNREQ_TEST:-false}
 
 qsub_id=0


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] ~~Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.~~

- [ ] ~~New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.~~

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsiblity to keep the PR up-to-date with the develop branch of ufs-weather-model. 

# Description

The rt.sh ignores the ACCNR value set by the user in the environment because the big per-platform "if/elif/fi" hard-codes it to per-platform values (`ACCNR=GFS-DEV`) instead of allowing a user-specified default (`ACCNR=${ACCNR:-GFS-DEV}`). It has to do this because the detect_machine.sh sets an incorrect default value (nems) so ACCNR is always set by the time it reaches the rt.sh per-platform if/elif/fi block. The fix is to remove the setting from detect_machine.sh and allow a user-specified default in rt.sh. The final default of ACCNR=${ACCNR:-nems} happens after that block to ensure the original behavior of a "nems" default when appropriate.

**Warning: If a user or automated test system was setting ACCNR to an invalid value, then rt.sh will use that value after this PR, and will fail. Make certain your scripts are setting ACCNR properly, or not setting it at all, before testing this!**

### Issue(s) addressed

The first attempt at fixing this (issue #979) is in PR #981, which caused a bug #1014 and didn't fix issues mentioned in #1015.

Resolves #1014 and resolves #1015

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

To avoid wasting CPU time, I have run *minimal* testing, sufficient to ensure the ACCNR is passed properly. To fully trust these changes, we need to run baseline generation and regression testing for all platforms.  This PR should be combined with an answer-changing PR to avoid wasting CPU time. Also note that this may break the github-driven automated testing if it set ACCNR incorrectly.

- [x] hera.intel
- [x] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [x] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

None.
