### PR TITLE
GPU-enabled version of Grell-Freitas convection in ccpp-physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = gf_gpu
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = gf_gpu
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,15 +1,15 @@
-Mon Feb 14 08:11:37 MST 2022
+Tue Feb 15 14:26:50 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 379 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 744 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 184 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 495 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 266 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 741 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 488 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 254 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,14 +56,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 273.774550
-0:The maximum resident set size (KB)                   = 432544
+0:The total amount of wall time                        = 274.224632
+0:The maximum resident set size (KB)                   = 432548
 
 Test 001 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -102,14 +102,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 137.115765
-0:The maximum resident set size (KB)                   = 182320
+0:The total amount of wall time                        = 144.026464
+0:The maximum resident set size (KB)                   = 182268
 
 Test 002 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_c48
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,14 +148,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 818.223874
-0:The maximum resident set size (KB)                   = 660808
+0:The total amount of wall time                        = 818.558762
+0:The maximum resident set size (KB)                   = 668988
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -166,14 +166,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 174.257119
-0:The maximum resident set size (KB)                   = 427004
+0:The total amount of wall time                        = 171.488495
+0:The maximum resident set size (KB)                   = 427044
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,14 +184,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 336.256332
-0:The maximum resident set size (KB)                   = 485592
+0:The total amount of wall time                        = 326.365109
+0:The maximum resident set size (KB)                   = 485140
 
 Test 005 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -202,14 +202,14 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 340.289492
-0:The maximum resident set size (KB)                   = 529044
+0:The total amount of wall time                        = 324.614523
+0:The maximum resident set size (KB)                   = 529780
 
 Test 006 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -220,14 +220,14 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 363.946533
-0:The maximum resident set size (KB)                   = 794860
+0:The total amount of wall time                        = 363.600038
+0:The maximum resident set size (KB)                   = 794812
 
 Test 007 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -238,14 +238,14 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 347.680983
-0:The maximum resident set size (KB)                   = 788756
+0:The total amount of wall time                        = 348.330554
+0:The maximum resident set size (KB)                   = 788688
 
 Test 008 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -256,14 +256,14 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 289.961119
-0:The maximum resident set size (KB)                   = 445548
+0:The total amount of wall time                        = 291.711861
+0:The maximum resident set size (KB)                   = 445572
 
 Test 009 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_p8
 Checking test 010 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -310,14 +310,14 @@ Checking test 010 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 285.352706
-0:The maximum resident set size (KB)                   = 490372
+0:The total amount of wall time                        = 278.888373
+0:The maximum resident set size (KB)                   = 490344
 
 Test 010 control_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -364,14 +364,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 688.779992
-0:The maximum resident set size (KB)                   = 773264
+0:The total amount of wall time                        = 700.007512
+0:The maximum resident set size (KB)                   = 773172
 
 Test 011 rap_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_2threads
 Checking test 012 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -418,14 +418,14 @@ Checking test 012 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1212.308550
+0:The total amount of wall time                        = 1201.445749
 0:The maximum resident set size (KB)                   = 839860
 
 Test 012 rap_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_restart
 Checking test 013 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -464,14 +464,14 @@ Checking test 013 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 343.085594
-0:The maximum resident set size (KB)                   = 520780
+0:The total amount of wall time                        = 344.485250
+0:The maximum resident set size (KB)                   = 520864
 
 Test 013 rap_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_sfcdiff
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_sfcdiff
 Checking test 014 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -518,14 +518,14 @@ Checking test 014 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 689.775287
-0:The maximum resident set size (KB)                   = 773064
+0:The total amount of wall time                        = 695.914588
+0:The maximum resident set size (KB)                   = 773092
 
 Test 014 rap_sfcdiff PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_sfcdiff_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_sfcdiff_restart
 Checking test 015 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 343.791975
-0:The maximum resident set size (KB)                   = 521392
+0:The total amount of wall time                        = 346.334351
+0:The maximum resident set size (KB)                   = 520680
 
 Test 015 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/hrrr_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/hrrr_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/hrrr_control
 Checking test 016 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -618,14 +618,14 @@ Checking test 016 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 666.810059
-0:The maximum resident set size (KB)                   = 771112
+0:The total amount of wall time                        = 665.990889
+0:The maximum resident set size (KB)                   = 770968
 
 Test 016 hrrr_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -672,14 +672,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 682.573597
-0:The maximum resident set size (KB)                   = 770712
+0:The total amount of wall time                        = 682.021618
+0:The maximum resident set size (KB)                   = 770616
 
 Test 017 rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_conus13km_hrrr_warm
 Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -688,14 +688,14 @@ Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 317.881211
-0:The maximum resident set size (KB)                   = 591680
+0:The total amount of wall time                        = 318.420795
+0:The maximum resident set size (KB)                   = 591576
 
 Test 018 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -704,250 +704,250 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 320.655930
-0:The maximum resident set size (KB)                   = 594500
+0:The total amount of wall time                        = 321.209667
+0:The maximum resident set size (KB)                   = 594276
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 79.349302
-0:The maximum resident set size (KB)                   = 423548
+0:The total amount of wall time                        = 80.241797
+0:The maximum resident set size (KB)                   = 423456
 
 Test 020 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 85.266818
-0:The maximum resident set size (KB)                   = 480848
+0:The total amount of wall time                        = 93.912913
+0:The maximum resident set size (KB)                   = 480832
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/regional_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/fv3_regional_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 129.989380
-0:The maximum resident set size (KB)                   = 534368
+0:The total amount of wall time                        = 130.487799
+0:The maximum resident set size (KB)                   = 534540
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.983634
-0:The maximum resident set size (KB)                   = 795336
+0:The total amount of wall time                        = 144.313031
+0:The maximum resident set size (KB)                   = 795360
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 152.334410
-0:The maximum resident set size (KB)                   = 879144
+0:The total amount of wall time                        = 153.015617
+0:The maximum resident set size (KB)                   = 878200
 
 Test 024 rap_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 231.919066
-0:The maximum resident set size (KB)                   = 793956
+0:The total amount of wall time                        = 232.269262
+0:The maximum resident set size (KB)                   = 793984
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rap_progcld_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.237566
-0:The maximum resident set size (KB)                   = 795408
+0:The total amount of wall time                        = 152.550608
+0:The maximum resident set size (KB)                   = 795348
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.875654
-0:The maximum resident set size (KB)                   = 790256
+0:The total amount of wall time                        = 143.418251
+0:The maximum resident set size (KB)                   = 790200
 
 Test 027 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.143222
-0:The maximum resident set size (KB)                   = 781428
+0:The total amount of wall time                        = 108.930975
+0:The maximum resident set size (KB)                   = 781400
 
 Test 028 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.265993
-0:The maximum resident set size (KB)                   = 776832
+0:The total amount of wall time                        = 90.669833
+0:The maximum resident set size (KB)                   = 776756
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson_extdiag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug_extdiag
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 100.115603
-0:The maximum resident set size (KB)                   = 823084
+0:The total amount of wall time                        = 108.078191
+0:The maximum resident set size (KB)                   = 823076
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_thompson_progcld_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.526551
-0:The maximum resident set size (KB)                   = 781464
+0:The total amount of wall time                        = 94.075291
+0:The maximum resident set size (KB)                   = 781408
 
-Test 031 control_thompson_progcld_thompson_debug PASS
+Test 031 control_thompson_progcld_thompson_debug PASS Tries: 2
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_rrtmgp_debug
 Checking test 032 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 86.348417
-0:The maximum resident set size (KB)                   = 518604
+0:The total amount of wall time                        = 89.783809
+0:The maximum resident set size (KB)                   = 518932
 
 Test 032 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_ras_debug
 Checking test 033 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 82.548197
-0:The maximum resident set size (KB)                   = 433456
+0:The total amount of wall time                        = 83.114245
+0:The maximum resident set size (KB)                   = 433368
 
 Test 033 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_stochy_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_stochy_debug
 Checking test 034 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 89.773944
-0:The maximum resident set size (KB)                   = 427400
+0:The total amount of wall time                        = 90.776800
+0:The maximum resident set size (KB)                   = 427412
 
 Test 034 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_debug_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_debug_p8
 Checking test 035 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.275402
-0:The maximum resident set size (KB)                   = 483888
+0:The total amount of wall time                        = 96.146801
+0:The maximum resident set size (KB)                   = 483856
 
 Test 035 control_debug_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/control_wam_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/control_wam_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_wam_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 142.467599
-0:The maximum resident set size (KB)                   = 169908
+0:The total amount of wall time                        = 142.667524
+0:The maximum resident set size (KB)                   = 169988
 
 Test 036 control_wam_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/cpld_control_c96_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_control_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/cpld_control_c96_p8
 Checking test 037 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 037 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 367.110487
-0:The maximum resident set size (KB)                   = 517592
+0:The total amount of wall time                        = 367.925787
+0:The maximum resident set size (KB)                   = 517672
 
 Test 037 cpld_control_c96_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/GNU/cpld_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_25129/cpld_debug_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/cpld_debug_p8
 Checking test 038 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,12 +1066,12 @@ Checking test 038 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 336.052769
-0:The maximum resident set size (KB)                   = 535688
+0:The total amount of wall time                        = 334.899861
+0:The maximum resident set size (KB)                   = 535664
 
 Test 038 cpld_debug_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 08:40:56 MST 2022
-Elapsed time: 00h:29m:19s. Have a nice day!
+Tue Feb 15 14:56:27 MST 2022
+Elapsed time: 00h:29m:38s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,23 +1,23 @@
-Mon Feb 14 09:15:10 MST 2022
+Tue Feb 15 15:31:15 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 995 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 386 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 745 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 699 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 801 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 585 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 372 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 353 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 278 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 730 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 724 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 428 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 223 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 606 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 989 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 409 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 746 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 809 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 597 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 380 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 361 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 289 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 732 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 728 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 443 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 220 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 608 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_control_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 248.670866
-0:The maximum resident set size (KB)                   = 535728
+0:The total amount of wall time                        = 251.474652
+0:The maximum resident set size (KB)                   = 535508
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_2threads_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 477.437492
-0:The maximum resident set size (KB)                   = 630660
+0:The total amount of wall time                        = 477.193518
+0:The maximum resident set size (KB)                   = 630632
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_decomp_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 246.615637
-0:The maximum resident set size (KB)                   = 531720
+0:The total amount of wall time                        = 247.674144
+0:The maximum resident set size (KB)                   = 531864
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_mpi_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 212.618874
-0:The maximum resident set size (KB)                   = 505840
+0:The total amount of wall time                        = 214.410807
+0:The maximum resident set size (KB)                   = 505896
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_control_p7_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 312.478052
-0:The maximum resident set size (KB)                   = 631180
+0:The total amount of wall time                        = 316.492428
+0:The maximum resident set size (KB)                   = 631272
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_bmark_p7
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 967.888380
-0:The maximum resident set size (KB)                   = 1207248
+0:The total amount of wall time                        = 977.018668
+0:The maximum resident set size (KB)                   = 1206520
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_bmark_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 966.434333
-0:The maximum resident set size (KB)                   = 1205048
+0:The total amount of wall time                        = 979.622591
+0:The maximum resident set size (KB)                   = 1205296
 
 Test 007 cpld_bmark_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_bmark_mpi_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 949.745991
-0:The maximum resident set size (KB)                   = 1207616
+0:The total amount of wall time                        = 977.394379
+0:The maximum resident set size (KB)                   = 1208760
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_control_c96_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 243.024911
-0:The maximum resident set size (KB)                   = 522752
+0:The total amount of wall time                        = 244.000564
+0:The maximum resident set size (KB)                   = 522628
 
 Test 009 cpld_control_c96_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_restart_c96_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 127.821183
-0:The maximum resident set size (KB)                   = 313528
+0:The total amount of wall time                        = 128.695564
+0:The maximum resident set size (KB)                   = 313580
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_control_c192_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 1027.633746
-0:The maximum resident set size (KB)                   = 692456
+0:The total amount of wall time                        = 1026.299489
+0:The maximum resident set size (KB)                   = 692476
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_restart_c192_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 651.360771
-0:The maximum resident set size (KB)                   = 754248
+0:The total amount of wall time                        = 645.409426
+0:The maximum resident set size (KB)                   = 754720
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_control_c384_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 1097.390195
-0:The maximum resident set size (KB)                   = 1230512
+0:The total amount of wall time                        = 1061.625251
+0:The maximum resident set size (KB)                   = 1232348
 
 Test 013 cpld_control_c384_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_restart_c384_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 576.538127
-0:The maximum resident set size (KB)                   = 1179468
+0:The total amount of wall time                        = 576.319311
+0:The maximum resident set size (KB)                   = 1179592
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/cpld_debug_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 655.774380
-0:The maximum resident set size (KB)                   = 584880
+0:The total amount of wall time                        = 653.886781
+0:The maximum resident set size (KB)                   = 584992
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 146.311812
-0:The maximum resident set size (KB)                   = 445396
+0:The total amount of wall time                        = 145.923617
+0:The maximum resident set size (KB)                   = 445432
 
 Test 016 control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_decomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 152.500019
-0:The maximum resident set size (KB)                   = 443828
+0:The total amount of wall time                        = 150.679924
+0:The maximum resident set size (KB)                   = 443876
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_2dwrtdecomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 141.008848
-0:The maximum resident set size (KB)                   = 445912
+0:The total amount of wall time                        = 139.090440
+0:The maximum resident set size (KB)                   = 445812
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 319.461611
-0:The maximum resident set size (KB)                   = 492328
+0:The total amount of wall time                        = 319.603682
+0:The maximum resident set size (KB)                   = 492108
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 75.548204
-0:The maximum resident set size (KB)                   = 189508
+0:The total amount of wall time                        = 75.280105
+0:The maximum resident set size (KB)                   = 188920
 
 Test 020 control_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_fhzero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.674953
-0:The maximum resident set size (KB)                   = 445504
+0:The total amount of wall time                        = 138.751568
+0:The maximum resident set size (KB)                   = 445568
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_CubedSphereGrid
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 141.789983
-0:The maximum resident set size (KB)                   = 445820
+0:The total amount of wall time                        = 141.905640
+0:The maximum resident set size (KB)                   = 445780
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_latlon
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_latlon
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 144.398922
-0:The maximum resident set size (KB)                   = 445508
+0:The total amount of wall time                        = 144.444532
+0:The maximum resident set size (KB)                   = 445392
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_wrtGauss_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.564455
-0:The maximum resident set size (KB)                   = 445424
+0:The total amount of wall time                        = 146.593840
+0:The maximum resident set size (KB)                   = 445616
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_c48
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 423.302667
-0:The maximum resident set size (KB)                   = 629144
+0:The total amount of wall time                        = 422.070148
+0:The maximum resident set size (KB)                   = 629012
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 593.702274
-0:The maximum resident set size (KB)                   = 540480
+0:The total amount of wall time                        = 586.711537
+0:The maximum resident set size (KB)                   = 540136
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_c384
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1093.372421
-0:The maximum resident set size (KB)                   = 795916
+0:The total amount of wall time                        = 1089.973156
+0:The maximum resident set size (KB)                   = 795948
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_c384gdas
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 939.614705
-0:The maximum resident set size (KB)                   = 948008
+0:The total amount of wall time                        = 939.036986
+0:The maximum resident set size (KB)                   = 948052
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_stochy
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 96.529556
-0:The maximum resident set size (KB)                   = 442708
+0:The total amount of wall time                        = 96.142206
+0:The maximum resident set size (KB)                   = 442776
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_stochy_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 51.572578
-0:The maximum resident set size (KB)                   = 222264
+0:The total amount of wall time                        = 50.497511
+0:The maximum resident set size (KB)                   = 221688
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_lndp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 87.165073
-0:The maximum resident set size (KB)                   = 450332
+0:The total amount of wall time                        = 87.024819
+0:The maximum resident set size (KB)                   = 450432
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr4
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_iovr4
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.271224
-0:The maximum resident set size (KB)                   = 445544
+0:The total amount of wall time                        = 145.768456
+0:The maximum resident set size (KB)                   = 445484
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr5
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_iovr5
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.446796
-0:The maximum resident set size (KB)                   = 445516
+0:The total amount of wall time                        = 146.615419
+0:The maximum resident set size (KB)                   = 445504
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 162.843985
-0:The maximum resident set size (KB)                   = 485220
+0:The total amount of wall time                        = 162.402577
+0:The maximum resident set size (KB)                   = 485104
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_restart_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 87.133067
+0:The total amount of wall time                        = 86.376107
 0:The maximum resident set size (KB)                   = 291124
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_decomp_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 166.304053
-0:The maximum resident set size (KB)                   = 479828
+0:The total amount of wall time                        = 167.063405
+0:The maximum resident set size (KB)                   = 479680
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_2threads_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 358.342270
-0:The maximum resident set size (KB)                   = 569344
+0:The total amount of wall time                        = 357.626681
+0:The maximum resident set size (KB)                   = 568656
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_p7_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 232.118600
-0:The maximum resident set size (KB)                   = 585908
+0:The total amount of wall time                        = 231.100886
+0:The maximum resident set size (KB)                   = 585900
 
 Test 038 control_p7_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 352.092705
-0:The maximum resident set size (KB)                   = 569112
+0:The total amount of wall time                        = 349.550351
+0:The maximum resident set size (KB)                   = 568984
 
 Test 039 regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 192.348474
-0:The maximum resident set size (KB)                   = 559252
+0:The total amount of wall time                        = 191.844704
+0:The maximum resident set size (KB)                   = 559468
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_control_2dwrtdecomp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 348.574078
-0:The maximum resident set size (KB)                   = 567556
+0:The total amount of wall time                        = 346.261000
+0:The maximum resident set size (KB)                   = 568420
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_noquilt
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 371.025642
-0:The maximum resident set size (KB)                   = 576988
+0:The total amount of wall time                        = 367.798203
+0:The maximum resident set size (KB)                   = 576376
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 926.762305
-0:The maximum resident set size (KB)                   = 555100
+0:The total amount of wall time                        = 928.230841
+0:The maximum resident set size (KB)                   = 554936
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_hafs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 349.049257
-0:The maximum resident set size (KB)                   = 557772
+0:The total amount of wall time                        = 356.634445
+0:The maximum resident set size (KB)                   = 557552
 
 Test 044 regional_hafs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_netcdf_parallel
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 349.330379
-0:The maximum resident set size (KB)                   = 557988
+0:The total amount of wall time                        = 346.531545
+0:The maximum resident set size (KB)                   = 558104
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_RRTMGP
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 503.024580
-0:The maximum resident set size (KB)                   = 681924
+0:The total amount of wall time                        = 475.795632
+0:The maximum resident set size (KB)                   = 681788
 
 Test 046 regional_RRTMGP PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 411.622243
-0:The maximum resident set size (KB)                   = 808032
+0:The total amount of wall time                        = 414.043640
+0:The maximum resident set size (KB)                   = 808232
 
 Test 047 rap_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_2threads
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 878.386604
-0:The maximum resident set size (KB)                   = 873456
+0:The total amount of wall time                        = 874.404234
+0:The maximum resident set size (KB)                   = 873332
 
 Test 048 rap_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.496852
-0:The maximum resident set size (KB)                   = 561796
+0:The total amount of wall time                        = 207.509885
+0:The maximum resident set size (KB)                   = 561760
 
 Test 049 rap_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_sfcdiff
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 413.743191
-0:The maximum resident set size (KB)                   = 807924
+0:The total amount of wall time                        = 409.927553
+0:The maximum resident set size (KB)                   = 808100
 
 Test 050 rap_sfcdiff PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_sfcdiff_restart
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 209.304672
-0:The maximum resident set size (KB)                   = 562628
+0:The total amount of wall time                        = 208.300022
+0:The maximum resident set size (KB)                   = 562064
 
 Test 051 rap_sfcdiff_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hrrr_control
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 397.900911
-0:The maximum resident set size (KB)                   = 806508
+0:The total amount of wall time                        = 395.742769
+0:The maximum resident set size (KB)                   = 806640
 
 Test 052 hrrr_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rrfs_v1beta
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.253688
-0:The maximum resident set size (KB)                   = 805504
+0:The total amount of wall time                        = 403.143243
+0:The maximum resident set size (KB)                   = 805320
 
 Test 053 rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rrfs_conus13km_hrrr_warm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 187.012744
-0:The maximum resident set size (KB)                   = 638464
+0:The total amount of wall time                        = 185.222061
+0:The maximum resident set size (KB)                   = 638272
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rrfs_conus13km_radar_tten_warm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 185.725985
-0:The maximum resident set size (KB)                   = 639776
+0:The total amount of wall time                        = 186.903123
+0:The maximum resident set size (KB)                   = 639940
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_rrtmgp
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 262.231912
-0:The maximum resident set size (KB)                   = 578824
+0:The total amount of wall time                        = 262.164009
+0:The maximum resident set size (KB)                   = 578536
 
 Test 056 control_rrtmgp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_rrtmgp_c192
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 694.817840
-0:The maximum resident set size (KB)                   = 781228
+0:The total amount of wall time                        = 697.255609
+0:The maximum resident set size (KB)                   = 781220
 
 Test 057 control_rrtmgp_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_csawmg
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 403.869795
-0:The maximum resident set size (KB)                   = 518576
+0:The total amount of wall time                        = 390.328108
+0:The maximum resident set size (KB)                   = 518516
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_csawmgt
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 399.355004
-0:The maximum resident set size (KB)                   = 518396
+0:The total amount of wall time                        = 397.852852
+0:The maximum resident set size (KB)                   = 518324
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_flake
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 266.508993
-0:The maximum resident set size (KB)                   = 515744
+0:The total amount of wall time                        = 262.865886
+0:The maximum resident set size (KB)                   = 515576
 
 Test 060 control_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_ras
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 206.129707
-0:The maximum resident set size (KB)                   = 477012
+0:The total amount of wall time                        = 205.419756
+0:The maximum resident set size (KB)                   = 477140
 
 Test 061 control_ras PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 260.211547
-0:The maximum resident set size (KB)                   = 826116
+0:The total amount of wall time                        = 261.048209
+0:The maximum resident set size (KB)                   = 826340
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson_no_aero
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 248.775533
-0:The maximum resident set size (KB)                   = 818932
+0:The total amount of wall time                        = 248.136786
+0:The maximum resident set size (KB)                   = 818704
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_repro
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_wam_repro
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 136.884112
-0:The maximum resident set size (KB)                   = 201396
+0:The total amount of wall time                        = 137.530147
+0:The maximum resident set size (KB)                   = 200972
 
 Test 064 control_wam PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 154.454623
-0:The maximum resident set size (KB)                   = 507844
+0:The total amount of wall time                        = 155.681719
+0:The maximum resident set size (KB)                   = 507800
 
 Test 065 control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_2threads_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 271.820349
-0:The maximum resident set size (KB)                   = 558112
+0:The total amount of wall time                        = 273.193591
+0:The maximum resident set size (KB)                   = 558188
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_CubedSphereGrid_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2428,488 +2428,488 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.675178
-0:The maximum resident set size (KB)                   = 507592
+0:The total amount of wall time                        = 172.419452
+0:The maximum resident set size (KB)                   = 507632
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.091676
-0:The maximum resident set size (KB)                   = 507848
+0:The total amount of wall time                        = 157.354520
+0:The maximum resident set size (KB)                   = 507692
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_stochy_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 176.802066
-0:The maximum resident set size (KB)                   = 510700
+0:The total amount of wall time                        = 180.546738
+0:The maximum resident set size (KB)                   = 510524
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 162.837194
-0:The maximum resident set size (KB)                   = 519732
+0:The total amount of wall time                        = 159.658715
+0:The maximum resident set size (KB)                   = 519788
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 174.347133
-0:The maximum resident set size (KB)                   = 616368
+0:The total amount of wall time                        = 174.641512
+0:The maximum resident set size (KB)                   = 616388
 
 Test 071 control_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_csawmg_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 250.534796
-0:The maximum resident set size (KB)                   = 553904
+0:The total amount of wall time                        = 254.310586
+0:The maximum resident set size (KB)                   = 553912
 
 Test 072 control_csawmg_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_csawmgt_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 247.035527
-0:The maximum resident set size (KB)                   = 553732
+0:The total amount of wall time                        = 251.175424
+0:The maximum resident set size (KB)                   = 553500
 
 Test 073 control_csawmgt_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_ras_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.614949
-0:The maximum resident set size (KB)                   = 517144
+0:The total amount of wall time                        = 163.592182
+0:The maximum resident set size (KB)                   = 516980
 
 Test 074 control_ras_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.313947
-0:The maximum resident set size (KB)                   = 562100
+0:The total amount of wall time                        = 167.204683
+0:The maximum resident set size (KB)                   = 562144
 
 Test 075 control_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_debug_p8
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 168.558172
-0:The maximum resident set size (KB)                   = 548004
+0:The total amount of wall time                        = 170.640590
+0:The maximum resident set size (KB)                   = 548032
 
 Test 076 control_debug_p8 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.064845
-0:The maximum resident set size (KB)                   = 864208
+0:The total amount of wall time                        = 186.178204
+0:The maximum resident set size (KB)                   = 864204
 
 Test 077 control_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson_no_aero_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.177468
-0:The maximum resident set size (KB)                   = 860756
+0:The total amount of wall time                        = 178.571258
+0:The maximum resident set size (KB)                   = 860620
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson_extdiag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 191.276849
-0:The maximum resident set size (KB)                   = 894980
+0:The total amount of wall time                        = 191.642866
+0:The maximum resident set size (KB)                   = 895080
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_thompson_progcld_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.097575
-0:The maximum resident set size (KB)                   = 864296
+0:The total amount of wall time                        = 182.033319
+0:The maximum resident set size (KB)                   = 864336
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/regional_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 258.691553
-0:The maximum resident set size (KB)                   = 591444
+0:The total amount of wall time                        = 259.093359
+0:The maximum resident set size (KB)                   = 591204
 
 Test 081 regional_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_control_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.580654
-0:The maximum resident set size (KB)                   = 871132
+0:The total amount of wall time                        = 284.688497
+0:The maximum resident set size (KB)                   = 871248
 
 Test 082 rap_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_unified_drag_suite_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.673595
-0:The maximum resident set size (KB)                   = 871304
+0:The total amount of wall time                        = 285.447459
+0:The maximum resident set size (KB)                   = 871180
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_diag_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 295.838113
-0:The maximum resident set size (KB)                   = 966028
+0:The total amount of wall time                        = 300.422763
+0:The maximum resident set size (KB)                   = 965916
 
 Test 084 rap_diag_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.555500
-0:The maximum resident set size (KB)                   = 875884
+0:The total amount of wall time                        = 291.939829
+0:The maximum resident set size (KB)                   = 875924
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_unified_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.307567
-0:The maximum resident set size (KB)                   = 871192
+0:The total amount of wall time                        = 288.443892
+0:The maximum resident set size (KB)                   = 871360
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_noah_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 280.109278
-0:The maximum resident set size (KB)                   = 871092
+0:The total amount of wall time                        = 281.300021
+0:The maximum resident set size (KB)                   = 870936
 
 Test 087 rap_noah_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_rrtmgp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 482.800630
-0:The maximum resident set size (KB)                   = 986896
+0:The total amount of wall time                        = 483.308813
+0:The maximum resident set size (KB)                   = 986684
 
 Test 088 rap_rrtmgp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_lndp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.010056
-0:The maximum resident set size (KB)                   = 872044
+0:The total amount of wall time                        = 288.247954
+0:The maximum resident set size (KB)                   = 871912
 
 Test 089 rap_lndp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_sfcdiff_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.750561
-0:The maximum resident set size (KB)                   = 871072
+0:The total amount of wall time                        = 283.850259
+0:The maximum resident set size (KB)                   = 870976
 
 Test 090 rap_sfcdiff_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_flake_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_flake_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 281.485099
-0:The maximum resident set size (KB)                   = 871196
+0:The total amount of wall time                        = 287.376331
+0:The maximum resident set size (KB)                   = 871048
 
 Test 091 rap_flake_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 470.389738
-0:The maximum resident set size (KB)                   = 870480
+0:The total amount of wall time                        = 473.030527
+0:The maximum resident set size (KB)                   = 870276
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rap_progcld_thompson_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.846278
-0:The maximum resident set size (KB)                   = 871280
+0:The total amount of wall time                        = 284.063557
+0:The maximum resident set size (KB)                   = 871268
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/rrfs_v1beta_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 279.321308
-0:The maximum resident set size (KB)                   = 868852
+0:The total amount of wall time                        = 284.500745
+0:The maximum resident set size (KB)                   = 868840
 
 Test 094 rrfs_v1beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_wam_debug
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 299.195339
-0:The maximum resident set size (KB)                   = 232488
+0:The total amount of wall time                        = 299.733527
+0:The maximum resident set size (KB)                   = 232528
 
 Test 095 control_wam_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 506.011849
-0:The maximum resident set size (KB)                   = 670764
+0:The total amount of wall time                        = 508.463439
+0:The maximum resident set size (KB)                   = 670312
 
 Test 096 hafs_regional_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 584.161265
-0:The maximum resident set size (KB)                   = 1026348
+0:The total amount of wall time                        = 585.584589
+0:The maximum resident set size (KB)                   = 1026892
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_atm_ocn
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 380.949210
-0:The maximum resident set size (KB)                   = 685888
+0:The total amount of wall time                        = 414.187749
+0:The maximum resident set size (KB)                   = 686156
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_atm_wav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 951.901717
-0:The maximum resident set size (KB)                   = 684652
+0:The total amount of wall time                        = 965.462502
+0:The maximum resident set size (KB)                   = 684912
 
 Test 099 hafs_regional_atm_wav PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_atm_ocn_wav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1048.667753
-0:The maximum resident set size (KB)                   = 685400
+0:The total amount of wall time                        = 1041.391915
+0:The maximum resident set size (KB)                   = 685492
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_1nest_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 1017.000735
-0:The maximum resident set size (KB)                   = 269940
+0:The total amount of wall time                        = 1017.729079
+0:The maximum resident set size (KB)                   = 270544
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_telescopic_2nests_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2918,30 +2918,30 @@ Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1059.983671
-0:The maximum resident set size (KB)                   = 279668
+0:The total amount of wall time                        = 1046.155525
+0:The maximum resident set size (KB)                   = 279964
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_global_1nest_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 668.084161
-0:The maximum resident set size (KB)                   = 167244
+0:The total amount of wall time                        = 667.876371
+0:The maximum resident set size (KB)                   = 167332
 
 Test 103 hafs_global_1nest_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_global_multiple_4nests_atm
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1232.300561
-0:The maximum resident set size (KB)                   = 235084
+0:The total amount of wall time                        = 1237.472171
+0:The maximum resident set size (KB)                   = 235304
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_docn
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2967,14 +2967,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 353.343823
-0:The maximum resident set size (KB)                   = 687876
+0:The total amount of wall time                        = 353.904422
+0:The maximum resident set size (KB)                   = 688384
 
 Test 105 hafs_regional_docn PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_docn_oisst
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2982,105 +2982,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 354.801870
-0:The maximum resident set size (KB)                   = 688156
+0:The total amount of wall time                        = 352.493028
+0:The maximum resident set size (KB)                   = 687396
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/hafs_regional_datm_cdeps
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1291.686893
-0:The maximum resident set size (KB)                   = 867616
+0:The total amount of wall time                        = 1289.435220
+0:The maximum resident set size (KB)                   = 868312
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_control_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.830133
-0:The maximum resident set size (KB)                   = 691752
+0:The total amount of wall time                        = 165.572018
+0:The maximum resident set size (KB)                   = 692244
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_restart_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.443841
-0:The maximum resident set size (KB)                   = 692120
+0:The total amount of wall time                        = 101.493853
+0:The maximum resident set size (KB)                   = 702788
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_control_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.233205
-0:The maximum resident set size (KB)                   = 589428
+0:The total amount of wall time                        = 158.451286
+0:The maximum resident set size (KB)                   = 589216
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_stochy_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.450496
-0:The maximum resident set size (KB)                   = 589928
+0:The total amount of wall time                        = 160.584988
+0:The maximum resident set size (KB)                   = 589908
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_bulk_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.613627
-0:The maximum resident set size (KB)                   = 702956
+0:The total amount of wall time                        = 165.855568
+0:The maximum resident set size (KB)                   = 691732
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_bulk_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.334310
-0:The maximum resident set size (KB)                   = 589236
+0:The total amount of wall time                        = 159.071092
+0:The maximum resident set size (KB)                   = 589264
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_mx025_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3089,14 +3089,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 349.305635
-0:The maximum resident set size (KB)                   = 510820
+0:The total amount of wall time                        = 351.943612
+0:The maximum resident set size (KB)                   = 513068
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_mx025_gefs
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3105,51 +3105,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 346.057136
-0:The maximum resident set size (KB)                   = 491900
+0:The total amount of wall time                        = 347.311654
+0:The maximum resident set size (KB)                   = 492784
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_multiple_files_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 164.571388
-0:The maximum resident set size (KB)                   = 702848
+0:The total amount of wall time                        = 159.783421
+0:The maximum resident set size (KB)                   = 691472
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_3072x1536_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 250.946130
-0:The maximum resident set size (KB)                   = 1842920
+0:The total amount of wall time                        = 251.063726
+0:The maximum resident set size (KB)                   = 1841492
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/datm_cdeps_debug_cfsr
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 456.274484
-0:The maximum resident set size (KB)                   = 699724
+0:The total amount of wall time                        = 455.729219
+0:The maximum resident set size (KB)                   = 699448
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_45772/control_atmwav
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3193,12 +3193,12 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 133.550878
-0:The maximum resident set size (KB)                   = 462876
+0:The total amount of wall time                        = 133.403617
+0:The maximum resident set size (KB)                   = 462988
 
 Test 119 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 10:22:39 MST 2022
-Elapsed time: 01h:07m:29s. Have a nice day!
+Tue Feb 15 16:39:03 MST 2022
+Elapsed time: 01h:07m:49s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,23 +1,23 @@
-Mon Feb 14 11:06:31 EST 2022
+Tue Feb 15 19:07:51 EST 2022
 Start Regression test
 
-Compile 001 elapsed time 592 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 222 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 483 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 460 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 502 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 208 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 533 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 528 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 268 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 603 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 230 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 489 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 476 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 230 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 491 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 505 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 292 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 013 elapsed time 138 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 495 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 457 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 272.316949
-  0: The maximum resident set size (KB)                   = 515704
+  0: The total amount of wall time                        = 243.679836
+  0: The maximum resident set size (KB)                   = 516048
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 322.419021
-  0: The maximum resident set size (KB)                   = 608764
+  0: The total amount of wall time                        = 291.810131
+  0: The maximum resident set size (KB)                   = 610812
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 270.927628
-  0: The maximum resident set size (KB)                   = 490892
+  0: The total amount of wall time                        = 234.146306
+  0: The maximum resident set size (KB)                   = 516092
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 229.269673
-  0: The maximum resident set size (KB)                   = 472612
+  0: The total amount of wall time                        = 196.344320
+  0: The maximum resident set size (KB)                   = 472772
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_control_p7_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 376.455573
-  0: The maximum resident set size (KB)                   = 587732
+  0: The total amount of wall time                        = 297.572189
+  0: The maximum resident set size (KB)                   = 587932
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_bmark_p7
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1024.624982
-  0: The maximum resident set size (KB)                   = 1158728
+  0: The total amount of wall time                        = 928.382959
+  0: The maximum resident set size (KB)                   = 1159132
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_bmark_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 979.139081
-  0: The maximum resident set size (KB)                   = 1158976
+  0: The total amount of wall time                        = 978.100095
+  0: The maximum resident set size (KB)                   = 1158392
 
 Test 007 cpld_bmark_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_bmark_mpi_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 958.128396
-  0: The maximum resident set size (KB)                   = 1161152
+  0: The total amount of wall time                        = 972.619623
+  0: The maximum resident set size (KB)                   = 1161064
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_control_c96_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 248.173897
-  0: The maximum resident set size (KB)                   = 515488
+  0: The total amount of wall time                        = 229.849789
+  0: The maximum resident set size (KB)                   = 515836
 
 Test 009 cpld_control_c96_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_restart_c96_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 142.598658
-  0: The maximum resident set size (KB)                   = 305480
+  0: The total amount of wall time                        = 120.874960
+  0: The maximum resident set size (KB)                   = 305516
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_control_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1026.727717
-  0: The maximum resident set size (KB)                   = 684828
+  0: The total amount of wall time                        = 983.536453
+  0: The maximum resident set size (KB)                   = 660200
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_restart_c192_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 648.467206
-  0: The maximum resident set size (KB)                   = 785980
+  0: The total amount of wall time                        = 670.585766
+  0: The maximum resident set size (KB)                   = 756948
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_control_c384_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1119.454842
-  0: The maximum resident set size (KB)                   = 1187020
+  0: The total amount of wall time                        = 1075.831742
+  0: The maximum resident set size (KB)                   = 1183140
 
 Test 013 cpld_control_c384_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_restart_c384_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 586.261207
-  0: The maximum resident set size (KB)                   = 1147132
+  0: The total amount of wall time                        = 603.130037
+  0: The maximum resident set size (KB)                   = 1146920
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/cpld_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 638.033262
+  0: The total amount of wall time                        = 629.159934
   0: The maximum resident set size (KB)                   = 577856
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 139.300262
-  0: The maximum resident set size (KB)                   = 436556
+  0: The total amount of wall time                        = 132.131469
+  0: The maximum resident set size (KB)                   = 436608
 
 Test 016 control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_decomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.014723
-  0: The maximum resident set size (KB)                   = 435796
+  0: The total amount of wall time                        = 137.199801
+  0: The maximum resident set size (KB)                   = 435892
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 140.383769
-  0: The maximum resident set size (KB)                   = 436560
+  0: The total amount of wall time                        = 153.272650
+  0: The maximum resident set size (KB)                   = 436592
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 169.552619
- 0: The maximum resident set size (KB)                   = 487404
+ 0: The total amount of wall time                        = 198.453568
+ 0: The maximum resident set size (KB)                   = 487652
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 97.055355
-  0: The maximum resident set size (KB)                   = 172304
+  0: The total amount of wall time                        = 106.561114
+  0: The maximum resident set size (KB)                   = 172284
 
 Test 020 control_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_fhzero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.364372
-  0: The maximum resident set size (KB)                   = 436544
+  0: The total amount of wall time                        = 123.132674
+  0: The maximum resident set size (KB)                   = 436616
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_CubedSphereGrid
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.452655
-  0: The maximum resident set size (KB)                   = 437924
+  0: The total amount of wall time                        = 125.987937
+  0: The maximum resident set size (KB)                   = 437860
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_latlon
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.114004
-  0: The maximum resident set size (KB)                   = 436600
+  0: The total amount of wall time                        = 128.565536
+  0: The maximum resident set size (KB)                   = 436528
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_wrtGauss_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.079660
-  0: The maximum resident set size (KB)                   = 436680
+  0: The total amount of wall time                        = 135.540179
+  0: The maximum resident set size (KB)                   = 436560
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_c48
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 352.204843
-0: The maximum resident set size (KB)                   = 632044
+0: The total amount of wall time                        = 352.752100
+0: The maximum resident set size (KB)                   = 632020
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 539.868415
-  0: The maximum resident set size (KB)                   = 540140
+  0: The total amount of wall time                        = 536.574194
+  0: The maximum resident set size (KB)                   = 540180
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_c384
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 910.876344
-  0: The maximum resident set size (KB)                   = 794780
+  0: The total amount of wall time                        = 913.221872
+  0: The maximum resident set size (KB)                   = 794332
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_c384gdas
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 884.360613
-  0: The maximum resident set size (KB)                   = 939008
+  0: The total amount of wall time                        = 825.580138
+  0: The maximum resident set size (KB)                   = 938796
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_stochy
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 134.875808
-  0: The maximum resident set size (KB)                   = 439844
+  0: The total amount of wall time                        = 113.466368
+  0: The maximum resident set size (KB)                   = 439828
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_stochy_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 47.986131
-  0: The maximum resident set size (KB)                   = 190324
+  0: The total amount of wall time                        = 74.005616
+  0: The maximum resident set size (KB)                   = 190216
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_lndp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.034452
-  0: The maximum resident set size (KB)                   = 443128
+  0: The total amount of wall time                        = 101.086305
+  0: The maximum resident set size (KB)                   = 443196
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_iovr4
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 162.925049
-  0: The maximum resident set size (KB)                   = 436540
+  0: The total amount of wall time                        = 155.276789
+  0: The maximum resident set size (KB)                   = 436572
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_iovr5
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 170.336009
-  0: The maximum resident set size (KB)                   = 436676
+  0: The total amount of wall time                        = 159.259550
+  0: The maximum resident set size (KB)                   = 436656
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.026160
-  0: The maximum resident set size (KB)                   = 469136
+  0: The total amount of wall time                        = 146.231476
+  0: The maximum resident set size (KB)                   = 469108
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_restart_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 115.974414
-  0: The maximum resident set size (KB)                   = 278192
+  0: The total amount of wall time                        = 80.819898
+  0: The maximum resident set size (KB)                   = 278200
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_decomp_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.915220
-  0: The maximum resident set size (KB)                   = 462256
+  0: The total amount of wall time                        = 154.603909
+  0: The maximum resident set size (KB)                   = 462224
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_2threads_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 204.705811
+ 0: The total amount of wall time                        = 192.694041
  0: The maximum resident set size (KB)                   = 546992
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_p7_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.519148
-  0: The maximum resident set size (KB)                   = 568292
+  0: The total amount of wall time                        = 193.890258
+  0: The maximum resident set size (KB)                   = 568204
 
 Test 038 control_p7_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 333.665842
- 0: The maximum resident set size (KB)                   = 540816
+ 0: The total amount of wall time                        = 364.140643
+ 0: The maximum resident set size (KB)                   = 540884
 
 Test 039 regional_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 185.577786
- 0: The maximum resident set size (KB)                   = 539096
+ 0: The total amount of wall time                        = 209.031808
+ 0: The maximum resident set size (KB)                   = 539108
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_control_2dwrtdecomp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 388.631610
- 0: The maximum resident set size (KB)                   = 540636
+ 0: The total amount of wall time                        = 329.788459
+ 0: The maximum resident set size (KB)                   = 540804
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_noquilt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 368.453212
- 0: The maximum resident set size (KB)                   = 548088
+ 0: The total amount of wall time                        = 351.071797
+ 0: The maximum resident set size (KB)                   = 548148
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 301.940669
- 0: The maximum resident set size (KB)                   = 543236
+ 0: The total amount of wall time                        = 263.778365
+ 0: The maximum resident set size (KB)                   = 543188
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_hafs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 355.935370
- 0: The maximum resident set size (KB)                   = 540316
+ 0: The total amount of wall time                        = 360.150615
+ 0: The maximum resident set size (KB)                   = 540384
 
 Test 044 regional_hafs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_netcdf_parallel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 364.860793
- 0: The maximum resident set size (KB)                   = 539176
+ 0: The total amount of wall time                        = 333.860950
+ 0: The maximum resident set size (KB)                   = 539096
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_RRTMGP
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 486.411870
- 0: The maximum resident set size (KB)                   = 666456
+ 0: The total amount of wall time                        = 448.891341
+ 0: The maximum resident set size (KB)                   = 666480
 
 Test 046 regional_RRTMGP PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 409.568247
-  0: The maximum resident set size (KB)                   = 805468
+  0: The total amount of wall time                        = 372.704484
+  0: The maximum resident set size (KB)                   = 805404
 
 Test 047 rap_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_2threads
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 509.101739
- 0: The maximum resident set size (KB)                   = 867412
+ 0: The total amount of wall time                        = 492.648996
+ 0: The maximum resident set size (KB)                   = 867516
 
 Test 048 rap_2threads PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.113668
-  0: The maximum resident set size (KB)                   = 543600
+  0: The total amount of wall time                        = 190.476274
+  0: The maximum resident set size (KB)                   = 543500
 
 Test 049 rap_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_sfcdiff
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 408.923341
-  0: The maximum resident set size (KB)                   = 804944
+  0: The total amount of wall time                        = 400.816984
+  0: The maximum resident set size (KB)                   = 804876
 
 Test 050 rap_sfcdiff PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_sfcdiff_restart
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.527419
-  0: The maximum resident set size (KB)                   = 543164
+  0: The total amount of wall time                        = 189.805968
+  0: The maximum resident set size (KB)                   = 543276
 
 Test 051 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hrrr_control
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 396.419665
-  0: The maximum resident set size (KB)                   = 802744
+  0: The total amount of wall time                        = 355.940367
+  0: The maximum resident set size (KB)                   = 802792
 
 Test 052 hrrr_control PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rrfs_v1beta
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 407.621207
-  0: The maximum resident set size (KB)                   = 801796
+  0: The total amount of wall time                        = 364.090293
+  0: The maximum resident set size (KB)                   = 801696
 
 Test 053 rrfs_v1beta PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rrfs_conus13km_hrrr_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 176.840952
-  0: The maximum resident set size (KB)                   = 613736
+  0: The total amount of wall time                        = 174.132347
+  0: The maximum resident set size (KB)                   = 613900
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rrfs_conus13km_radar_tten_warm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 181.273014
-  0: The maximum resident set size (KB)                   = 616424
+  0: The total amount of wall time                        = 175.881179
+  0: The maximum resident set size (KB)                   = 616436
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_rrtmgp
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 213.214336
-  0: The maximum resident set size (KB)                   = 562712
+  0: The total amount of wall time                        = 212.239367
+  0: The maximum resident set size (KB)                   = 562804
 
 Test 056 control_rrtmgp PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_rrtmgp_c192
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 606.253029
-  0: The maximum resident set size (KB)                   = 774768
+  0: The total amount of wall time                        = 585.834848
+  0: The maximum resident set size (KB)                   = 774776
 
 Test 057 control_rrtmgp_c192 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_csawmgt
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmgt
 Checking test 058 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 380.565485
-  0: The maximum resident set size (KB)                   = 504588
+  0: The total amount of wall time                        = 365.055974
+  0: The maximum resident set size (KB)                   = 504520
 
 Test 058 control_csawmgt PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_flake
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_flake
 Checking test 059 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 269.728956
-  0: The maximum resident set size (KB)                   = 508360
+  0: The total amount of wall time                        = 237.072094
+  0: The maximum resident set size (KB)                   = 508352
 
 Test 059 control_flake PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_ras
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_ras
 Checking test 060 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 201.237859
-  0: The maximum resident set size (KB)                   = 471388
+  0: The total amount of wall time                        = 207.213408
+  0: The maximum resident set size (KB)                   = 471492
 
 Test 060 control_ras PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson
 Checking test 061 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 226.934168
-  0: The maximum resident set size (KB)                   = 820676
+  0: The total amount of wall time                        = 225.970913
+  0: The maximum resident set size (KB)                   = 820728
 
 Test 061 control_thompson PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson_no_aero
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_no_aero
 Checking test 062 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,54 +2336,54 @@ Checking test 062 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.723147
-  0: The maximum resident set size (KB)                   = 815052
+  0: The total amount of wall time                        = 215.697931
+  0: The maximum resident set size (KB)                   = 815084
 
 Test 062 control_thompson_no_aero PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_repro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_wam_repro
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wam_repro
 Checking test 063 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.438959
-  0: The maximum resident set size (KB)                   = 181480
+  0: The total amount of wall time                        = 114.346604
+  0: The maximum resident set size (KB)                   = 181380
 
 Test 063 control_wam PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_debug
 Checking test 064 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.822551
-  0: The maximum resident set size (KB)                   = 503124
+  0: The total amount of wall time                        = 144.564805
+  0: The maximum resident set size (KB)                   = 503284
 
 Test 064 control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_2threads_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads_debug
 Checking test 065 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 252.473206
- 0: The maximum resident set size (KB)                   = 554008
+ 0: The total amount of wall time                        = 251.653220
+ 0: The maximum resident set size (KB)                   = 557452
 
 Test 065 control_2threads_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_CubedSphereGrid_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_CubedSphereGrid_debug
 Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2410,428 +2410,428 @@ Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.364142
-  0: The maximum resident set size (KB)                   = 503796
+  0: The total amount of wall time                        = 154.950153
+  0: The maximum resident set size (KB)                   = 503696
 
 Test 066 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wrtGauss_netcdf_parallel_debug
 Checking test 067 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.469991
-  0: The maximum resident set size (KB)                   = 503296
+  0: The total amount of wall time                        = 152.942441
+  0: The maximum resident set size (KB)                   = 503188
 
 Test 067 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_stochy_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy_debug
 Checking test 068 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.786433
-  0: The maximum resident set size (KB)                   = 508448
+  0: The total amount of wall time                        = 167.049954
+  0: The maximum resident set size (KB)                   = 508596
 
 Test 068 control_stochy_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_lndp_debug
 Checking test 069 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.683155
-  0: The maximum resident set size (KB)                   = 509492
+  0: The total amount of wall time                        = 149.120631
+  0: The maximum resident set size (KB)                   = 509484
 
 Test 069 control_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp_debug
 Checking test 070 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.769685
-  0: The maximum resident set size (KB)                   = 608928
+  0: The total amount of wall time                        = 162.409738
+  0: The maximum resident set size (KB)                   = 608944
 
 Test 070 control_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_csawmg_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 251.706185
-  0: The maximum resident set size (KB)                   = 545496
+  0: The total amount of wall time                        = 254.591017
+  0: The maximum resident set size (KB)                   = 545656
 
 Test 071 control_csawmg_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_csawmgt_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.334227
-  0: The maximum resident set size (KB)                   = 545284
+  0: The total amount of wall time                        = 235.716272
+  0: The maximum resident set size (KB)                   = 545360
 
 Test 072 control_csawmgt_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_ras_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.778038
-  0: The maximum resident set size (KB)                   = 516092
+  0: The total amount of wall time                        = 151.034063
+  0: The maximum resident set size (KB)                   = 516080
 
 Test 073 control_ras_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.423743
-  0: The maximum resident set size (KB)                   = 561424
+  0: The total amount of wall time                        = 153.457119
+  0: The maximum resident set size (KB)                   = 561412
 
 Test 074 control_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_debug_p8
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.568134
-  0: The maximum resident set size (KB)                   = 530168
+  0: The total amount of wall time                        = 159.150677
+  0: The maximum resident set size (KB)                   = 530148
 
 Test 075 control_debug_p8 PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.622621
-  0: The maximum resident set size (KB)                   = 864184
+  0: The total amount of wall time                        = 172.623264
+  0: The maximum resident set size (KB)                   = 864440
 
 Test 076 control_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson_no_aero_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 197.875200
-  0: The maximum resident set size (KB)                   = 859704
+  0: The total amount of wall time                        = 165.233336
+  0: The maximum resident set size (KB)                   = 859692
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson_extdiag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.645844
-  0: The maximum resident set size (KB)                   = 892768
+  0: The total amount of wall time                        = 180.871630
+  0: The maximum resident set size (KB)                   = 892804
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_thompson_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.823668
-  0: The maximum resident set size (KB)                   = 864300
+  0: The total amount of wall time                        = 172.143231
+  0: The maximum resident set size (KB)                   = 864204
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/regional_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 257.181676
- 0: The maximum resident set size (KB)                   = 567372
+ 0: The total amount of wall time                        = 259.410932
+ 0: The maximum resident set size (KB)                   = 567184
 
 Test 080 regional_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_control_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.025107
-  0: The maximum resident set size (KB)                   = 872040
+  0: The total amount of wall time                        = 273.472080
+  0: The maximum resident set size (KB)                   = 871684
 
 Test 081 rap_control_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_unified_drag_suite_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.099435
-  0: The maximum resident set size (KB)                   = 871988
+  0: The total amount of wall time                        = 271.412851
+  0: The maximum resident set size (KB)                   = 871684
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_diag_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.868617
-  0: The maximum resident set size (KB)                   = 954532
+  0: The total amount of wall time                        = 286.864285
+  0: The maximum resident set size (KB)                   = 954652
 
 Test 083 rap_diag_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.415528
-  0: The maximum resident set size (KB)                   = 874676
+  0: The total amount of wall time                        = 279.216756
+  0: The maximum resident set size (KB)                   = 874392
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_unified_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.022775
-  0: The maximum resident set size (KB)                   = 871692
+  0: The total amount of wall time                        = 279.425399
+  0: The maximum resident set size (KB)                   = 871708
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_noah_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_noah_debug
 Checking test 086 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.712790
-  0: The maximum resident set size (KB)                   = 870844
+  0: The total amount of wall time                        = 273.966622
+  0: The maximum resident set size (KB)                   = 870688
 
 Test 086 rap_noah_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_rrtmgp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_rrtmgp_debug
 Checking test 087 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 471.824064
-  0: The maximum resident set size (KB)                   = 978044
+  0: The total amount of wall time                        = 471.646553
+  0: The maximum resident set size (KB)                   = 978180
 
 Test 087 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_lndp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_lndp_debug
 Checking test 088 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.672556
-  0: The maximum resident set size (KB)                   = 872804
+  0: The total amount of wall time                        = 275.533220
+  0: The maximum resident set size (KB)                   = 872540
 
 Test 088 rap_lndp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_sfcdiff_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff_debug
 Checking test 089 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.189976
-  0: The maximum resident set size (KB)                   = 871836
+  0: The total amount of wall time                        = 274.413185
+  0: The maximum resident set size (KB)                   = 871424
 
 Test 089 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_flake_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_flake_debug
 Checking test 090 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.887458
-  0: The maximum resident set size (KB)                   = 871596
+  0: The total amount of wall time                        = 272.682261
+  0: The maximum resident set size (KB)                   = 871984
 
 Test 090 rap_flake_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 091 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 461.748026
-  0: The maximum resident set size (KB)                   = 870400
+  0: The total amount of wall time                        = 458.434193
+  0: The maximum resident set size (KB)                   = 870704
 
 Test 091 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rap_progcld_thompson_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_progcld_thompson_debug
 Checking test 092 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.722583
-  0: The maximum resident set size (KB)                   = 871716
+  0: The total amount of wall time                        = 275.614448
+  0: The maximum resident set size (KB)                   = 871920
 
 Test 092 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/rrfs_v1beta_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.277041
-  0: The maximum resident set size (KB)                   = 869148
+  0: The total amount of wall time                        = 270.948477
+  0: The maximum resident set size (KB)                   = 869296
 
 Test 093 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_wam_debug
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 295.903107
-  0: The maximum resident set size (KB)                   = 212228
+  0: The total amount of wall time                        = 316.115908
+  0: The maximum resident set size (KB)                   = 212024
 
 Test 094 control_wam_debug PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 281.474070
-  0: The maximum resident set size (KB)                   = 657688
+  0: The total amount of wall time                        = 273.421568
+  0: The maximum resident set size (KB)                   = 657592
 
 Test 095 hafs_regional_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 335.745186
-  0: The maximum resident set size (KB)                   = 1020884
+  0: The total amount of wall time                        = 336.022377
+  0: The maximum resident set size (KB)                   = 1020264
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_atm_ocn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2840,28 +2840,28 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 380.684249
-  0: The maximum resident set size (KB)                   = 662240
+  0: The total amount of wall time                        = 409.579382
+  0: The maximum resident set size (KB)                   = 662348
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_atm_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 864.329576
-  0: The maximum resident set size (KB)                   = 663648
+  0: The total amount of wall time                        = 858.769000
+  0: The maximum resident set size (KB)                   = 663796
 
 Test 098 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_atm_ocn_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2870,28 +2870,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 985.929684
-  0: The maximum resident set size (KB)                   = 667092
+  0: The total amount of wall time                        = 967.237777
+  0: The maximum resident set size (KB)                   = 667016
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 519.231856
-  0: The maximum resident set size (KB)                   = 257032
+  0: The total amount of wall time                        = 512.687854
+  0: The maximum resident set size (KB)                   = 258264
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_telescopic_2nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2900,28 +2900,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 525.413212
-  0: The maximum resident set size (KB)                   = 262800
+  0: The total amount of wall time                        = 534.660011
+  0: The maximum resident set size (KB)                   = 263204
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_global_1nest_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 235.402241
-  0: The maximum resident set size (KB)                   = 162716
+  0: The total amount of wall time                        = 279.082776
+  0: The maximum resident set size (KB)                   = 162632
 
 Test 102 hafs_global_1nest_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_global_multiple_4nests_atm
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2934,14 +2934,14 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 677.753753
-  0: The maximum resident set size (KB)                   = 232964
+  0: The total amount of wall time                        = 667.364351
+  0: The maximum resident set size (KB)                   = 219080
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_docn
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_docn
 Checking test 104 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2949,14 +2949,14 @@ Checking test 104 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 347.494330
-  0: The maximum resident set size (KB)                   = 661964
+  0: The total amount of wall time                        = 347.539869
+  0: The maximum resident set size (KB)                   = 662072
 
 Test 104 hafs_regional_docn PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_docn_oisst
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_docn_oisst
 Checking test 105 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2964,105 +2964,105 @@ Checking test 105 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 345.554009
-  0: The maximum resident set size (KB)                   = 662024
+  0: The total amount of wall time                        = 338.939027
+  0: The maximum resident set size (KB)                   = 661960
 
 Test 105 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/hafs_regional_datm_cdeps
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_datm_cdeps
 Checking test 106 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1052.405585
-  0: The maximum resident set size (KB)                   = 807172
+  0: The total amount of wall time                        = 1034.620846
+  0: The maximum resident set size (KB)                   = 806972
 
 Test 106 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_control_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_control_cfsr
 Checking test 107 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.856405
- 0: The maximum resident set size (KB)                   = 683408
+ 0: The total amount of wall time                        = 154.669850
+ 0: The maximum resident set size (KB)                   = 664356
 
 Test 107 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_restart_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_restart_cfsr
 Checking test 108 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 120.191765
- 0: The maximum resident set size (KB)                   = 683420
+ 0: The total amount of wall time                        = 84.722146
+ 0: The maximum resident set size (KB)                   = 683308
 
 Test 108 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_control_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_control_gefs
 Checking test 109 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.695901
- 0: The maximum resident set size (KB)                   = 565692
+ 0: The total amount of wall time                        = 147.566347
+ 0: The maximum resident set size (KB)                   = 563656
 
 Test 109 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_stochy_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_stochy_gefs
 Checking test 110 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.325353
- 0: The maximum resident set size (KB)                   = 563776
+ 0: The total amount of wall time                        = 152.964605
+ 0: The maximum resident set size (KB)                   = 569612
 
 Test 110 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_bulk_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_bulk_cfsr
 Checking test 111 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.347873
- 0: The maximum resident set size (KB)                   = 683312
+ 0: The total amount of wall time                        = 147.738854
+ 0: The maximum resident set size (KB)                   = 688984
 
 Test 111 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_bulk_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_bulk_gefs
 Checking test 112 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.073673
- 0: The maximum resident set size (KB)                   = 565976
+ 0: The total amount of wall time                        = 142.862553
+ 0: The maximum resident set size (KB)                   = 567636
 
 Test 112 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_mx025_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_mx025_cfsr
 Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3071,14 +3071,14 @@ Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 338.109573
-  0: The maximum resident set size (KB)                   = 482484
+  0: The total amount of wall time                        = 340.172076
+  0: The maximum resident set size (KB)                   = 482796
 
 Test 113 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_mx025_gefs
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_mx025_gefs
 Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3087,51 +3087,51 @@ Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 330.661331
-  0: The maximum resident set size (KB)                   = 449980
+  0: The total amount of wall time                        = 341.392784
+  0: The maximum resident set size (KB)                   = 449856
 
 Test 114 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_multiple_files_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_multiple_files_cfsr
 Checking test 115 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.441613
- 0: The maximum resident set size (KB)                   = 688908
+ 0: The total amount of wall time                        = 149.154385
+ 0: The maximum resident set size (KB)                   = 683144
 
 Test 115 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_3072x1536_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_3072x1536_cfsr
 Checking test 116 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 200.594112
- 0: The maximum resident set size (KB)                   = 1835504
+ 0: The total amount of wall time                        = 200.451765
+ 0: The maximum resident set size (KB)                   = 1835724
 
 Test 116 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/datm_cdeps_debug_cfsr
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_debug_cfsr
 Checking test 117 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 392.367566
- 0: The maximum resident set size (KB)                   = 688360
+ 0: The total amount of wall time                        = 364.342141
+ 0: The maximum resident set size (KB)                   = 680968
 
 Test 117 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_atmwav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_atmwav
 Checking test 118 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3175,14 +3175,14 @@ Checking test 118 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 116.067212
-  0: The maximum resident set size (KB)                   = 449540
+  0: The total amount of wall time                        = 119.625471
+  0: The maximum resident set size (KB)                   = 449532
 
 Test 118 control_atmwav PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_6697/control_c384gdas_wav
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384gdas_wav
 Checking test 119 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3228,12 +3228,12 @@ Checking test 119 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 1483.067177
-  0: The maximum resident set size (KB)                   = 952528
+  0: The total amount of wall time                        = 1384.624113
+  0: The maximum resident set size (KB)                   = 957076
 
 Test 119 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 12:21:23 EST 2022
-Elapsed time: 01h:14m:53s. Have a nice day!
+Tue Feb 15 20:35:39 EST 2022
+Elapsed time: 01h:27m:49s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,15 +1,15 @@
-Mon Feb 14 15:28:17 UTC 2022
+Tue Feb 15 19:05:49 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 282 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 94 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 222 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 115 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 300 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 106 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 233 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 123 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,14 +56,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 800.350655
-  0: The maximum resident set size (KB)                   = 441192
+  0: The total amount of wall time                        = 807.432720
+  0: The maximum resident set size (KB)                   = 443156
 
 Test 001 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -102,14 +102,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 380.287334
-  0: The maximum resident set size (KB)                   = 180668
+  0: The total amount of wall time                        = 389.166269
+  0: The maximum resident set size (KB)                   = 177568
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,14 +148,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 678.076076
-0: The maximum resident set size (KB)                   = 692216
+0: The total amount of wall time                        = 674.805435
+0: The maximum resident set size (KB)                   = 690816
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -166,14 +166,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 622.375096
-  0: The maximum resident set size (KB)                   = 446580
+  0: The total amount of wall time                        = 625.062652
+  0: The maximum resident set size (KB)                   = 447492
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,14 +184,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1389.282251
-  0: The maximum resident set size (KB)                   = 493000
+  0: The total amount of wall time                        = 1391.612954
+  0: The maximum resident set size (KB)                   = 492776
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -202,14 +202,14 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 842.523401
-  0: The maximum resident set size (KB)                   = 544348
+  0: The total amount of wall time                        = 832.837061
+  0: The maximum resident set size (KB)                   = 538620
 
 Test 006 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -220,14 +220,14 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1000.200844
-  0: The maximum resident set size (KB)                   = 801884
+  0: The total amount of wall time                        = 985.025303
+  0: The maximum resident set size (KB)                   = 801932
 
 Test 007 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -238,14 +238,14 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 970.546100
-  0: The maximum resident set size (KB)                   = 799408
+  0: The total amount of wall time                        = 950.340740
+  0: The maximum resident set size (KB)                   = 796396
 
 Test 008 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -256,14 +256,14 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 787.326169
-  0: The maximum resident set size (KB)                   = 448264
+  0: The total amount of wall time                        = 805.753128
+  0: The maximum resident set size (KB)                   = 448908
 
 Test 009 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_p8
 Checking test 010 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -310,14 +310,14 @@ Checking test 010 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 816.056013
-  0: The maximum resident set size (KB)                   = 480564
+  0: The total amount of wall time                        = 798.873597
+  0: The maximum resident set size (KB)                   = 476256
 
 Test 010 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -364,14 +364,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1379.781710
-  0: The maximum resident set size (KB)                   = 788348
+  0: The total amount of wall time                        = 1390.142322
+  0: The maximum resident set size (KB)                   = 785772
 
 Test 011 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_2threads
 Checking test 012 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -418,14 +418,14 @@ Checking test 012 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1382.675019
- 0: The maximum resident set size (KB)                   = 850728
+ 0: The total amount of wall time                        = 1413.811857
+ 0: The maximum resident set size (KB)                   = 846024
 
 Test 012 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_restart
 Checking test 013 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -464,14 +464,14 @@ Checking test 013 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 681.857017
-  0: The maximum resident set size (KB)                   = 530124
+  0: The total amount of wall time                        = 666.075535
+  0: The maximum resident set size (KB)                   = 533036
 
 Test 013 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_sfcdiff
 Checking test 014 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -518,14 +518,14 @@ Checking test 014 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1390.499801
-  0: The maximum resident set size (KB)                   = 783180
+  0: The total amount of wall time                        = 1387.120301
+  0: The maximum resident set size (KB)                   = 788436
 
 Test 014 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_sfcdiff_restart
 Checking test 015 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 667.041322
-  0: The maximum resident set size (KB)                   = 535472
+  0: The total amount of wall time                        = 678.798878
+  0: The maximum resident set size (KB)                   = 535132
 
 Test 015 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/hrrr_control
 Checking test 016 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -618,14 +618,14 @@ Checking test 016 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1359.034542
-  0: The maximum resident set size (KB)                   = 785992
+  0: The total amount of wall time                        = 1356.238015
+  0: The maximum resident set size (KB)                   = 782268
 
 Test 016 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -672,14 +672,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1372.029955
-  0: The maximum resident set size (KB)                   = 784684
+  0: The total amount of wall time                        = 1378.026667
+  0: The maximum resident set size (KB)                   = 784848
 
 Test 017 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_conus13km_hrrr_warm
 Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -688,14 +688,14 @@ Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1538.837267
-  0: The maximum resident set size (KB)                   = 630968
+  0: The total amount of wall time                        = 1537.012025
+  0: The maximum resident set size (KB)                   = 627932
 
 Test 018 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -704,250 +704,250 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1535.158900
-  0: The maximum resident set size (KB)                   = 630032
+  0: The total amount of wall time                        = 1541.935576
+  0: The maximum resident set size (KB)                   = 630208
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.141841
-  0: The maximum resident set size (KB)                   = 439420
+  0: The total amount of wall time                        = 100.270532
+  0: The maximum resident set size (KB)                   = 436596
 
 Test 020 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 123.714969
-  0: The maximum resident set size (KB)                   = 498300
+  0: The total amount of wall time                        = 125.436539
+  0: The maximum resident set size (KB)                   = 494344
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 125.835492
- 0: The maximum resident set size (KB)                   = 550332
+ 0: The total amount of wall time                        = 126.505351
+ 0: The maximum resident set size (KB)                   = 545840
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.312679
-  0: The maximum resident set size (KB)                   = 807084
+  0: The total amount of wall time                        = 167.238228
+  0: The maximum resident set size (KB)                   = 805400
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.121977
-  0: The maximum resident set size (KB)                   = 889020
+  0: The total amount of wall time                        = 203.922455
+  0: The maximum resident set size (KB)                   = 890304
 
 Test 024 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.366731
-  0: The maximum resident set size (KB)                   = 806876
+  0: The total amount of wall time                        = 263.338297
+  0: The maximum resident set size (KB)                   = 803620
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.748965
-  0: The maximum resident set size (KB)                   = 808672
+  0: The total amount of wall time                        = 168.340687
+  0: The maximum resident set size (KB)                   = 803900
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.141507
-  0: The maximum resident set size (KB)                   = 801624
+  0: The total amount of wall time                        = 167.344122
+  0: The maximum resident set size (KB)                   = 800848
 
 Test 027 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 111.494816
-  0: The maximum resident set size (KB)                   = 803248
+  0: The total amount of wall time                        = 114.465309
+  0: The maximum resident set size (KB)                   = 794988
 
 Test 028 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.723367
-  0: The maximum resident set size (KB)                   = 796180
+  0: The total amount of wall time                        = 111.909539
+  0: The maximum resident set size (KB)                   = 792580
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 132.006949
-  0: The maximum resident set size (KB)                   = 829392
+  0: The total amount of wall time                        = 132.412307
+  0: The maximum resident set size (KB)                   = 828716
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_thompson_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 114.018543
-  0: The maximum resident set size (KB)                   = 801296
+  0: The total amount of wall time                        = 110.836178
+  0: The maximum resident set size (KB)                   = 795064
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_rrtmgp_debug
 Checking test 032 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.992889
-  0: The maximum resident set size (KB)                   = 540356
+  0: The total amount of wall time                        = 104.490232
+  0: The maximum resident set size (KB)                   = 536464
 
 Test 032 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_ras_debug
 Checking test 033 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.612147
-  0: The maximum resident set size (KB)                   = 450720
+  0: The total amount of wall time                        = 101.293748
+  0: The maximum resident set size (KB)                   = 449000
 
 Test 033 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_stochy_debug
 Checking test 034 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 114.711747
-  0: The maximum resident set size (KB)                   = 445716
+  0: The total amount of wall time                        = 115.678930
+  0: The maximum resident set size (KB)                   = 438648
 
 Test 034 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_debug_p8
 Checking test 035 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 108.221677
-  0: The maximum resident set size (KB)                   = 480276
+  0: The total amount of wall time                        = 105.481971
+  0: The maximum resident set size (KB)                   = 478116
 
 Test 035 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 180.143300
-  0: The maximum resident set size (KB)                   = 187800
+  0: The total amount of wall time                        = 179.933537
+  0: The maximum resident set size (KB)                   = 188212
 
 Test 036 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/cpld_control_c96_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/cpld_control_c96_p8
 Checking test 037 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 037 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1100.603704
-  0: The maximum resident set size (KB)                   = 503968
+  0: The total amount of wall time                        = 1094.253906
+  0: The maximum resident set size (KB)                   = 504052
 
 Test 037 cpld_control_c96_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_4005/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/cpld_debug_p8
 Checking test 038 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,12 +1066,12 @@ Checking test 038 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 555.761003
-  0: The maximum resident set size (KB)                   = 517088
+  0: The total amount of wall time                        = 558.276381
+  0: The maximum resident set size (KB)                   = 513104
 
 Test 038 cpld_debug_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 16:13:36 UTC 2022
-Elapsed time: 00h:45m:20s. Have a nice day!
+Tue Feb 15 19:53:06 UTC 2022
+Elapsed time: 00h:47m:18s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,24 +1,24 @@
-Mon Feb 14 16:11:00 UTC 2022
+Tue Feb 15 19:46:20 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 455 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 174 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 378 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 366 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 387 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 171 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 202 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 400 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 469 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 181 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 613 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 410 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 333 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 533 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 538 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 401 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 011 elapsed time 410 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 186 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 89 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 392 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 410 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 211 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 168 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 391 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 412 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +83,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 212.019919
-  0: The maximum resident set size (KB)                   = 562808
+  0: The total amount of wall time                        = 218.458712
+  0: The maximum resident set size (KB)                   = 563320
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -143,14 +143,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 241.018804
-  0: The maximum resident set size (KB)                   = 644848
+  0: The total amount of wall time                        = 246.410751
+  0: The maximum resident set size (KB)                   = 642032
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 213.527671
-  0: The maximum resident set size (KB)                   = 563316
+  0: The total amount of wall time                        = 214.941898
+  0: The maximum resident set size (KB)                   = 562176
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -263,14 +263,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 178.745466
-  0: The maximum resident set size (KB)                   = 539052
+  0: The total amount of wall time                        = 184.007988
+  0: The maximum resident set size (KB)                   = 533044
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_control_p7_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -323,14 +323,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 248.663804
-  0: The maximum resident set size (KB)                   = 661992
+  0: The total amount of wall time                        = 256.389425
+  0: The maximum resident set size (KB)                   = 664184
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_bmark_p7
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -375,14 +375,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 855.214494
-  0: The maximum resident set size (KB)                   = 1228148
+  0: The total amount of wall time                        = 869.950990
+  0: The maximum resident set size (KB)                   = 1227132
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_bmark_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -427,14 +427,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 857.939565
-  0: The maximum resident set size (KB)                   = 1230136
+  0: The total amount of wall time                        = 871.459322
+  0: The maximum resident set size (KB)                   = 1228016
 
 Test 007 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_bmark_mpi_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -479,14 +479,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 835.163646
-  0: The maximum resident set size (KB)                   = 1229648
+  0: The total amount of wall time                        = 849.770747
+  0: The maximum resident set size (KB)                   = 1231332
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_control_c96_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -548,14 +548,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 204.022869
-  0: The maximum resident set size (KB)                   = 556108
+  0: The total amount of wall time                        = 211.465655
+  0: The maximum resident set size (KB)                   = 556288
 
 Test 009 cpld_control_c96_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_restart_c96_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -605,14 +605,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 109.273196
-  0: The maximum resident set size (KB)                   = 324528
+  0: The total amount of wall time                        = 111.273357
+  0: The maximum resident set size (KB)                   = 324352
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_control_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -662,14 +662,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 842.216855
-  0: The maximum resident set size (KB)                   = 730488
+  0: The total amount of wall time                        = 848.412694
+  0: The maximum resident set size (KB)                   = 726304
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_restart_c192_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 570.625570
-  0: The maximum resident set size (KB)                   = 830464
+  0: The total amount of wall time                        = 573.778107
+  0: The maximum resident set size (KB)                   = 828784
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_control_c384_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -769,14 +769,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 993.982972
-  0: The maximum resident set size (KB)                   = 1242548
+  0: The total amount of wall time                        = 998.060455
+  0: The maximum resident set size (KB)                   = 1242128
 
 Test 013 cpld_control_c384_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_restart_c384_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -819,14 +819,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 538.201547
-  0: The maximum resident set size (KB)                   = 1204784
+  0: The total amount of wall time                        = 575.312625
+  0: The maximum resident set size (KB)                   = 1204012
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/cpld_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -876,14 +876,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 610.028256
-  0: The maximum resident set size (KB)                   = 611056
+  0: The total amount of wall time                        = 601.832893
+  0: The maximum resident set size (KB)                   = 612140
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -930,14 +930,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 122.769916
-  0: The maximum resident set size (KB)                   = 464056
+  0: The total amount of wall time                        = 126.981262
+  0: The maximum resident set size (KB)                   = 457284
 
 Test 016 control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_decomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -980,28 +980,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.607079
-  0: The maximum resident set size (KB)                   = 461052
+  0: The total amount of wall time                        = 130.738014
+  0: The maximum resident set size (KB)                   = 464960
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 122.185910
-  0: The maximum resident set size (KB)                   = 464976
+  0: The total amount of wall time                        = 124.369300
+  0: The maximum resident set size (KB)                   = 462264
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1044,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 151.153451
- 0: The maximum resident set size (KB)                   = 509392
+ 0: The total amount of wall time                        = 151.083120
+ 0: The maximum resident set size (KB)                   = 509568
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1090,14 +1090,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 66.960073
-  0: The maximum resident set size (KB)                   = 203640
+  0: The total amount of wall time                        = 65.105552
+  0: The maximum resident set size (KB)                   = 204780
 
 Test 020 control_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_fhzero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1140,14 +1140,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 122.468369
-  0: The maximum resident set size (KB)                   = 463816
+  0: The total amount of wall time                        = 120.738669
+  0: The maximum resident set size (KB)                   = 464516
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_CubedSphereGrid
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.777481
-  0: The maximum resident set size (KB)                   = 464648
+  0: The total amount of wall time                        = 120.184942
+  0: The maximum resident set size (KB)                   = 460168
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_latlon
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1192,14 +1192,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 125.144301
-  0: The maximum resident set size (KB)                   = 460804
+  0: The total amount of wall time                        = 126.886910
+  0: The maximum resident set size (KB)                   = 462044
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1210,14 +1210,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.666237
-  0: The maximum resident set size (KB)                   = 462772
+  0: The total amount of wall time                        = 127.630515
+  0: The maximum resident set size (KB)                   = 463540
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_c48
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1256,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 316.215981
-0: The maximum resident set size (KB)                   = 657916
+0: The total amount of wall time                        = 312.081977
+0: The maximum resident set size (KB)                   = 657968
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1274,14 +1274,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 465.299810
-  0: The maximum resident set size (KB)                   = 561248
+  0: The total amount of wall time                        = 469.015885
+  0: The maximum resident set size (KB)                   = 560300
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_c384
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1292,14 +1292,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 768.335614
-  0: The maximum resident set size (KB)                   = 822836
+  0: The total amount of wall time                        = 770.516623
+  0: The maximum resident set size (KB)                   = 826908
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_c384gdas
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 678.708559
-  0: The maximum resident set size (KB)                   = 966232
+  0: The total amount of wall time                        = 676.725380
+  0: The maximum resident set size (KB)                   = 968852
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_stochy
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,28 +1360,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.385731
-  0: The maximum resident set size (KB)                   = 465012
+  0: The total amount of wall time                        = 84.894714
+  0: The maximum resident set size (KB)                   = 462172
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_stochy_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.005746
-  0: The maximum resident set size (KB)                   = 242256
+  0: The total amount of wall time                        = 45.356361
+  0: The maximum resident set size (KB)                   = 247020
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_lndp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1392,14 +1392,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.243418
-  0: The maximum resident set size (KB)                   = 467464
+  0: The total amount of wall time                        = 74.049089
+  0: The maximum resident set size (KB)                   = 465576
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_iovr4
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 124.494050
-  0: The maximum resident set size (KB)                   = 457860
+  0: The total amount of wall time                        = 130.919674
+  0: The maximum resident set size (KB)                   = 462220
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_iovr5
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1436,14 +1436,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 124.077377
-  0: The maximum resident set size (KB)                   = 460832
+  0: The total amount of wall time                        = 129.310257
+  0: The maximum resident set size (KB)                   = 458896
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 143.356919
-  0: The maximum resident set size (KB)                   = 491652
+  0: The total amount of wall time                        = 142.620242
+  0: The maximum resident set size (KB)                   = 490708
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_restart_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1536,14 +1536,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 75.501741
-  0: The maximum resident set size (KB)                   = 290356
+  0: The total amount of wall time                        = 73.106904
+  0: The maximum resident set size (KB)                   = 293724
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_decomp_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,14 +1586,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.010551
-  0: The maximum resident set size (KB)                   = 489968
+  0: The total amount of wall time                        = 142.859904
+  0: The maximum resident set size (KB)                   = 489520
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_2threads_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1636,14 +1636,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 170.127281
- 0: The maximum resident set size (KB)                   = 568656
+ 0: The total amount of wall time                        = 170.863910
+ 0: The maximum resident set size (KB)                   = 564632
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_p7_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.793055
-  0: The maximum resident set size (KB)                   = 592964
+  0: The total amount of wall time                        = 178.416551
+  0: The maximum resident set size (KB)                   = 594540
 
 Test 038 control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1708,42 +1708,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 301.808453
- 0: The maximum resident set size (KB)                   = 573280
+ 0: The total amount of wall time                        = 299.108703
+ 0: The maximum resident set size (KB)                   = 577648
 
 Test 039 regional_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 170.078842
- 0: The maximum resident set size (KB)                   = 578444
+ 0: The total amount of wall time                        = 170.787362
+ 0: The maximum resident set size (KB)                   = 577748
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_control_2dwrtdecomp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 300.196837
- 0: The maximum resident set size (KB)                   = 577348
+ 0: The total amount of wall time                        = 306.991759
+ 0: The maximum resident set size (KB)                   = 573036
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_noquilt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 314.239736
- 0: The maximum resident set size (KB)                   = 591472
+ 0: The total amount of wall time                        = 315.029088
+ 0: The maximum resident set size (KB)                   = 591180
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 233.744960
- 0: The maximum resident set size (KB)                   = 577716
+ 0: The total amount of wall time                        = 234.275143
+ 0: The maximum resident set size (KB)                   = 576988
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_hafs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1785,28 +1785,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 296.040535
- 0: The maximum resident set size (KB)                   = 575960
+ 0: The total amount of wall time                        = 298.220233
+ 0: The maximum resident set size (KB)                   = 576896
 
 Test 044 regional_hafs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_netcdf_parallel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 296.094418
- 0: The maximum resident set size (KB)                   = 570756
+ 0: The total amount of wall time                        = 299.552785
+ 0: The maximum resident set size (KB)                   = 575012
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_RRTMGP
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1817,14 +1817,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 376.936505
- 0: The maximum resident set size (KB)                   = 693056
+ 0: The total amount of wall time                        = 373.951628
+ 0: The maximum resident set size (KB)                   = 691520
 
 Test 046 regional_RRTMGP PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1871,14 +1871,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 351.373977
-  0: The maximum resident set size (KB)                   = 832548
+  0: The total amount of wall time                        = 347.381685
+  0: The maximum resident set size (KB)                   = 834060
 
 Test 047 rap_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_2threads
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 429.431985
- 0: The maximum resident set size (KB)                   = 897592
+ 0: The total amount of wall time                        = 438.200004
+ 0: The maximum resident set size (KB)                   = 895972
 
 Test 048 rap_2threads PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.436523
-  0: The maximum resident set size (KB)                   = 583128
+  0: The total amount of wall time                        = 180.395554
+  0: The maximum resident set size (KB)                   = 582052
 
 Test 049 rap_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_sfcdiff
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2025,14 +2025,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 359.447944
-  0: The maximum resident set size (KB)                   = 826964
+  0: The total amount of wall time                        = 365.966639
+  0: The maximum resident set size (KB)                   = 829160
 
 Test 050 rap_sfcdiff PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_sfcdiff_restart
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 181.145714
-  0: The maximum resident set size (KB)                   = 580820
+  0: The total amount of wall time                        = 176.368771
+  0: The maximum resident set size (KB)                   = 582220
 
 Test 051 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hrrr_control
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.205528
-  0: The maximum resident set size (KB)                   = 827872
+  0: The total amount of wall time                        = 347.858324
+  0: The maximum resident set size (KB)                   = 831684
 
 Test 052 hrrr_control PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rrfs_v1beta
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.359283
-  0: The maximum resident set size (KB)                   = 831676
+  0: The total amount of wall time                        = 360.327521
+  0: The maximum resident set size (KB)                   = 827488
 
 Test 053 rrfs_v1beta PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2195,14 +2195,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 169.929266
-  0: The maximum resident set size (KB)                   = 665512
+  0: The total amount of wall time                        = 169.651872
+  0: The maximum resident set size (KB)                   = 660436
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2211,14 +2211,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 173.164372
-  0: The maximum resident set size (KB)                   = 663648
+  0: The total amount of wall time                        = 170.641471
+  0: The maximum resident set size (KB)                   = 663592
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_rrtmgp
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.559598
-  0: The maximum resident set size (KB)                   = 589268
+  0: The total amount of wall time                        = 193.210478
+  0: The maximum resident set size (KB)                   = 587976
 
 Test 056 control_rrtmgp PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_rrtmgp_c192
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2247,14 +2247,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 512.273683
-  0: The maximum resident set size (KB)                   = 800376
+  0: The total amount of wall time                        = 507.112749
+  0: The maximum resident set size (KB)                   = 800936
 
 Test 057 control_rrtmgp_c192 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_csawmg
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2265,14 +2265,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 314.976051
-  0: The maximum resident set size (KB)                   = 533940
+  0: The total amount of wall time                        = 318.157651
+  0: The maximum resident set size (KB)                   = 533324
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_csawmgt
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2283,14 +2283,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 307.941706
-  0: The maximum resident set size (KB)                   = 531980
+  0: The total amount of wall time                        = 312.453859
+  0: The maximum resident set size (KB)                   = 531868
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_flake
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2301,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 229.375064
-  0: The maximum resident set size (KB)                   = 534892
+  0: The total amount of wall time                        = 230.550437
+  0: The maximum resident set size (KB)                   = 535896
 
 Test 060 control_flake PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_ras
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2319,14 +2319,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.666810
-  0: The maximum resident set size (KB)                   = 497664
+  0: The total amount of wall time                        = 166.029332
+  0: The maximum resident set size (KB)                   = 495360
 
 Test 061 control_ras PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2337,14 +2337,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 213.225468
-  0: The maximum resident set size (KB)                   = 846592
+  0: The total amount of wall time                        = 215.438934
+  0: The maximum resident set size (KB)                   = 849104
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson_no_aero
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2355,54 +2355,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.420292
-  0: The maximum resident set size (KB)                   = 842472
+  0: The total amount of wall time                        = 203.333249
+  0: The maximum resident set size (KB)                   = 843256
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_repro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_wam_repro
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 118.612929
-  0: The maximum resident set size (KB)                   = 221076
+  0: The total amount of wall time                        = 116.969887
+  0: The maximum resident set size (KB)                   = 223484
 
 Test 064 control_wam PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 140.892085
-  0: The maximum resident set size (KB)                   = 532580
+  0: The total amount of wall time                        = 138.548838
+  0: The maximum resident set size (KB)                   = 533412
 
 Test 065 control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_2threads_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 213.641427
- 0: The maximum resident set size (KB)                   = 583048
+ 0: The total amount of wall time                        = 209.554034
+ 0: The maximum resident set size (KB)                   = 582240
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_CubedSphereGrid_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2429,428 +2429,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.324230
-  0: The maximum resident set size (KB)                   = 534088
+  0: The total amount of wall time                        = 154.700021
+  0: The maximum resident set size (KB)                   = 536160
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.141397
-  0: The maximum resident set size (KB)                   = 533628
+  0: The total amount of wall time                        = 144.829524
+  0: The maximum resident set size (KB)                   = 533420
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_stochy_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.859396
-  0: The maximum resident set size (KB)                   = 539816
+  0: The total amount of wall time                        = 160.695393
+  0: The maximum resident set size (KB)                   = 544144
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.372023
-  0: The maximum resident set size (KB)                   = 538732
+  0: The total amount of wall time                        = 144.422749
+  0: The maximum resident set size (KB)                   = 536856
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.557682
-  0: The maximum resident set size (KB)                   = 637876
+  0: The total amount of wall time                        = 156.796430
+  0: The maximum resident set size (KB)                   = 640892
 
 Test 071 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_csawmg_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 222.274863
-  0: The maximum resident set size (KB)                   = 575184
+  0: The total amount of wall time                        = 227.132422
+  0: The maximum resident set size (KB)                   = 574416
 
 Test 072 control_csawmg_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_csawmgt_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 225.258889
-  0: The maximum resident set size (KB)                   = 574564
+  0: The total amount of wall time                        = 216.271635
+  0: The maximum resident set size (KB)                   = 578868
 
 Test 073 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_ras_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 147.096752
-  0: The maximum resident set size (KB)                   = 548540
+  0: The total amount of wall time                        = 147.919618
+  0: The maximum resident set size (KB)                   = 548700
 
 Test 074 control_ras_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.843481
-  0: The maximum resident set size (KB)                   = 592020
+  0: The total amount of wall time                        = 153.264724
+  0: The maximum resident set size (KB)                   = 591620
 
 Test 075 control_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_debug_p8
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.653479
-  0: The maximum resident set size (KB)                   = 558432
+  0: The total amount of wall time                        = 152.342233
+  0: The maximum resident set size (KB)                   = 557584
 
 Test 076 control_debug_p8 PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.428905
-  0: The maximum resident set size (KB)                   = 895468
+  0: The total amount of wall time                        = 165.297901
+  0: The maximum resident set size (KB)                   = 897180
 
 Test 077 control_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson_no_aero_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.340331
-  0: The maximum resident set size (KB)                   = 887060
+  0: The total amount of wall time                        = 159.869228
+  0: The maximum resident set size (KB)                   = 889460
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson_extdiag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.612765
-  0: The maximum resident set size (KB)                   = 924580
+  0: The total amount of wall time                        = 174.760181
+  0: The maximum resident set size (KB)                   = 924312
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_thompson_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.755813
-  0: The maximum resident set size (KB)                   = 896908
+  0: The total amount of wall time                        = 163.896855
+  0: The maximum resident set size (KB)                   = 896816
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/regional_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 235.243047
- 0: The maximum resident set size (KB)                   = 606840
+ 0: The total amount of wall time                        = 236.004992
+ 0: The maximum resident set size (KB)                   = 608780
 
 Test 081 regional_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_control_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.003063
-  0: The maximum resident set size (KB)                   = 899592
+  0: The total amount of wall time                        = 256.346876
+  0: The maximum resident set size (KB)                   = 898420
 
 Test 082 rap_control_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_unified_drag_suite_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.341081
-  0: The maximum resident set size (KB)                   = 894176
+  0: The total amount of wall time                        = 260.454394
+  0: The maximum resident set size (KB)                   = 898352
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_diag_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.550920
-  0: The maximum resident set size (KB)                   = 986160
+  0: The total amount of wall time                        = 276.076663
+  0: The maximum resident set size (KB)                   = 985300
 
 Test 084 rap_diag_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.057778
-  0: The maximum resident set size (KB)                   = 901728
+  0: The total amount of wall time                        = 266.342087
+  0: The maximum resident set size (KB)                   = 901312
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_unified_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.140645
-  0: The maximum resident set size (KB)                   = 894408
+  0: The total amount of wall time                        = 268.900861
+  0: The maximum resident set size (KB)                   = 894624
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_noah_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 250.760581
-  0: The maximum resident set size (KB)                   = 898608
+  0: The total amount of wall time                        = 253.076946
+  0: The maximum resident set size (KB)                   = 898684
 
 Test 087 rap_noah_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_rrtmgp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 441.484214
-  0: The maximum resident set size (KB)                   = 1003628
+  0: The total amount of wall time                        = 443.269434
+  0: The maximum resident set size (KB)                   = 1002504
 
 Test 088 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_lndp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.648491
-  0: The maximum resident set size (KB)                   = 897692
+  0: The total amount of wall time                        = 259.292016
+  0: The maximum resident set size (KB)                   = 898420
 
 Test 089 rap_lndp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_sfcdiff_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.465270
-  0: The maximum resident set size (KB)                   = 897584
+  0: The total amount of wall time                        = 259.548920
+  0: The maximum resident set size (KB)                   = 901104
 
 Test 090 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_flake_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.292694
-  0: The maximum resident set size (KB)                   = 901856
+  0: The total amount of wall time                        = 256.182270
+  0: The maximum resident set size (KB)                   = 900468
 
 Test 091 rap_flake_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 424.147837
-  0: The maximum resident set size (KB)                   = 893992
+  0: The total amount of wall time                        = 427.369349
+  0: The maximum resident set size (KB)                   = 897528
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rap_progcld_thompson_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.205998
-  0: The maximum resident set size (KB)                   = 895244
+  0: The total amount of wall time                        = 263.367028
+  0: The maximum resident set size (KB)                   = 901876
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/rrfs_v1beta_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.296874
-  0: The maximum resident set size (KB)                   = 895868
+  0: The total amount of wall time                        = 255.634394
+  0: The maximum resident set size (KB)                   = 897352
 
 Test 094 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_wam_debug
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 276.091305
-  0: The maximum resident set size (KB)                   = 251972
+  0: The total amount of wall time                        = 276.821741
+  0: The maximum resident set size (KB)                   = 248508
 
 Test 095 control_wam_debug PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 272.430748
-  0: The maximum resident set size (KB)                   = 694884
+  0: The total amount of wall time                        = 275.130735
+  0: The maximum resident set size (KB)                   = 706960
 
 Test 096 hafs_regional_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 326.460695
-  0: The maximum resident set size (KB)                   = 1055108
+  0: The total amount of wall time                        = 321.450445
+  0: The maximum resident set size (KB)                   = 1056348
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_atm_ocn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2859,28 +2859,28 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 359.181968
-  0: The maximum resident set size (KB)                   = 720712
+  0: The total amount of wall time                        = 366.933027
+  0: The maximum resident set size (KB)                   = 717584
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_atm_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 831.180454
-  0: The maximum resident set size (KB)                   = 715064
+  0: The total amount of wall time                        = 866.086307
+  0: The maximum resident set size (KB)                   = 715076
 
 Test 099 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_atm_ocn_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2889,58 +2889,58 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 923.087883
-  0: The maximum resident set size (KB)                   = 719308
+  0: The total amount of wall time                        = 951.000761
+  0: The maximum resident set size (KB)                   = 719984
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 417.181573
-  0: The maximum resident set size (KB)                   = 307768
+  0: The total amount of wall time                        = 413.162610
+  0: The maximum resident set size (KB)                   = 309144
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
- Comparing sfc.nest03.f006.nc .........OK
+ Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 427.655725
-  0: The maximum resident set size (KB)                   = 319372
+  0: The total amount of wall time                        = 442.861812
+  0: The maximum resident set size (KB)                   = 321092
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_global_1nest_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 193.780519
-  0: The maximum resident set size (KB)                   = 198632
+  0: The total amount of wall time                        = 193.295272
+  0: The maximum resident set size (KB)                   = 197664
 
 Test 103 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_global_multiple_4nests_atm
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2953,14 +2953,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 531.897534
-  0: The maximum resident set size (KB)                   = 269892
+  0: The total amount of wall time                        = 529.210878
+  0: The maximum resident set size (KB)                   = 270348
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_docn
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2968,14 +2968,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 342.435398
-  0: The maximum resident set size (KB)                   = 714132
+  0: The total amount of wall time                        = 350.253716
+  0: The maximum resident set size (KB)                   = 715408
 
 Test 105 hafs_regional_docn PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_docn_oisst
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2983,105 +2983,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 346.823320
-  0: The maximum resident set size (KB)                   = 716980
+  0: The total amount of wall time                        = 350.341911
+  0: The maximum resident set size (KB)                   = 718736
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/hafs_regional_datm_cdeps
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 943.160934
-  0: The maximum resident set size (KB)                   = 852736
+  0: The total amount of wall time                        = 946.591552
+  0: The maximum resident set size (KB)                   = 851916
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_control_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.647787
- 0: The maximum resident set size (KB)                   = 719716
+ 0: The total amount of wall time                        = 140.094684
+ 0: The maximum resident set size (KB)                   = 719704
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_restart_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 91.285592
- 0: The maximum resident set size (KB)                   = 719088
+ 0: The total amount of wall time                        = 94.763088
+ 0: The maximum resident set size (KB)                   = 719568
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_control_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.456054
- 0: The maximum resident set size (KB)                   = 621476
+ 0: The total amount of wall time                        = 137.681801
+ 0: The maximum resident set size (KB)                   = 622516
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_stochy_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.399193
- 0: The maximum resident set size (KB)                   = 620892
+ 0: The total amount of wall time                        = 139.270731
+ 0: The maximum resident set size (KB)                   = 620248
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_bulk_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.434752
- 0: The maximum resident set size (KB)                   = 719028
+ 0: The total amount of wall time                        = 141.414221
+ 0: The maximum resident set size (KB)                   = 738876
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_bulk_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.073300
- 0: The maximum resident set size (KB)                   = 620616
+ 0: The total amount of wall time                        = 138.383719
+ 0: The maximum resident set size (KB)                   = 618904
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_mx025_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3090,14 +3090,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 304.097166
-  0: The maximum resident set size (KB)                   = 561684
+  0: The total amount of wall time                        = 302.874651
+  0: The maximum resident set size (KB)                   = 569448
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_mx025_gefs
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,51 +3106,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 296.927334
-  0: The maximum resident set size (KB)                   = 527972
+  0: The total amount of wall time                        = 304.501556
+  0: The maximum resident set size (KB)                   = 536564
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.702584
- 0: The maximum resident set size (KB)                   = 739516
+ 0: The total amount of wall time                        = 140.669241
+ 0: The maximum resident set size (KB)                   = 719720
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 191.254803
- 0: The maximum resident set size (KB)                   = 1834556
+ 0: The total amount of wall time                        = 190.535720
+ 0: The maximum resident set size (KB)                   = 1835212
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/datm_cdeps_debug_cfsr
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 442.147802
- 0: The maximum resident set size (KB)                   = 725224
+ 0: The total amount of wall time                        = 451.176329
+ 0: The maximum resident set size (KB)                   = 724920
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_atmwav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3194,14 +3194,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 77.383754
-  0: The maximum resident set size (KB)                   = 493372
+  0: The total amount of wall time                        = 81.982290
+  0: The maximum resident set size (KB)                   = 496272
 
 Test 119 control_atmwav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_c384gdas_wav
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3247,14 +3247,14 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 703.695166
-  0: The maximum resident set size (KB)                   = 1039288
+  0: The total amount of wall time                        = 703.590722
+  0: The maximum resident set size (KB)                   = 1044940
 
 Test 120 control_c384gdas_wav PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_26860/control_atm_aerosols
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_atm_aerosols
 Checking test 121 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3301,12 +3301,12 @@ Checking test 121 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 276.838273
-  0: The maximum resident set size (KB)                   = 900072
+  0: The total amount of wall time                        = 279.059002
+  0: The maximum resident set size (KB)                   = 900824
 
 Test 121 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 17:10:58 UTC 2022
-Elapsed time: 00h:59m:58s. Have a nice day!
+Tue Feb 15 20:45:19 UTC 2022
+Elapsed time: 00h:59m:00s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,23 +1,23 @@
-Mon Feb 14 17:02:51 GMT 2022
+Tue Feb 15 23:08:29 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1689 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 221 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1536 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 1513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1574 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 830 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 237 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 1694 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 223 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1550 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 1521 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 828 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 233 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 008 elapsed time 229 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1574 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1568 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 274 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 009 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1568 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1567 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 273 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
 Compile 013 elapsed time 121 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 1509 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1504 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 289.020888
-  0: The maximum resident set size (KB)                   = 606808
+  0: The total amount of wall time                        = 287.537434
+  0: The maximum resident set size (KB)                   = 599480
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 911.618702
-  0: The maximum resident set size (KB)                   = 668676
+  0: The total amount of wall time                        = 850.182065
+  0: The maximum resident set size (KB)                   = 668516
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_mpi_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_mpi_p8
 Checking test 003 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 249.082175
-  0: The maximum resident set size (KB)                   = 597944
+  0: The total amount of wall time                        = 250.412408
+  0: The maximum resident set size (KB)                   = 595328
 
 Test 003 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_control_p7_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_p7_rrtmgp
 Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 329.702774
-  0: The maximum resident set size (KB)                   = 703316
+  0: The total amount of wall time                        = 332.556963
+  0: The maximum resident set size (KB)                   = 704512
 
 Test 004 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_bmark_p7
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_p7
 Checking test 005 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -314,14 +314,14 @@ Checking test 005 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1158.677993
-  0: The maximum resident set size (KB)                   = 1369428
+  0: The total amount of wall time                        = 1156.445259
+  0: The maximum resident set size (KB)                   = 1367492
 
 Test 005 cpld_bmark_p7 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_bmark_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_p8
 Checking test 006 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -366,14 +366,14 @@ Checking test 006 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1157.280066
-  0: The maximum resident set size (KB)                   = 1367116
+  0: The total amount of wall time                        = 1154.424777
+  0: The maximum resident set size (KB)                   = 1368652
 
 Test 006 cpld_bmark_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_bmark_mpi_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_mpi_p8
 Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -418,14 +418,14 @@ Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1143.439567
-  0: The maximum resident set size (KB)                   = 1365892
+  0: The total amount of wall time                        = 1143.578481
+  0: The maximum resident set size (KB)                   = 1368128
 
 Test 007 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_control_c96_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c96_p8
 Checking test 008 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -487,14 +487,14 @@ Checking test 008 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 281.500804
-  0: The maximum resident set size (KB)                   = 593048
+  0: The total amount of wall time                        = 281.752821
+  0: The maximum resident set size (KB)                   = 593292
 
 Test 008 cpld_control_c96_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_restart_c96_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c96_p8
 Checking test 009 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -544,14 +544,14 @@ Checking test 009 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 155.396063
-  0: The maximum resident set size (KB)                   = 352820
+  0: The total amount of wall time                        = 156.183674
+  0: The maximum resident set size (KB)                   = 351852
 
 Test 009 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_control_c192_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -601,14 +601,14 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1197.292933
-  0: The maximum resident set size (KB)                   = 785436
+  0: The total amount of wall time                        = 1191.642790
+  0: The maximum resident set size (KB)                   = 785936
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_restart_c192_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -658,14 +658,14 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 754.779374
-  0: The maximum resident set size (KB)                   = 886904
+  0: The total amount of wall time                        = 745.946772
+  0: The maximum resident set size (KB)                   = 886608
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_control_c384_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c384_p8
 Checking test 012 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -708,14 +708,14 @@ Checking test 012 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1320.979548
-  0: The maximum resident set size (KB)                   = 1335540
+  0: The total amount of wall time                        = 1322.755919
+  0: The maximum resident set size (KB)                   = 1338152
 
 Test 012 cpld_control_c384_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_restart_c384_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c384_p8
 Checking test 013 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -758,14 +758,14 @@ Checking test 013 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 720.380618
-  0: The maximum resident set size (KB)                   = 1293684
+  0: The total amount of wall time                        = 715.778780
+  0: The maximum resident set size (KB)                   = 1293564
 
 Test 013 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/cpld_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -815,14 +815,14 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 799.999887
-  0: The maximum resident set size (KB)                   = 644456
+  0: The total amount of wall time                        = 799.151252
+  0: The maximum resident set size (KB)                   = 645616
 
 Test 014 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -869,14 +869,14 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.345135
-  0: The maximum resident set size (KB)                   = 481136
+  0: The total amount of wall time                        = 168.568770
+  0: The maximum resident set size (KB)                   = 483568
 
 Test 015 control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_decomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -919,28 +919,28 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.473586
-  0: The maximum resident set size (KB)                   = 480332
+  0: The total amount of wall time                        = 172.603810
+  0: The maximum resident set size (KB)                   = 484460
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2dwrtdecomp
 Checking test 017 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 157.240391
-  0: The maximum resident set size (KB)                   = 480084
+  0: The total amount of wall time                        = 157.579583
+  0: The maximum resident set size (KB)                   = 479888
 
 Test 017 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_2threads
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -983,14 +983,14 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 878.604733
- 0: The maximum resident set size (KB)                   = 522748
+ 0: The total amount of wall time                        = 741.362627
+ 0: The maximum resident set size (KB)                   = 529228
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1029,14 +1029,14 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 89.637528
-  0: The maximum resident set size (KB)                   = 220872
+  0: The total amount of wall time                        = 90.526641
+  0: The maximum resident set size (KB)                   = 219504
 
 Test 019 control_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_fhzero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1079,14 +1079,14 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.113015
-  0: The maximum resident set size (KB)                   = 480104
+  0: The total amount of wall time                        = 156.166924
+  0: The maximum resident set size (KB)                   = 478524
 
 Test 020 control_fhzero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_CubedSphereGrid
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,14 +1113,14 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.489668
-  0: The maximum resident set size (KB)                   = 477712
+  0: The total amount of wall time                        = 157.717925
+  0: The maximum resident set size (KB)                   = 476668
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_latlon
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_latlon
 Checking test 022 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1131,14 +1131,14 @@ Checking test 022 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 162.068661
-  0: The maximum resident set size (KB)                   = 480028
+  0: The total amount of wall time                        = 163.647894
+  0: The maximum resident set size (KB)                   = 478892
 
 Test 022 control_latlon PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1149,14 +1149,14 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.175006
-  0: The maximum resident set size (KB)                   = 481656
+  0: The total amount of wall time                        = 164.769911
+  0: The maximum resident set size (KB)                   = 476268
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_c48
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1195,14 +1195,14 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 534.235668
-0: The maximum resident set size (KB)                   = 662320
+0: The total amount of wall time                        = 535.037076
+0: The maximum resident set size (KB)                   = 665588
 
 Test 024 control_c48 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1213,14 +1213,14 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 639.241006
-  0: The maximum resident set size (KB)                   = 584372
+  0: The total amount of wall time                        = 643.971257
+  0: The maximum resident set size (KB)                   = 585596
 
 Test 025 control_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_c384
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1231,14 +1231,14 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 802.452421
-  0: The maximum resident set size (KB)                   = 755876
+  0: The total amount of wall time                        = 799.550167
+  0: The maximum resident set size (KB)                   = 752768
 
 Test 026 control_c384 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_c384gdas
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1281,14 +1281,14 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 735.096081
-  0: The maximum resident set size (KB)                   = 843092
+  0: The total amount of wall time                        = 746.475032
+  0: The maximum resident set size (KB)                   = 842540
 
 Test 027 control_c384gdas PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_stochy
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1299,28 +1299,28 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 109.951283
-  0: The maximum resident set size (KB)                   = 481888
+  0: The total amount of wall time                        = 108.317093
+  0: The maximum resident set size (KB)                   = 482408
 
 Test 028 control_stochy PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_stochy_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 61.361935
-  0: The maximum resident set size (KB)                   = 244124
+  0: The total amount of wall time                        = 61.446534
+  0: The maximum resident set size (KB)                   = 241280
 
 Test 029 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_lndp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1331,14 +1331,14 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 97.975719
-  0: The maximum resident set size (KB)                   = 479500
+  0: The total amount of wall time                        = 99.721761
+  0: The maximum resident set size (KB)                   = 482356
 
 Test 030 control_lndp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_iovr4
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_iovr4
 Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 031 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.794452
-  0: The maximum resident set size (KB)                   = 473340
+  0: The total amount of wall time                        = 166.357026
+  0: The maximum resident set size (KB)                   = 480828
 
 Test 031 control_iovr4 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_iovr5
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_iovr5
 Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1375,14 +1375,14 @@ Checking test 032 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.846217
-  0: The maximum resident set size (KB)                   = 476276
+  0: The total amount of wall time                        = 166.812480
+  0: The maximum resident set size (KB)                   = 479468
 
 Test 032 control_iovr5 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_p8
 Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1429,14 +1429,14 @@ Checking test 033 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 186.518382
-  0: The maximum resident set size (KB)                   = 506024
+  0: The total amount of wall time                        = 187.348967
+  0: The maximum resident set size (KB)                   = 506028
 
 Test 033 control_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_restart_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_restart_p8
 Checking test 034 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1475,14 +1475,14 @@ Checking test 034 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 102.271164
-  0: The maximum resident set size (KB)                   = 289928
+  0: The total amount of wall time                        = 102.374673
+  0: The maximum resident set size (KB)                   = 291884
 
 Test 034 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_decomp_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_decomp_p8
 Checking test 035 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1525,14 +1525,14 @@ Checking test 035 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.788184
-  0: The maximum resident set size (KB)                   = 498224
+  0: The total amount of wall time                        = 191.866907
+  0: The maximum resident set size (KB)                   = 498832
 
 Test 035 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_2threads_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads_p8
 Checking test 036 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1575,14 +1575,14 @@ Checking test 036 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 825.248538
- 0: The maximum resident set size (KB)                   = 574072
+ 0: The total amount of wall time                        = 882.494034
+ 0: The maximum resident set size (KB)                   = 573868
 
 Test 036 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_p7_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_p7_rrtmgp
 Checking test 037 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1629,14 +1629,14 @@ Checking test 037 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.727623
-  0: The maximum resident set size (KB)                   = 599096
+  0: The total amount of wall time                        = 231.710208
+  0: The maximum resident set size (KB)                   = 604940
 
 Test 037 control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_control
 Checking test 038 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1647,42 +1647,42 @@ Checking test 038 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 414.285501
- 0: The maximum resident set size (KB)                   = 587744
+ 0: The total amount of wall time                        = 413.136845
+ 0: The maximum resident set size (KB)                   = 586992
 
 Test 038 regional_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_restart
 Checking test 039 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 230.560397
- 0: The maximum resident set size (KB)                   = 584392
+ 0: The total amount of wall time                        = 229.512172
+ 0: The maximum resident set size (KB)                   = 586228
 
 Test 039 regional_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_control_2dwrtdecomp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_control_2dwrtdecomp
 Checking test 040 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 410.593854
- 0: The maximum resident set size (KB)                   = 585016
+ 0: The total amount of wall time                        = 412.450230
+ 0: The maximum resident set size (KB)                   = 583476
 
 Test 040 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_noquilt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_noquilt
 Checking test 041 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 041 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 439.324903
- 0: The maximum resident set size (KB)                   = 594260
+ 0: The total amount of wall time                        = 438.047574
+ 0: The maximum resident set size (KB)                   = 594116
 
 Test 041 regional_noquilt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_hafs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_hafs
 Checking test 042 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1706,28 +1706,28 @@ Checking test 042 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 406.186993
- 0: The maximum resident set size (KB)                   = 587736
+ 0: The total amount of wall time                        = 410.665038
+ 0: The maximum resident set size (KB)                   = 592916
 
 Test 042 regional_hafs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_netcdf_parallel
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_netcdf_parallel
 Checking test 043 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 408.571903
- 0: The maximum resident set size (KB)                   = 592560
+ 0: The total amount of wall time                        = 411.499997
+ 0: The maximum resident set size (KB)                   = 581896
 
 Test 043 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_RRTMGP
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_RRTMGP
 Checking test 044 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1738,14 +1738,14 @@ Checking test 044 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 516.046180
- 0: The maximum resident set size (KB)                   = 710116
+ 0: The total amount of wall time                        = 518.501952
+ 0: The maximum resident set size (KB)                   = 713388
 
 Test 044 regional_RRTMGP PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_control
 Checking test 045 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1792,14 +1792,14 @@ Checking test 045 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.850915
-  0: The maximum resident set size (KB)                   = 844064
+  0: The total amount of wall time                        = 460.031430
+  0: The maximum resident set size (KB)                   = 844192
 
 Test 045 rap_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_restart
 Checking test 046 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1838,14 +1838,14 @@ Checking test 046 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 237.307292
-  0: The maximum resident set size (KB)                   = 590596
+  0: The total amount of wall time                        = 238.742098
+  0: The maximum resident set size (KB)                   = 591264
 
 Test 046 rap_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_sfcdiff
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff
 Checking test 047 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1892,14 +1892,14 @@ Checking test 047 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.917480
-  0: The maximum resident set size (KB)                   = 844540
+  0: The total amount of wall time                        = 465.527081
+  0: The maximum resident set size (KB)                   = 849380
 
 Test 047 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_sfcdiff_restart
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff_restart
 Checking test 048 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1938,14 +1938,14 @@ Checking test 048 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.201027
-  0: The maximum resident set size (KB)                   = 591856
+  0: The total amount of wall time                        = 238.739240
+  0: The maximum resident set size (KB)                   = 593724
 
 Test 048 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hrrr_control
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hrrr_control
 Checking test 049 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1992,14 +1992,14 @@ Checking test 049 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 442.770889
-  0: The maximum resident set size (KB)                   = 842372
+  0: The total amount of wall time                        = 449.699345
+  0: The maximum resident set size (KB)                   = 846120
 
 Test 049 hrrr_control PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rrfs_v1beta
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_v1beta
 Checking test 050 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2046,14 +2046,14 @@ Checking test 050 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.310522
-  0: The maximum resident set size (KB)                   = 837724
+  0: The total amount of wall time                        = 461.657812
+  0: The maximum resident set size (KB)                   = 843752
 
 Test 050 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_conus13km_hrrr_warm
 Checking test 051 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2062,14 +2062,14 @@ Checking test 051 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 213.341532
-  0: The maximum resident set size (KB)                   = 691244
+  0: The total amount of wall time                        = 213.051039
+  0: The maximum resident set size (KB)                   = 692616
 
 Test 051 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_conus13km_radar_tten_warm
 Checking test 052 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2078,14 +2078,14 @@ Checking test 052 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 212.369442
-  0: The maximum resident set size (KB)                   = 691736
+  0: The total amount of wall time                        = 214.655281
+  0: The maximum resident set size (KB)                   = 693856
 
 Test 052 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_rrtmgp
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp
 Checking test 053 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2096,14 +2096,14 @@ Checking test 053 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 250.070215
-  0: The maximum resident set size (KB)                   = 596824
+  0: The total amount of wall time                        = 250.787878
+  0: The maximum resident set size (KB)                   = 597644
 
 Test 053 control_rrtmgp PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_rrtmgp_c192
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp_c192
 Checking test 054 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2114,14 +2114,14 @@ Checking test 054 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 686.823443
-  0: The maximum resident set size (KB)                   = 806912
+  0: The total amount of wall time                        = 687.422961
+  0: The maximum resident set size (KB)                   = 805624
 
 Test 054 control_rrtmgp_c192 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_csawmg
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmg
 Checking test 055 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 055 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 418.133567
-  0: The maximum resident set size (KB)                   = 536556
+  0: The total amount of wall time                        = 419.219626
+  0: The maximum resident set size (KB)                   = 535724
 
 Test 055 control_csawmg PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_csawmgt
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmgt
 Checking test 056 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2150,14 +2150,14 @@ Checking test 056 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 411.571632
-  0: The maximum resident set size (KB)                   = 538340
+  0: The total amount of wall time                        = 412.567280
+  0: The maximum resident set size (KB)                   = 537088
 
 Test 056 control_csawmgt PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_flake
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_flake
 Checking test 057 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2168,14 +2168,14 @@ Checking test 057 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 276.327247
-  0: The maximum resident set size (KB)                   = 548748
+  0: The total amount of wall time                        = 276.445136
+  0: The maximum resident set size (KB)                   = 547340
 
 Test 057 control_flake PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_ras
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_ras
 Checking test 058 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 058 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 223.927815
-  0: The maximum resident set size (KB)                   = 509440
+  0: The total amount of wall time                        = 224.931886
+  0: The maximum resident set size (KB)                   = 508824
 
 Test 058 control_ras PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson
 Checking test 059 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2204,14 +2204,14 @@ Checking test 059 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 278.858186
-  0: The maximum resident set size (KB)                   = 859696
+  0: The total amount of wall time                        = 278.052867
+  0: The maximum resident set size (KB)                   = 861924
 
 Test 059 control_thompson PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson_no_aero
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_no_aero
 Checking test 060 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2222,54 +2222,54 @@ Checking test 060 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 268.920858
-  0: The maximum resident set size (KB)                   = 856012
+  0: The total amount of wall time                        = 267.232408
+  0: The maximum resident set size (KB)                   = 854868
 
 Test 060 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_repro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_wam_repro
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wam_repro
 Checking test 061 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 148.484345
-  0: The maximum resident set size (KB)                   = 236360
+  0: The total amount of wall time                        = 148.641721
+  0: The maximum resident set size (KB)                   = 238188
 
 Test 061 control_wam PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_debug
 Checking test 062 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.307604
-  0: The maximum resident set size (KB)                   = 539708
+  0: The total amount of wall time                        = 188.084606
+  0: The maximum resident set size (KB)                   = 539536
 
 Test 062 control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_2threads_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads_debug
 Checking test 063 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 360.815651
- 0: The maximum resident set size (KB)                   = 587892
+ 0: The total amount of wall time                        = 358.384775
+ 0: The maximum resident set size (KB)                   = 591816
 
 Test 063 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_CubedSphereGrid_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_CubedSphereGrid_debug
 Checking test 064 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2296,428 +2296,428 @@ Checking test 064 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.333335
-  0: The maximum resident set size (KB)                   = 547096
+  0: The total amount of wall time                        = 204.805348
+  0: The maximum resident set size (KB)                   = 538548
 
 Test 064 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wrtGauss_netcdf_parallel_debug
 Checking test 065 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.020153
-  0: The maximum resident set size (KB)                   = 540940
+  0: The total amount of wall time                        = 192.213611
+  0: The maximum resident set size (KB)                   = 543400
 
 Test 065 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_stochy_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy_debug
 Checking test 066 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 215.616992
-  0: The maximum resident set size (KB)                   = 554864
+  0: The total amount of wall time                        = 217.253974
+  0: The maximum resident set size (KB)                   = 543216
 
 Test 066 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_lndp_debug
 Checking test 067 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 196.495995
-  0: The maximum resident set size (KB)                   = 545228
+  0: The total amount of wall time                        = 194.770881
+  0: The maximum resident set size (KB)                   = 546576
 
 Test 067 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp_debug
 Checking test 068 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 209.421337
-  0: The maximum resident set size (KB)                   = 640580
+  0: The total amount of wall time                        = 209.945333
+  0: The maximum resident set size (KB)                   = 638336
 
 Test 068 control_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_csawmg_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmg_debug
 Checking test 069 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 305.043702
-  0: The maximum resident set size (KB)                   = 579276
+  0: The total amount of wall time                        = 302.284641
+  0: The maximum resident set size (KB)                   = 576368
 
 Test 069 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_csawmgt_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmgt_debug
 Checking test 070 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.388803
-  0: The maximum resident set size (KB)                   = 572640
+  0: The total amount of wall time                        = 299.923767
+  0: The maximum resident set size (KB)                   = 575244
 
 Test 070 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_ras_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.370757
-  0: The maximum resident set size (KB)                   = 550188
+  0: The total amount of wall time                        = 194.938391
+  0: The maximum resident set size (KB)                   = 557584
 
 Test 071 control_ras_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 203.572931
-  0: The maximum resident set size (KB)                   = 597040
+  0: The total amount of wall time                        = 201.365865
+  0: The maximum resident set size (KB)                   = 597396
 
 Test 072 control_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_debug_p8
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_debug_p8
 Checking test 073 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 206.967665
-  0: The maximum resident set size (KB)                   = 558328
+  0: The total amount of wall time                        = 207.890511
+  0: The maximum resident set size (KB)                   = 557768
 
 Test 073 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 222.091918
-  0: The maximum resident set size (KB)                   = 901492
+  0: The total amount of wall time                        = 222.745665
+  0: The maximum resident set size (KB)                   = 900056
 
 Test 074 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson_no_aero_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 215.661057
-  0: The maximum resident set size (KB)                   = 897720
+  0: The total amount of wall time                        = 214.308171
+  0: The maximum resident set size (KB)                   = 900132
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson_extdiag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 235.607460
-  0: The maximum resident set size (KB)                   = 932544
+  0: The total amount of wall time                        = 234.118404
+  0: The maximum resident set size (KB)                   = 932852
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_thompson_progcld_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_progcld_thompson_debug
 Checking test 077 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 223.862088
-  0: The maximum resident set size (KB)                   = 902976
+  0: The total amount of wall time                        = 221.990753
+  0: The maximum resident set size (KB)                   = 899824
 
 Test 077 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/regional_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_debug
 Checking test 078 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 321.011949
- 0: The maximum resident set size (KB)                   = 611140
+ 0: The total amount of wall time                        = 320.677425
+ 0: The maximum resident set size (KB)                   = 616552
 
 Test 078 regional_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_control_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_control_debug
 Checking test 079 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.378453
-  0: The maximum resident set size (KB)                   = 910348
+  0: The total amount of wall time                        = 342.418090
+  0: The maximum resident set size (KB)                   = 908656
 
 Test 079 rap_control_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_unified_drag_suite_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_unified_drag_suite_debug
 Checking test 080 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.926756
-  0: The maximum resident set size (KB)                   = 908316
+  0: The total amount of wall time                        = 342.639697
+  0: The maximum resident set size (KB)                   = 905864
 
 Test 080 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_diag_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_diag_debug
 Checking test 081 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.305164
-  0: The maximum resident set size (KB)                   = 993860
+  0: The total amount of wall time                        = 364.101000
+  0: The maximum resident set size (KB)                   = 991736
 
 Test 081 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_cires_ugwp_debug
 Checking test 082 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.290142
-  0: The maximum resident set size (KB)                   = 906092
+  0: The total amount of wall time                        = 350.317857
+  0: The maximum resident set size (KB)                   = 912212
 
 Test 082 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_unified_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_unified_ugwp_debug
 Checking test 083 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.803753
-  0: The maximum resident set size (KB)                   = 909048
+  0: The total amount of wall time                        = 351.239030
+  0: The maximum resident set size (KB)                   = 911600
 
 Test 083 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_noah_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_noah_debug
 Checking test 084 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 337.938229
-  0: The maximum resident set size (KB)                   = 907176
+  0: The total amount of wall time                        = 338.517879
+  0: The maximum resident set size (KB)                   = 908444
 
 Test 084 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_rrtmgp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_rrtmgp_debug
 Checking test 085 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 583.544795
-  0: The maximum resident set size (KB)                   = 1015972
+  0: The total amount of wall time                        = 583.846268
+  0: The maximum resident set size (KB)                   = 1007140
 
 Test 085 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_lndp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.005925
-  0: The maximum resident set size (KB)                   = 908380
+  0: The total amount of wall time                        = 345.438342
+  0: The maximum resident set size (KB)                   = 909412
 
 Test 086 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_sfcdiff_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff_debug
 Checking test 087 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.257154
-  0: The maximum resident set size (KB)                   = 915104
+  0: The total amount of wall time                        = 342.678667
+  0: The maximum resident set size (KB)                   = 910424
 
 Test 087 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_flake_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_flake_debug
 Checking test 088 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.044806
-  0: The maximum resident set size (KB)                   = 906140
+  0: The total amount of wall time                        = 344.691838
+  0: The maximum resident set size (KB)                   = 909552
 
 Test 088 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 089 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 570.593627
-  0: The maximum resident set size (KB)                   = 904444
+  0: The total amount of wall time                        = 570.525723
+  0: The maximum resident set size (KB)                   = 905892
 
 Test 089 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rap_progcld_thompson_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_progcld_thompson_debug
 Checking test 090 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.165024
-  0: The maximum resident set size (KB)                   = 905792
+  0: The total amount of wall time                        = 342.606229
+  0: The maximum resident set size (KB)                   = 905776
 
 Test 090 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/rrfs_v1beta_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_v1beta_debug
 Checking test 091 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 341.831793
-  0: The maximum resident set size (KB)                   = 906912
+  0: The total amount of wall time                        = 342.462510
+  0: The maximum resident set size (KB)                   = 906852
 
 Test 091 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_wam_debug
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wam_debug
 Checking test 092 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 366.003316
-  0: The maximum resident set size (KB)                   = 259784
+  0: The total amount of wall time                        = 365.517252
+  0: The maximum resident set size (KB)                   = 260668
 
 Test 092 control_wam_debug PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_atm
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm
 Checking test 093 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1025.803864
-  0: The maximum resident set size (KB)                   = 793872
+  0: The total amount of wall time                        = 1058.151958
+  0: The maximum resident set size (KB)                   = 803096
 
 Test 093 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_thompson_gfdlsf
 Checking test 094 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 1176.118664
-  0: The maximum resident set size (KB)                   = 1151136
+  0: The total amount of wall time                        = 1149.722170
+  0: The maximum resident set size (KB)                   = 1145192
 
 Test 094 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_atm_ocn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_ocn
 Checking test 095 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2726,28 +2726,28 @@ Checking test 095 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 454.655065
-  0: The maximum resident set size (KB)                   = 816640
+  0: The total amount of wall time                        = 453.174536
+  0: The maximum resident set size (KB)                   = 813800
 
 Test 095 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_atm_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_wav
 Checking test 096 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 926.711557
-  0: The maximum resident set size (KB)                   = 816236
+  0: The total amount of wall time                        = 914.520666
+  0: The maximum resident set size (KB)                   = 819268
 
 Test 096 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_ocn_wav
 Checking test 097 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2756,29 +2756,29 @@ Checking test 097 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1021.606109
-  0: The maximum resident set size (KB)                   = 820500
+  0: The total amount of wall time                        = 1031.739883
+  0: The maximum resident set size (KB)                   = 813272
 
 Test 097 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_docn
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_docn
 Checking test 098 hafs_regional_docn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 438.224711
-  0: The maximum resident set size (KB)                   = 816136
+  0: The total amount of wall time                        = 440.198005
+  0: The maximum resident set size (KB)                   = 817244
 
 Test 098 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_docn_oisst
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_docn_oisst
 Checking test 099 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2786,105 +2786,105 @@ Checking test 099 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 439.008634
-  0: The maximum resident set size (KB)                   = 818784
+  0: The total amount of wall time                        = 438.378216
+  0: The maximum resident set size (KB)                   = 818636
 
 Test 099 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/hafs_regional_datm_cdeps
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_datm_cdeps
 Checking test 100 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1216.328934
-  0: The maximum resident set size (KB)                   = 858940
+  0: The total amount of wall time                        = 1218.944838
+  0: The maximum resident set size (KB)                   = 858084
 
 Test 100 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_control_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_control_cfsr
 Checking test 101 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.462508
- 0: The maximum resident set size (KB)                   = 727132
+ 0: The total amount of wall time                        = 193.409926
+ 0: The maximum resident set size (KB)                   = 727952
 
 Test 101 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_restart_cfsr
 Checking test 102 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 117.971187
- 0: The maximum resident set size (KB)                   = 725340
+ 0: The total amount of wall time                        = 116.575107
+ 0: The maximum resident set size (KB)                   = 725680
 
 Test 102 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_control_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_control_gefs
 Checking test 103 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.997563
- 0: The maximum resident set size (KB)                   = 626636
+ 0: The total amount of wall time                        = 190.162015
+ 0: The maximum resident set size (KB)                   = 628464
 
 Test 103 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_stochy_gefs
 Checking test 104 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.334153
- 0: The maximum resident set size (KB)                   = 629820
+ 0: The total amount of wall time                        = 193.115683
+ 0: The maximum resident set size (KB)                   = 627708
 
 Test 104 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_bulk_cfsr
 Checking test 105 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.764230
- 0: The maximum resident set size (KB)                   = 727216
+ 0: The total amount of wall time                        = 194.530453
+ 0: The maximum resident set size (KB)                   = 726392
 
 Test 105 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_bulk_gefs
 Checking test 106 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.616845
- 0: The maximum resident set size (KB)                   = 627028
+ 0: The total amount of wall time                        = 189.205731
+ 0: The maximum resident set size (KB)                   = 625268
 
 Test 106 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_mx025_cfsr
 Checking test 107 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2893,14 +2893,14 @@ Checking test 107 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 406.098107
-  0: The maximum resident set size (KB)                   = 607476
+  0: The total amount of wall time                        = 416.154362
+  0: The maximum resident set size (KB)                   = 590856
 
 Test 107 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_mx025_gefs
 Checking test 108 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2909,51 +2909,51 @@ Checking test 108 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 403.817134
-  0: The maximum resident set size (KB)                   = 562228
+  0: The total amount of wall time                        = 402.960870
+  0: The maximum resident set size (KB)                   = 564612
 
 Test 108 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_multiple_files_cfsr
 Checking test 109 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.751469
- 0: The maximum resident set size (KB)                   = 725488
+ 0: The total amount of wall time                        = 194.205364
+ 0: The maximum resident set size (KB)                   = 727760
 
 Test 109 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_3072x1536_cfsr
 Checking test 110 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 271.326329
- 0: The maximum resident set size (KB)                   = 1839636
+ 0: The total amount of wall time                        = 267.315270
+ 0: The maximum resident set size (KB)                   = 1839800
 
 Test 110 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_debug_cfsr
 Checking test 111 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 570.876406
- 0: The maximum resident set size (KB)                   = 731084
+ 0: The total amount of wall time                        = 569.141297
+ 0: The maximum resident set size (KB)                   = 732256
 
 Test 111 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_12562/control_atmwav
+baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_atmwav
 Checking test 112 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2997,12 +2997,12 @@ Checking test 112 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 109.794508
-  0: The maximum resident set size (KB)                   = 521584
+  0: The total amount of wall time                        = 110.766014
+  0: The maximum resident set size (KB)                   = 523360
 
 Test 112 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 19:04:15 GMT 2022
-Elapsed time: 02h:01m:25s. Have a nice day!
+Wed Feb 16 01:47:31 GMT 2022
+Elapsed time: 02h:39m:03s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,23 +1,23 @@
-Mon Feb 14 15:47:15 CST 2022
+Tue Feb 15 16:32:26 CST 2022
 Start Regression test
 
-Compile 001 elapsed time 667 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 213 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 532 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 530 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 570 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 492 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 218 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 613 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 433 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 245 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 114 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 566 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 497 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 179 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 465 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 386 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 378 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 182 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 176 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 142 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 432 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 434 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 190 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 96 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 394 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 214.132001
-  0: The maximum resident set size (KB)                   = 642972
+  0: The total amount of wall time                        = 212.264174
+  0: The maximum resident set size (KB)                   = 643836
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 240.623525
-  0: The maximum resident set size (KB)                   = 694296
+  0: The total amount of wall time                        = 241.282786
+  0: The maximum resident set size (KB)                   = 691560
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 212.882065
-  0: The maximum resident set size (KB)                   = 642068
+  0: The total amount of wall time                        = 213.688946
+  0: The maximum resident set size (KB)                   = 642800
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 186.227129
-  0: The maximum resident set size (KB)                   = 648340
+  0: The total amount of wall time                        = 185.519115
+  0: The maximum resident set size (KB)                   = 649044
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_control_p7_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 249.080093
-  0: The maximum resident set size (KB)                   = 740616
+  0: The total amount of wall time                        = 248.012750
+  0: The maximum resident set size (KB)                   = 743184
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_bmark_p7
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 875.844273
-  0: The maximum resident set size (KB)                   = 1470436
+  0: The total amount of wall time                        = 889.749692
+  0: The maximum resident set size (KB)                   = 1470324
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_bmark_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 872.302418
-  0: The maximum resident set size (KB)                   = 1473536
+  0: The total amount of wall time                        = 883.328460
+  0: The maximum resident set size (KB)                   = 1468240
 
 Test 007 cpld_bmark_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_bmark_mpi_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 866.497818
-  0: The maximum resident set size (KB)                   = 1488320
+  0: The total amount of wall time                        = 861.184317
+  0: The maximum resident set size (KB)                   = 1487304
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_control_c96_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 205.450969
-  0: The maximum resident set size (KB)                   = 631776
+  0: The total amount of wall time                        = 204.140277
+  0: The maximum resident set size (KB)                   = 633092
 
 Test 009 cpld_control_c96_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_restart_c96_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 114.185735
-  0: The maximum resident set size (KB)                   = 390376
+  0: The total amount of wall time                        = 114.237328
+  0: The maximum resident set size (KB)                   = 392420
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_control_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 857.296499
-  0: The maximum resident set size (KB)                   = 847596
+  0: The total amount of wall time                        = 856.173169
+  0: The maximum resident set size (KB)                   = 847996
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_restart_c192_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 575.885147
-  0: The maximum resident set size (KB)                   = 914484
+  0: The total amount of wall time                        = 589.561757
+  0: The maximum resident set size (KB)                   = 914756
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_control_c384_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1016.854651
-  0: The maximum resident set size (KB)                   = 1442632
+  0: The total amount of wall time                        = 1018.116829
+  0: The maximum resident set size (KB)                   = 1435776
 
 Test 013 cpld_control_c384_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_restart_c384_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 559.044564
-  0: The maximum resident set size (KB)                   = 1400720
+  0: The total amount of wall time                        = 551.328401
+  0: The maximum resident set size (KB)                   = 1396276
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/cpld_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 629.522423
-  0: The maximum resident set size (KB)                   = 688928
+  0: The total amount of wall time                        = 632.984667
+  0: The maximum resident set size (KB)                   = 686276
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.442313
-  0: The maximum resident set size (KB)                   = 482096
+  0: The total amount of wall time                        = 120.588474
+  0: The maximum resident set size (KB)                   = 483092
 
 Test 016 control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_decomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.076497
-  0: The maximum resident set size (KB)                   = 484152
+  0: The total amount of wall time                        = 127.810705
+  0: The maximum resident set size (KB)                   = 485596
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 121.645849
-  0: The maximum resident set size (KB)                   = 485804
+  0: The total amount of wall time                        = 114.529986
+  0: The maximum resident set size (KB)                   = 484980
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 142.612098
- 0: The maximum resident set size (KB)                   = 530772
+ 0: The total amount of wall time                        = 146.204093
+ 0: The maximum resident set size (KB)                   = 534052
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 68.678626
-  0: The maximum resident set size (KB)                   = 223792
+  0: The total amount of wall time                        = 65.856529
+  0: The maximum resident set size (KB)                   = 225480
 
 Test 020 control_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_fhzero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.903232
-  0: The maximum resident set size (KB)                   = 483580
+  0: The total amount of wall time                        = 113.902153
+  0: The maximum resident set size (KB)                   = 484240
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_CubedSphereGrid
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.459111
-  0: The maximum resident set size (KB)                   = 482724
+  0: The total amount of wall time                        = 116.975733
+  0: The maximum resident set size (KB)                   = 484220
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_latlon
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,17 +1191,17 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 119.088210
-  0: The maximum resident set size (KB)                   = 485052
+  0: The total amount of wall time                        = 119.713612
+  0: The maximum resident set size (KB)                   = 485952
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_wrtGauss_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 127.426039
-  0: The maximum resident set size (KB)                   = 483700
+  0: The total amount of wall time                        = 121.837351
+  0: The maximum resident set size (KB)                   = 483588
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_c48
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 306.248635
-0: The maximum resident set size (KB)                   = 653116
+0: The total amount of wall time                        = 305.045168
+0: The maximum resident set size (KB)                   = 653552
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 463.572456
-  0: The maximum resident set size (KB)                   = 584608
+  0: The total amount of wall time                        = 459.408769
+  0: The maximum resident set size (KB)                   = 584544
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_c384
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 760.566926
-  0: The maximum resident set size (KB)                   = 883540
+  0: The total amount of wall time                        = 776.299041
+  0: The maximum resident set size (KB)                   = 883464
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_c384gdas
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 687.656637
-  0: The maximum resident set size (KB)                   = 1001132
+  0: The total amount of wall time                        = 660.451381
+  0: The maximum resident set size (KB)                   = 1001060
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_stochy
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 78.194003
-  0: The maximum resident set size (KB)                   = 481160
+  0: The total amount of wall time                        = 79.113992
+  0: The maximum resident set size (KB)                   = 481768
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_stochy_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.085749
-  0: The maximum resident set size (KB)                   = 264532
+  0: The total amount of wall time                        = 45.478994
+  0: The maximum resident set size (KB)                   = 264360
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_lndp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.546097
-  0: The maximum resident set size (KB)                   = 488364
+  0: The total amount of wall time                        = 73.627672
+  0: The maximum resident set size (KB)                   = 489164
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_iovr4
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 120.624622
-  0: The maximum resident set size (KB)                   = 482960
+  0: The total amount of wall time                        = 120.694138
+  0: The maximum resident set size (KB)                   = 481792
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_iovr5
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 120.947054
-  0: The maximum resident set size (KB)                   = 485380
+  0: The total amount of wall time                        = 121.040798
+  0: The maximum resident set size (KB)                   = 484260
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.405912
-  0: The maximum resident set size (KB)                   = 509372
+  0: The total amount of wall time                        = 133.838752
+  0: The maximum resident set size (KB)                   = 505784
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_restart_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 76.014739
-  0: The maximum resident set size (KB)                   = 293016
+  0: The total amount of wall time                        = 74.940431
+  0: The maximum resident set size (KB)                   = 295656
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_decomp_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.379334
-  0: The maximum resident set size (KB)                   = 507540
+  0: The total amount of wall time                        = 141.519225
+  0: The maximum resident set size (KB)                   = 505500
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_2threads_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 161.246588
- 0: The maximum resident set size (KB)                   = 578316
+ 0: The total amount of wall time                        = 165.821777
+ 0: The maximum resident set size (KB)                   = 577292
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_p7_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.349801
-  0: The maximum resident set size (KB)                   = 608692
+  0: The total amount of wall time                        = 170.144966
+  0: The maximum resident set size (KB)                   = 609228
 
 Test 038 control_p7_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 296.532435
- 0: The maximum resident set size (KB)                   = 588932
+ 0: The total amount of wall time                        = 295.827230
+ 0: The maximum resident set size (KB)                   = 584848
 
 Test 039 regional_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 167.130797
- 0: The maximum resident set size (KB)                   = 588844
+ 0: The total amount of wall time                        = 168.041594
+ 0: The maximum resident set size (KB)                   = 585712
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_control_2dwrtdecomp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 293.855191
- 0: The maximum resident set size (KB)                   = 584272
+ 0: The total amount of wall time                        = 293.582344
+ 0: The maximum resident set size (KB)                   = 588296
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_noquilt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 300.594973
- 0: The maximum resident set size (KB)                   = 600332
+ 0: The total amount of wall time                        = 300.092311
+ 0: The maximum resident set size (KB)                   = 600816
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 211.276853
- 0: The maximum resident set size (KB)                   = 594516
+ 0: The total amount of wall time                        = 212.765525
+ 0: The maximum resident set size (KB)                   = 596600
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_hafs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 293.672021
- 0: The maximum resident set size (KB)                   = 583592
+ 0: The total amount of wall time                        = 294.152437
+ 0: The maximum resident set size (KB)                   = 589072
 
 Test 044 regional_hafs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_netcdf_parallel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 294.881086
- 0: The maximum resident set size (KB)                   = 584600
+ 0: The total amount of wall time                        = 295.838616
+ 0: The maximum resident set size (KB)                   = 588412
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_RRTMGP
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 376.891170
- 0: The maximum resident set size (KB)                   = 708560
+ 0: The total amount of wall time                        = 372.666116
+ 0: The maximum resident set size (KB)                   = 711412
 
 Test 046 regional_RRTMGP PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 339.038108
-  0: The maximum resident set size (KB)                   = 852372
+  0: The total amount of wall time                        = 338.737976
+  0: The maximum resident set size (KB)                   = 852068
 
 Test 047 rap_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_2threads
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 409.370728
- 0: The maximum resident set size (KB)                   = 908476
+ 0: The total amount of wall time                        = 414.899143
+ 0: The maximum resident set size (KB)                   = 912884
 
 Test 048 rap_2threads PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.485826
-  0: The maximum resident set size (KB)                   = 605092
+  0: The total amount of wall time                        = 174.948777
+  0: The maximum resident set size (KB)                   = 602408
 
 Test 049 rap_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_sfcdiff
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.232674
-  0: The maximum resident set size (KB)                   = 850240
+  0: The total amount of wall time                        = 337.949056
+  0: The maximum resident set size (KB)                   = 851744
 
 Test 050 rap_sfcdiff PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_sfcdiff_restart
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.888028
-  0: The maximum resident set size (KB)                   = 606364
+  0: The total amount of wall time                        = 174.643253
+  0: The maximum resident set size (KB)                   = 604520
 
 Test 051 rap_sfcdiff_restart PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hrrr_control
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 327.590428
-  0: The maximum resident set size (KB)                   = 846764
+  0: The total amount of wall time                        = 327.888047
+  0: The maximum resident set size (KB)                   = 850168
 
 Test 052 hrrr_control PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rrfs_v1beta
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 334.311333
-  0: The maximum resident set size (KB)                   = 848664
+  0: The total amount of wall time                        = 334.530115
+  0: The maximum resident set size (KB)                   = 848360
 
 Test 053 rrfs_v1beta PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rrfs_conus13km_hrrr_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 159.598542
-  0: The maximum resident set size (KB)                   = 716276
+  0: The total amount of wall time                        = 165.208605
+  0: The maximum resident set size (KB)                   = 716388
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rrfs_conus13km_radar_tten_warm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 161.272587
-  0: The maximum resident set size (KB)                   = 719616
+  0: The total amount of wall time                        = 162.555459
+  0: The maximum resident set size (KB)                   = 714200
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_rrtmgp
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.805666
-  0: The maximum resident set size (KB)                   = 602372
+  0: The total amount of wall time                        = 185.869453
+  0: The maximum resident set size (KB)                   = 604292
 
 Test 056 control_rrtmgp PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_rrtmgp_c192
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 509.038658
-  0: The maximum resident set size (KB)                   = 805392
+  0: The total amount of wall time                        = 503.546430
+  0: The maximum resident set size (KB)                   = 806864
 
 Test 057 control_rrtmgp_c192 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_csawmg
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 305.688165
-  0: The maximum resident set size (KB)                   = 542928
+  0: The total amount of wall time                        = 304.763176
+  0: The maximum resident set size (KB)                   = 543472
 
 Test 058 control_csawmg PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_csawmgt
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 301.290936
-  0: The maximum resident set size (KB)                   = 542456
+  0: The total amount of wall time                        = 300.924151
+  0: The maximum resident set size (KB)                   = 543164
 
 Test 059 control_csawmgt PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_flake
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.280161
-  0: The maximum resident set size (KB)                   = 556708
+  0: The total amount of wall time                        = 215.213298
+  0: The maximum resident set size (KB)                   = 556860
 
 Test 060 control_flake PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_ras
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.567390
-  0: The maximum resident set size (KB)                   = 513688
+  0: The total amount of wall time                        = 164.183978
+  0: The maximum resident set size (KB)                   = 514240
 
 Test 061 control_ras PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 207.521761
-  0: The maximum resident set size (KB)                   = 865904
+  0: The total amount of wall time                        = 206.098830
+  0: The maximum resident set size (KB)                   = 865864
 
 Test 062 control_thompson PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson_no_aero
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.937547
-  0: The maximum resident set size (KB)                   = 857128
+  0: The total amount of wall time                        = 196.521702
+  0: The maximum resident set size (KB)                   = 859528
 
 Test 063 control_thompson_no_aero PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_wam_repro
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 111.871345
-  0: The maximum resident set size (KB)                   = 247452
+  0: The total amount of wall time                        = 111.314381
+  0: The maximum resident set size (KB)                   = 247612
 
 Test 064 control_wam PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.518469
-  0: The maximum resident set size (KB)                   = 543636
+  0: The total amount of wall time                        = 151.032266
+  0: The maximum resident set size (KB)                   = 542852
 
 Test 065 control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_2threads_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 231.852060
- 0: The maximum resident set size (KB)                   = 589600
+ 0: The total amount of wall time                        = 226.919576
+ 0: The maximum resident set size (KB)                   = 587192
 
 Test 066 control_2threads_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_CubedSphereGrid_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2428,428 +2428,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 164.460709
-  0: The maximum resident set size (KB)                   = 540364
+  0: The total amount of wall time                        = 163.352132
+  0: The maximum resident set size (KB)                   = 542428
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.138284
-  0: The maximum resident set size (KB)                   = 542420
+  0: The total amount of wall time                        = 153.798926
+  0: The maximum resident set size (KB)                   = 540384
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_stochy_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.442432
-  0: The maximum resident set size (KB)                   = 548560
+  0: The total amount of wall time                        = 172.285929
+  0: The maximum resident set size (KB)                   = 545096
 
 Test 069 control_stochy_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.200491
-  0: The maximum resident set size (KB)                   = 557860
+  0: The total amount of wall time                        = 156.431775
+  0: The maximum resident set size (KB)                   = 554640
 
 Test 070 control_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.226654
-  0: The maximum resident set size (KB)                   = 637924
+  0: The total amount of wall time                        = 169.193199
+  0: The maximum resident set size (KB)                   = 638636
 
 Test 071 control_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_csawmg_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.348181
-  0: The maximum resident set size (KB)                   = 579560
+  0: The total amount of wall time                        = 237.676619
+  0: The maximum resident set size (KB)                   = 576188
 
 Test 072 control_csawmg_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_csawmgt_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 242.732239
-  0: The maximum resident set size (KB)                   = 577852
+  0: The total amount of wall time                        = 232.426301
+  0: The maximum resident set size (KB)                   = 574144
 
 Test 073 control_csawmgt_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_ras_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.703989
-  0: The maximum resident set size (KB)                   = 550352
+  0: The total amount of wall time                        = 158.517146
+  0: The maximum resident set size (KB)                   = 553728
 
 Test 074 control_ras_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.320763
-  0: The maximum resident set size (KB)                   = 602412
+  0: The total amount of wall time                        = 162.008977
+  0: The maximum resident set size (KB)                   = 599508
 
 Test 075 control_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_debug_p8
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.943691
-  0: The maximum resident set size (KB)                   = 569328
+  0: The total amount of wall time                        = 166.367794
+  0: The maximum resident set size (KB)                   = 567156
 
 Test 076 control_debug_p8 PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.304034
-  0: The maximum resident set size (KB)                   = 901624
+  0: The total amount of wall time                        = 180.977053
+  0: The maximum resident set size (KB)                   = 907160
 
 Test 077 control_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson_no_aero_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.406692
-  0: The maximum resident set size (KB)                   = 901008
+  0: The total amount of wall time                        = 170.291407
+  0: The maximum resident set size (KB)                   = 899352
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson_extdiag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 190.747722
-  0: The maximum resident set size (KB)                   = 936404
+  0: The total amount of wall time                        = 186.051630
+  0: The maximum resident set size (KB)                   = 936928
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_thompson_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.783299
-  0: The maximum resident set size (KB)                   = 906848
+  0: The total amount of wall time                        = 177.460747
+  0: The maximum resident set size (KB)                   = 906540
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/regional_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 256.467934
- 0: The maximum resident set size (KB)                   = 612892
+ 0: The total amount of wall time                        = 250.671408
+ 0: The maximum resident set size (KB)                   = 616508
 
 Test 081 regional_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_control_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.003635
-  0: The maximum resident set size (KB)                   = 911716
+  0: The total amount of wall time                        = 273.523298
+  0: The maximum resident set size (KB)                   = 909940
 
 Test 082 rap_control_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_unified_drag_suite_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.860463
-  0: The maximum resident set size (KB)                   = 908592
+  0: The total amount of wall time                        = 271.819758
+  0: The maximum resident set size (KB)                   = 908784
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_diag_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 300.694111
-  0: The maximum resident set size (KB)                   = 1005820
+  0: The total amount of wall time                        = 290.469690
+  0: The maximum resident set size (KB)                   = 1005772
 
 Test 084 rap_diag_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.192724
-  0: The maximum resident set size (KB)                   = 915592
+  0: The total amount of wall time                        = 274.375296
+  0: The maximum resident set size (KB)                   = 915404
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_unified_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.565937
-  0: The maximum resident set size (KB)                   = 908332
+  0: The total amount of wall time                        = 280.582644
+  0: The maximum resident set size (KB)                   = 913020
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_noah_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.722837
-  0: The maximum resident set size (KB)                   = 912336
+  0: The total amount of wall time                        = 270.940835
+  0: The maximum resident set size (KB)                   = 912144
 
 Test 087 rap_noah_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_rrtmgp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 458.931067
-  0: The maximum resident set size (KB)                   = 1011472
+  0: The total amount of wall time                        = 462.431713
+  0: The maximum resident set size (KB)                   = 1011368
 
 Test 088 rap_rrtmgp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_lndp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.736290
-  0: The maximum resident set size (KB)                   = 910432
+  0: The total amount of wall time                        = 273.029144
+  0: The maximum resident set size (KB)                   = 910320
 
 Test 089 rap_lndp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_sfcdiff_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.926983
-  0: The maximum resident set size (KB)                   = 910244
+  0: The total amount of wall time                        = 273.919260
+  0: The maximum resident set size (KB)                   = 908780
 
 Test 090 rap_sfcdiff_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_flake_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.794943
-  0: The maximum resident set size (KB)                   = 909560
+  0: The total amount of wall time                        = 271.865092
+  0: The maximum resident set size (KB)                   = 908400
 
 Test 091 rap_flake_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 444.593201
-  0: The maximum resident set size (KB)                   = 906720
+  0: The total amount of wall time                        = 457.893596
+  0: The maximum resident set size (KB)                   = 908316
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rap_progcld_thompson_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.671497
-  0: The maximum resident set size (KB)                   = 908960
+  0: The total amount of wall time                        = 271.580671
+  0: The maximum resident set size (KB)                   = 913300
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/rrfs_v1beta_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.637236
-  0: The maximum resident set size (KB)                   = 911776
+  0: The total amount of wall time                        = 270.407976
+  0: The maximum resident set size (KB)                   = 907160
 
 Test 094 rrfs_v1beta_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_wam_debug
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 295.256274
-  0: The maximum resident set size (KB)                   = 274248
+  0: The total amount of wall time                        = 289.820278
+  0: The maximum resident set size (KB)                   = 272164
 
 Test 095 control_wam_debug PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 246.139095
-  0: The maximum resident set size (KB)                   = 851352
+  0: The total amount of wall time                        = 245.595453
+  0: The maximum resident set size (KB)                   = 848056
 
 Test 096 hafs_regional_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 303.484944
-  0: The maximum resident set size (KB)                   = 1208284
+  0: The total amount of wall time                        = 301.718889
+  0: The maximum resident set size (KB)                   = 1204896
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_atm_ocn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2858,28 +2858,28 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 355.342702
-  0: The maximum resident set size (KB)                   = 885976
+  0: The total amount of wall time                        = 353.582163
+  0: The maximum resident set size (KB)                   = 887228
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_atm_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 754.929458
-  0: The maximum resident set size (KB)                   = 883916
+  0: The total amount of wall time                        = 759.818307
+  0: The maximum resident set size (KB)                   = 885204
 
 Test 099 hafs_regional_atm_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_atm_ocn_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2888,28 +2888,28 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1377.734545
-  0: The maximum resident set size (KB)                   = 885512
+  0: The total amount of wall time                        = 859.827896
+  0: The maximum resident set size (KB)                   = 888988
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 1259.971026
-  0: The maximum resident set size (KB)                   = 389600
+  0: The total amount of wall time                        = 1256.953938
+  0: The maximum resident set size (KB)                   = 387436
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_telescopic_2nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2918,28 +2918,28 @@ Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 415.577158
-  0: The maximum resident set size (KB)                   = 443220
+  0: The total amount of wall time                        = 411.686998
+  0: The maximum resident set size (KB)                   = 428076
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_global_1nest_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 184.280560
-  0: The maximum resident set size (KB)                   = 273196
+  0: The total amount of wall time                        = 185.255104
+  0: The maximum resident set size (KB)                   = 273352
 
 Test 103 hafs_global_1nest_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_global_multiple_4nests_atm
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 518.175326
-  0: The maximum resident set size (KB)                   = 454456
+  0: The total amount of wall time                        = 521.599350
+  0: The maximum resident set size (KB)                   = 458652
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_docn
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2967,14 +2967,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 333.776677
-  0: The maximum resident set size (KB)                   = 889204
+  0: The total amount of wall time                        = 331.057996
+  0: The maximum resident set size (KB)                   = 886496
 
 Test 105 hafs_regional_docn PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_docn_oisst
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2982,105 +2982,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 340.239394
-  0: The maximum resident set size (KB)                   = 889048
+  0: The total amount of wall time                        = 334.912796
+  0: The maximum resident set size (KB)                   = 889916
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/hafs_regional_datm_cdeps
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 917.624168
-  0: The maximum resident set size (KB)                   = 865204
+  0: The total amount of wall time                        = 918.198700
+  0: The maximum resident set size (KB)                   = 870028
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_control_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.798511
- 0: The maximum resident set size (KB)                   = 720408
+ 0: The total amount of wall time                        = 142.516470
+ 0: The maximum resident set size (KB)                   = 720788
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_restart_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 99.394273
- 0: The maximum resident set size (KB)                   = 723192
+ 0: The total amount of wall time                        = 96.632069
+ 0: The maximum resident set size (KB)                   = 718324
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_control_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.090349
- 0: The maximum resident set size (KB)                   = 621912
+ 0: The total amount of wall time                        = 136.722042
+ 0: The maximum resident set size (KB)                   = 621300
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_stochy_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.144632
- 0: The maximum resident set size (KB)                   = 622304
+ 0: The total amount of wall time                        = 141.435816
+ 0: The maximum resident set size (KB)                   = 621608
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_bulk_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.238509
- 0: The maximum resident set size (KB)                   = 722740
+ 0: The total amount of wall time                        = 142.020927
+ 0: The maximum resident set size (KB)                   = 720656
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_bulk_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.926196
- 0: The maximum resident set size (KB)                   = 619084
+ 0: The total amount of wall time                        = 136.961868
+ 0: The maximum resident set size (KB)                   = 623804
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_mx025_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3089,14 +3089,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 302.730972
-  0: The maximum resident set size (KB)                   = 633808
+  0: The total amount of wall time                        = 297.323710
+  0: The maximum resident set size (KB)                   = 638900
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_mx025_gefs
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3105,51 +3105,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 297.646156
-  0: The maximum resident set size (KB)                   = 595064
+  0: The total amount of wall time                        = 294.142747
+  0: The maximum resident set size (KB)                   = 594440
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_multiple_files_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.404301
- 0: The maximum resident set size (KB)                   = 719428
+ 0: The total amount of wall time                        = 140.982771
+ 0: The maximum resident set size (KB)                   = 720980
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_3072x1536_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 191.492568
- 0: The maximum resident set size (KB)                   = 1894336
+ 0: The total amount of wall time                        = 185.144586
+ 0: The maximum resident set size (KB)                   = 1831440
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/datm_cdeps_debug_cfsr
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 433.395471
- 0: The maximum resident set size (KB)                   = 726128
+ 0: The total amount of wall time                        = 434.471459
+ 0: The maximum resident set size (KB)                   = 723444
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_atmwav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3193,14 +3193,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 80.316263
-  0: The maximum resident set size (KB)                   = 566312
+  0: The total amount of wall time                        = 80.329841
+  0: The maximum resident set size (KB)                   = 568300
 
 Test 119 control_atmwav PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_261195/control_c384gdas_wav
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3246,12 +3246,12 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 666.071535
-  0: The maximum resident set size (KB)                   = 1208288
+  0: The total amount of wall time                        = 663.983848
+  0: The maximum resident set size (KB)                   = 1209932
 
 Test 120 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 16:57:12 CST 2022
-Elapsed time: 01h:09m:59s. Have a nice day!
+Tue Feb 15 17:48:03 CST 2022
+Elapsed time: 01h:15m:38s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,17 +1,17 @@
-Mon Feb 14 15:32:45 UTC 2022
+Wed Feb 16 04:13:07 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 780 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 776 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 801 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 761 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 005 elapsed time 527 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 515 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 455 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 811 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 755 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 769 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 807 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 754 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 005 elapsed time 508 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 500 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 458 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 828 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,14 +58,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 141.381540
-The maximum resident set size (KB)                   = 422856
+The total amount of wall time                        = 140.963002
+The maximum resident set size (KB)                   = 422816
 
 Test 001 control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_decomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -108,28 +108,28 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 144.710243
-The maximum resident set size (KB)                   = 421856
+The total amount of wall time                        = 144.171561
+The maximum resident set size (KB)                   = 421784
 
 Test 002 control_decomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_2dwrtdecomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_2dwrtdecomp
 Checking test 003 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 132.979323
-The maximum resident set size (KB)                   = 422964
+The total amount of wall time                        = 130.717840
+The maximum resident set size (KB)                   = 422856
 
 Test 003 control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_restart
 Checking test 004 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -168,14 +168,14 @@ Checking test 004 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 79.095202
-The maximum resident set size (KB)                   = 156572
+The total amount of wall time                        = 77.203543
+The maximum resident set size (KB)                   = 155972
 
 Test 004 control_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_fhzero
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_fhzero
 Checking test 005 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -218,14 +218,14 @@ Checking test 005 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.075816
-The maximum resident set size (KB)                   = 422944
+The total amount of wall time                        = 132.591842
+The maximum resident set size (KB)                   = 422752
 
 Test 005 control_fhzero PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_CubedSphereGrid
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_CubedSphereGrid
 Checking test 006 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 133.633847
-The maximum resident set size (KB)                   = 422868
+The total amount of wall time                        = 134.052832
+The maximum resident set size (KB)                   = 422808
 
 Test 006 control_CubedSphereGrid PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_latlon
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_latlon
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_latlon
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_latlon
 Checking test 007 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -270,14 +270,14 @@ Checking test 007 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.803804
-The maximum resident set size (KB)                   = 422748
+The total amount of wall time                        = 135.697683
+The maximum resident set size (KB)                   = 422980
 
 Test 007 control_latlon PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_wrtGauss_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wrtGauss_netcdf_parallel
 Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -288,14 +288,14 @@ Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 138.257976
-The maximum resident set size (KB)                   = 422764
+The total amount of wall time                        = 138.457561
+The maximum resident set size (KB)                   = 422616
 
 Test 008 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c48
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_c48
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c48
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_c48
 Checking test 009 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -334,14 +334,14 @@ Checking test 009 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 430.599967
-The maximum resident set size (KB)                   = 630444
+The total amount of wall time                        = 429.924454
+The maximum resident set size (KB)                   = 630300
 
 Test 009 control_c48 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c192
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c192
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_c192
 Checking test 010 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 010 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 531.783086
-The maximum resident set size (KB)                   = 522700
+The total amount of wall time                        = 536.803974
+The maximum resident set size (KB)                   = 523004
 
 Test 010 control_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_stochy
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_stochy
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy
 Checking test 011 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -370,28 +370,28 @@ Checking test 011 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 95.103730
-The maximum resident set size (KB)                   = 426408
+The total amount of wall time                        = 95.001371
+The maximum resident set size (KB)                   = 426504
 
 Test 011 control_stochy PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_stochy
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_stochy_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy_restart
 Checking test 012 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 52.294925
-The maximum resident set size (KB)                   = 172420
+The total amount of wall time                        = 52.759183
+The maximum resident set size (KB)                   = 172396
 
 Test 012 control_stochy_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_lndp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_lndp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_lndp
 Checking test 013 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -402,14 +402,14 @@ Checking test 013 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 86.486198
-The maximum resident set size (KB)                   = 427236
+The total amount of wall time                        = 85.728256
+The maximum resident set size (KB)                   = 427216
 
 Test 013 control_lndp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_iovr4
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_iovr4
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr4
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_iovr4
 Checking test 014 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -424,14 +424,14 @@ Checking test 014 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 140.858785
-The maximum resident set size (KB)                   = 422616
+The total amount of wall time                        = 140.138415
+The maximum resident set size (KB)                   = 422800
 
 Test 014 control_iovr4 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_iovr5
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_iovr5
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr5
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_iovr5
 Checking test 015 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -446,14 +446,14 @@ Checking test 015 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 139.652332
-The maximum resident set size (KB)                   = 422756
+The total amount of wall time                        = 140.007979
+The maximum resident set size (KB)                   = 422584
 
 Test 015 control_iovr5 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p8
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_p8
 Checking test 016 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -500,14 +500,14 @@ Checking test 016 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 159.927190
-The maximum resident set size (KB)                   = 454592
+The total amount of wall time                        = 160.907674
+The maximum resident set size (KB)                   = 455532
 
 Test 016 control_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p8
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_restart_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_restart_p8
 Checking test 017 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -546,14 +546,14 @@ Checking test 017 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 90.849615
-The maximum resident set size (KB)                   = 264368
+The total amount of wall time                        = 89.951239
+The maximum resident set size (KB)                   = 264364
 
 Test 017 control_restart_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p8
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_decomp_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_decomp_p8
 Checking test 018 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -596,14 +596,14 @@ Checking test 018 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 164.585851
-The maximum resident set size (KB)                   = 448804
+The total amount of wall time                        = 167.064946
+The maximum resident set size (KB)                   = 448944
 
 Test 018 control_decomp_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p7_rrtmgp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_p7_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p7_rrtmgp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_p7_rrtmgp
 Checking test 019 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -650,14 +650,14 @@ Checking test 019 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 202.336555
-The maximum resident set size (KB)                   = 551868
+The total amount of wall time                        = 204.532712
+The maximum resident set size (KB)                   = 551916
 
 Test 019 control_p7_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_control
 Checking test 020 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -668,42 +668,42 @@ Checking test 020 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 343.096921
-The maximum resident set size (KB)                   = 532808
+The total amount of wall time                        = 341.461452
+The maximum resident set size (KB)                   = 532800
 
 Test 020 regional_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_restart
 Checking test 021 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 205.725724
-The maximum resident set size (KB)                   = 527028
+The total amount of wall time                        = 206.655364
+The maximum resident set size (KB)                   = 527232
 
 Test 021 regional_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_control_2dwrtdecomp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_control_2dwrtdecomp
 Checking test 022 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 344.431826
-The maximum resident set size (KB)                   = 532744
+The total amount of wall time                        = 342.416099
+The maximum resident set size (KB)                   = 532752
 
 Test 022 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_noquilt
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_noquilt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_noquilt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_noquilt
 Checking test 023 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -711,14 +711,14 @@ Checking test 023 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 371.628000
-The maximum resident set size (KB)                   = 534760
+The total amount of wall time                        = 372.742520
+The maximum resident set size (KB)                   = 534752
 
 Test 023 regional_noquilt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_hafs
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_hafs
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_hafs
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_hafs
 Checking test 024 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -727,28 +727,28 @@ Checking test 024 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 338.261781
-The maximum resident set size (KB)                   = 527344
+The total amount of wall time                        = 338.305705
+The maximum resident set size (KB)                   = 527336
 
 Test 024 regional_hafs PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_netcdf_parallel
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_netcdf_parallel
 Checking test 025 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 336.637679
-The maximum resident set size (KB)                   = 528504
+The total amount of wall time                        = 335.269752
+The maximum resident set size (KB)                   = 528460
 
 Test 025 regional_netcdf_parallel PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_RRTMGP
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_RRTMGP
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_RRTMGP
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_RRTMGP
 Checking test 026 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -759,14 +759,14 @@ Checking test 026 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 431.143415
-The maximum resident set size (KB)                   = 654072
+The total amount of wall time                        = 430.228733
+The maximum resident set size (KB)                   = 654096
 
 Test 026 regional_RRTMGP PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_control
 Checking test 027 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -813,14 +813,14 @@ Checking test 027 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 382.543147
-The maximum resident set size (KB)                   = 789660
+The total amount of wall time                        = 382.770623
+The maximum resident set size (KB)                   = 789616
 
 Test 027 rap_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_restart
 Checking test 028 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -859,14 +859,14 @@ Checking test 028 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.405670
-The maximum resident set size (KB)                   = 529092
+The total amount of wall time                        = 200.900685
+The maximum resident set size (KB)                   = 529236
 
 Test 028 rap_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_sfcdiff
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff
 Checking test 029 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -913,14 +913,14 @@ Checking test 029 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 382.502884
-The maximum resident set size (KB)                   = 789584
+The total amount of wall time                        = 383.082145
+The maximum resident set size (KB)                   = 789548
 
 Test 029 rap_sfcdiff PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_sfcdiff_restart
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff_restart
 Checking test 030 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -959,14 +959,14 @@ Checking test 030 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.670112
-The maximum resident set size (KB)                   = 528676
+The total amount of wall time                        = 198.907234
+The maximum resident set size (KB)                   = 528780
 
 Test 030 rap_sfcdiff_restart PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hrrr_control
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hrrr_control
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hrrr_control
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hrrr_control
 Checking test 031 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1013,14 +1013,14 @@ Checking test 031 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 374.937256
-The maximum resident set size (KB)                   = 787364
+The total amount of wall time                        = 368.371023
+The maximum resident set size (KB)                   = 787292
 
 Test 031 hrrr_control PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rrfs_v1beta
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_v1beta
 Checking test 032 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1067,14 +1067,14 @@ Checking test 032 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 385.303188
-The maximum resident set size (KB)                   = 787572
+The total amount of wall time                        = 374.512100
+The maximum resident set size (KB)                   = 787288
 
 Test 032 rrfs_v1beta PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rrfs_conus13km_hrrr_warm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_conus13km_hrrr_warm
 Checking test 033 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1083,14 +1083,14 @@ Checking test 033 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 236.266122
-The maximum resident set size (KB)                   = 596212
+The total amount of wall time                        = 244.062864
+The maximum resident set size (KB)                   = 596108
 
 Test 033 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rrfs_conus13km_radar_tten_warm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_conus13km_radar_tten_warm
 Checking test 034 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1099,14 +1099,14 @@ Checking test 034 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 245.734374
-The maximum resident set size (KB)                   = 600272
+The total amount of wall time                        = 252.982695
+The maximum resident set size (KB)                   = 601916
 
 Test 034 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_rrtmgp
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1117,14 +1117,14 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 215.277659
-The maximum resident set size (KB)                   = 549340
+The total amount of wall time                        = 214.731299
+The maximum resident set size (KB)                   = 549484
 
 Test 035 control_rrtmgp PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp_c192
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_rrtmgp_c192
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_c192
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp_c192
 Checking test 036 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1135,14 +1135,14 @@ Checking test 036 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 587.591406
-The maximum resident set size (KB)                   = 760876
+The total amount of wall time                        = 587.230894
+The maximum resident set size (KB)                   = 760460
 
 Test 036 control_rrtmgp_c192 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmg
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_csawmg
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmg
 Checking test 037 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1153,14 +1153,14 @@ Checking test 037 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 353.053321
-The maximum resident set size (KB)                   = 490496
+The total amount of wall time                        = 356.033772
+The maximum resident set size (KB)                   = 490688
 
 Test 037 control_csawmg PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_csawmgt
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmgt
 Checking test 038 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1171,14 +1171,14 @@ Checking test 038 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 347.968460
-The maximum resident set size (KB)                   = 490312
+The total amount of wall time                        = 349.403539
+The maximum resident set size (KB)                   = 490540
 
 Test 038 control_csawmgt PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_flake
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_flake
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_flake
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_flake
 Checking test 039 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1189,14 +1189,14 @@ Checking test 039 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 231.825610
-The maximum resident set size (KB)                   = 491856
+The total amount of wall time                        = 229.614982
+The maximum resident set size (KB)                   = 491780
 
 Test 039 control_flake PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_ras
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_ras
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1207,40 +1207,40 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 190.214205
-The maximum resident set size (KB)                   = 457420
+The total amount of wall time                        = 191.267527
+The maximum resident set size (KB)                   = 457248
 
 Test 040 control_ras PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wam_repro
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_wam_repro
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_repro
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wam_repro
 Checking test 041 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 116.951317
-The maximum resident set size (KB)                   = 167808
+The total amount of wall time                        = 117.702270
+The maximum resident set size (KB)                   = 167840
 
 Test 041 control_wam PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_debug
 Checking test 042 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 140.545171
-The maximum resident set size (KB)                   = 488796
+The total amount of wall time                        = 141.253889
+The maximum resident set size (KB)                   = 488948
 
 Test 042 control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_CubedSphereGrid_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_CubedSphereGrid_debug
 Checking test 043 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1267,428 +1267,428 @@ Checking test 043 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 149.418875
-The maximum resident set size (KB)                   = 489160
+The total amount of wall time                        = 150.633314
+The maximum resident set size (KB)                   = 489104
 
 Test 043 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wrtGauss_netcdf_parallel_debug
 Checking test 044 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.325323
-The maximum resident set size (KB)                   = 488840
+The total amount of wall time                        = 144.266689
+The maximum resident set size (KB)                   = 488980
 
 Test 044 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_stochy_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy_debug
 Checking test 045 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.988314
-The maximum resident set size (KB)                   = 493856
+The total amount of wall time                        = 160.877999
+The maximum resident set size (KB)                   = 493828
 
 Test 045 control_stochy_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_lndp_debug
 Checking test 046 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.888152
-The maximum resident set size (KB)                   = 493952
+The total amount of wall time                        = 145.323902
+The maximum resident set size (KB)                   = 493876
 
 Test 046 control_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_rrtmgp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp_debug
 Checking test 047 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.230024
-The maximum resident set size (KB)                   = 594704
+The total amount of wall time                        = 156.806495
+The maximum resident set size (KB)                   = 594776
 
 Test 047 control_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_csawmg_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmg_debug
 Checking test 048 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 229.593263
-The maximum resident set size (KB)                   = 531172
+The total amount of wall time                        = 232.145498
+The maximum resident set size (KB)                   = 532304
 
 Test 048 control_csawmg_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_csawmgt_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmgt_debug
 Checking test 049 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 225.280263
-The maximum resident set size (KB)                   = 531492
+The total amount of wall time                        = 226.772665
+The maximum resident set size (KB)                   = 531176
 
 Test 049 control_csawmgt_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_ras_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_ras_debug
 Checking test 050 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 147.507477
-The maximum resident set size (KB)                   = 501660
+The total amount of wall time                        = 146.822706
+The maximum resident set size (KB)                   = 501684
 
 Test 050 control_ras_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_diag_debug
 Checking test 051 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 149.450406
-The maximum resident set size (KB)                   = 546720
+The total amount of wall time                        = 150.066414
+The maximum resident set size (KB)                   = 546828
 
 Test 051 control_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_debug_p8
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_debug_p8
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug_p8
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_debug_p8
 Checking test 052 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.533879
-The maximum resident set size (KB)                   = 515076
+The total amount of wall time                        = 157.551228
+The maximum resident set size (KB)                   = 515056
 
 Test 052 control_debug_p8 PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_debug
 Checking test 053 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 171.553472
-The maximum resident set size (KB)                   = 850564
+The total amount of wall time                        = 172.928448
+The maximum resident set size (KB)                   = 850632
 
 Test 053 control_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_thompson_no_aero_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_no_aero_debug
 Checking test 054 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 159.991375
-The maximum resident set size (KB)                   = 844612
+The total amount of wall time                        = 160.926273
+The maximum resident set size (KB)                   = 844592
 
 Test 054 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_thompson_extdiag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug_extdiag
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_extdiag_debug
 Checking test 055 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.651323
-The maximum resident set size (KB)                   = 878272
+The total amount of wall time                        = 180.878733
+The maximum resident set size (KB)                   = 878520
 
 Test 055 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_thompson_progcld_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_progcld_thompson_debug
 Checking test 056 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.704824
-The maximum resident set size (KB)                   = 850548
+The total amount of wall time                        = 172.087889
+The maximum resident set size (KB)                   = 850616
 
 Test 056 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/regional_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_debug
 Checking test 057 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 248.863469
-The maximum resident set size (KB)                   = 553560
+The total amount of wall time                        = 249.498301
+The maximum resident set size (KB)                   = 553480
 
 Test 057 regional_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_control_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_control_debug
 Checking test 058 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.432423
-The maximum resident set size (KB)                   = 856808
+The total amount of wall time                        = 265.239789
+The maximum resident set size (KB)                   = 857296
 
 Test 058 rap_control_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_unified_drag_suite_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_unified_drag_suite_debug
 Checking test 059 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.113350
-The maximum resident set size (KB)                   = 857296
+The total amount of wall time                        = 266.930092
+The maximum resident set size (KB)                   = 856752
 
 Test 059 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_diag_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_diag_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_diag_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_diag_debug
 Checking test 060 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 282.093670
-The maximum resident set size (KB)                   = 939276
+The total amount of wall time                        = 283.392043
+The maximum resident set size (KB)                   = 939252
 
 Test 060 rap_diag_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_cires_ugwp_debug
 Checking test 061 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 272.701192
-The maximum resident set size (KB)                   = 857876
+The total amount of wall time                        = 271.577796
+The maximum resident set size (KB)                   = 857792
 
 Test 061 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_unified_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_unified_ugwp_debug
 Checking test 062 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 269.319125
-The maximum resident set size (KB)                   = 856772
+The total amount of wall time                        = 272.281313
+The maximum resident set size (KB)                   = 856724
 
 Test 062 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_noah_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_noah_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_noah_debug
 Checking test 063 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 259.910049
-The maximum resident set size (KB)                   = 855700
+The total amount of wall time                        = 260.875220
+The maximum resident set size (KB)                   = 855580
 
 Test 063 rap_noah_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_rrtmgp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_rrtmgp_debug
 Checking test 064 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 447.155509
-The maximum resident set size (KB)                   = 963564
+The total amount of wall time                        = 445.668639
+The maximum resident set size (KB)                   = 963296
 
 Test 064 rap_rrtmgp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_lndp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_lndp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_lndp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_lndp_debug
 Checking test 065 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.797394
-The maximum resident set size (KB)                   = 857908
+The total amount of wall time                        = 269.504618
+The maximum resident set size (KB)                   = 858336
 
 Test 065 rap_lndp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_sfcdiff_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_sfcdiff_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff_debug
 Checking test 066 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.003478
-The maximum resident set size (KB)                   = 857076
+The total amount of wall time                        = 266.290773
+The maximum resident set size (KB)                   = 857012
 
 Test 066 rap_sfcdiff_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_flake_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_flake_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_flake_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_flake_debug
 Checking test 067 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 265.586367
-The maximum resident set size (KB)                   = 856828
+The total amount of wall time                        = 263.396048
+The maximum resident set size (KB)                   = 857228
 
 Test 067 rap_flake_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 068 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 434.176070
-The maximum resident set size (KB)                   = 855508
+The total amount of wall time                        = 439.249639
+The maximum resident set size (KB)                   = 855332
 
 Test 068 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rap_progcld_thompson_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_progcld_thompson_debug
 Checking test 069 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 265.439731
-The maximum resident set size (KB)                   = 856788
+The total amount of wall time                        = 264.874770
+The maximum resident set size (KB)                   = 857260
 
 Test 069 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/rrfs_v1beta_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_v1beta_debug
 Checking test 070 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.572859
-The maximum resident set size (KB)                   = 854248
+The total amount of wall time                        = 264.021967
+The maximum resident set size (KB)                   = 854056
 
 Test 070 rrfs_v1beta_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wam_debug
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/control_wam_debug
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_debug
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wam_debug
 Checking test 071 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 270.904148
-The maximum resident set size (KB)                   = 197328
+The total amount of wall time                        = 271.170001
+The maximum resident set size (KB)                   = 197384
 
 Test 071 control_wam_debug PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm
 Checking test 072 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 330.091030
-The maximum resident set size (KB)                   = 642968
+The total amount of wall time                        = 333.521750
+The maximum resident set size (KB)                   = 641720
 
 Test 072 hafs_regional_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_thompson_gfdlsf
 Checking test 073 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 371.251855
-The maximum resident set size (KB)                   = 1000220
+The total amount of wall time                        = 370.991926
+The maximum resident set size (KB)                   = 998016
 
 Test 073 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_atm_ocn
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_ocn
 Checking test 074 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1697,28 +1697,28 @@ Checking test 074 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 506.673476
-The maximum resident set size (KB)                   = 639676
+The total amount of wall time                        = 509.651724
+The maximum resident set size (KB)                   = 639568
 
 Test 074 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_wav
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_atm_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_wav
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_wav
 Checking test 075 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 910.295722
-The maximum resident set size (KB)                   = 643300
+The total amount of wall time                        = 898.438599
+The maximum resident set size (KB)                   = 643280
 
 Test 075 hafs_regional_atm_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_atm_ocn_wav
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_ocn_wav
 Checking test 076 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1727,28 +1727,28 @@ Checking test 076 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 979.234067
-The maximum resident set size (KB)                   = 644324
+The total amount of wall time                        = 982.686760
+The maximum resident set size (KB)                   = 644304
 
 Test 076 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_1nest_atm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_1nest_atm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_1nest_atm
 Checking test 077 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 358.889091
-The maximum resident set size (KB)                   = 244652
+The total amount of wall time                        = 358.580142
+The maximum resident set size (KB)                   = 244808
 
 Test 077 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_regional_telescopic_2nests_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_telescopic_2nests_atm
 Checking test 078 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1757,26 +1757,26 @@ Checking test 078 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 374.671852
-The maximum resident set size (KB)                   = 246508
+The total amount of wall time                        = 374.833921
+The maximum resident set size (KB)                   = 245872
 
 Test 078 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_global_1nest_atm
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_14169/hafs_global_1nest_atm
+baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_1nest_atm
+working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_global_1nest_atm
 Checking test 079 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 164.089580
-The maximum resident set size (KB)                   = 148476
+The total amount of wall time                        = 161.172515
+The maximum resident set size (KB)                   = 149968
 
 Test 079 hafs_global_1nest_atm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 16:09:10 UTC 2022
-Elapsed time: 00h:36m:25s. Have a nice day!
+Wed Feb 16 04:50:19 UTC 2022
+Elapsed time: 00h:37m:12s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,2326 +1,3268 @@
-Mon Feb 14 14:45:40 UTC 2022
+Wed Feb 16 04:12:38 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 2048 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 535 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1207 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 1498 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 910 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 464 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 436 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 289 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1282 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1267 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 806 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 333 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 951 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Test 009 compile FAIL
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_control_p8
+Compile 001 elapsed time 1710 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 516 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1153 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 1113 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1306 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 891 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 446 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 445 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1244 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1228 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 776 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 434 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 963 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
-Moving baseline 001 cpld_control_p8 files ....
- Moving sfcf021.tile1.nc .........OK
- Moving sfcf021.tile2.nc .........OK
- Moving sfcf021.tile3.nc .........OK
- Moving sfcf021.tile4.nc .........OK
- Moving sfcf021.tile5.nc .........OK
- Moving sfcf021.tile6.nc .........OK
- Moving atmf021.tile1.nc .........OK
- Moving atmf021.tile2.nc .........OK
- Moving atmf021.tile3.nc .........OK
- Moving atmf021.tile4.nc .........OK
- Moving atmf021.tile5.nc .........OK
- Moving atmf021.tile6.nc .........OK
- Moving sfcf024.tile1.nc .........OK
- Moving sfcf024.tile2.nc .........OK
- Moving sfcf024.tile3.nc .........OK
- Moving sfcf024.tile4.nc .........OK
- Moving sfcf024.tile5.nc .........OK
- Moving sfcf024.tile6.nc .........OK
- Moving atmf024.tile1.nc .........OK
- Moving atmf024.tile2.nc .........OK
- Moving atmf024.tile3.nc .........OK
- Moving atmf024.tile4.nc .........OK
- Moving atmf024.tile5.nc .........OK
- Moving atmf024.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-23-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Moving 20210323.060000.out_grd.glo_1deg .........OK
- Moving 20210323.060000.out_pnt.points .........OK
- Moving 20210323.060000.restart.glo_1deg .........OK
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 243.912352
-[0] The maximum resident set size (KB)                   = 552272
+[0] The total amount of wall time                        = 244.461606
+[0] The maximum resident set size (KB)                   = 553928
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_control_p7_rrtmgp
-Checking test 002 cpld_control_p7_rrtmgp results ....
-Moving baseline 002 cpld_control_p7_rrtmgp files ....
- Moving sfcf024.tile1.nc .........OK
- Moving sfcf024.tile2.nc .........OK
- Moving sfcf024.tile3.nc .........OK
- Moving sfcf024.tile4.nc .........OK
- Moving sfcf024.tile5.nc .........OK
- Moving sfcf024.tile6.nc .........OK
- Moving atmf024.tile1.nc .........OK
- Moving atmf024.tile2.nc .........OK
- Moving atmf024.tile3.nc .........OK
- Moving atmf024.tile4.nc .........OK
- Moving atmf024.tile5.nc .........OK
- Moving atmf024.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-23-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Moving 20210323.060000.out_grd.glo_1deg .........OK
- Moving 20210323.060000.out_pnt.points .........OK
- Moving 20210323.060000.restart.glo_1deg .........OK
-
-[0] The total amount of wall time                        = 287.927395
-[0] The maximum resident set size (KB)                   = 653524
-
-Test 002 cpld_control_p7_rrtmgp PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_bmark_p7
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_bmark_p7
-Checking test 003 cpld_bmark_p7 results ....
-Moving baseline 003 cpld_bmark_p7 files ....
- Moving sfcf006.nc .........OK
- Moving atmf006.nc .........OK
- Moving 20130401.060000.out_grd.gwes_30m .........OK
- Moving 20130401.060000.out_pnt.points .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/MOM.res_1.nc .........OK
- Moving RESTART/MOM.res_2.nc .........OK
- Moving RESTART/MOM.res_3.nc .........OK
- Moving RESTART/iced.2013-04-01-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
-
-[0] The total amount of wall time                        = 1033.702538
-[0] The maximum resident set size (KB)                   = 1271616
-
-Test 003 cpld_bmark_p7 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_bmark_p8
-Checking test 004 cpld_bmark_p8 results ....
-Moving baseline 004 cpld_bmark_p8 files ....
- Moving sfcf006.nc .........OK
- Moving atmf006.nc .........OK
- Moving 20130401.060000.out_grd.gwes_30m .........OK
- Moving 20130401.060000.out_pnt.points .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/MOM.res_1.nc .........OK
- Moving RESTART/MOM.res_2.nc .........OK
- Moving RESTART/MOM.res_3.nc .........OK
- Moving RESTART/iced.2013-04-01-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
-
-[0] The total amount of wall time                        = 1013.411697
-[0] The maximum resident set size (KB)                   = 1270304
-
-Test 004 cpld_bmark_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_control_c96_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_control_c96_p8
-Checking test 005 cpld_control_c96_p8 results ....
-Moving baseline 005 cpld_control_c96_p8 files ....
- Moving sfcf021.tile1.nc .........OK
- Moving sfcf021.tile2.nc .........OK
- Moving sfcf021.tile3.nc .........OK
- Moving sfcf021.tile4.nc .........OK
- Moving sfcf021.tile5.nc .........OK
- Moving sfcf021.tile6.nc .........OK
- Moving atmf021.tile1.nc .........OK
- Moving atmf021.tile2.nc .........OK
- Moving atmf021.tile3.nc .........OK
- Moving atmf021.tile4.nc .........OK
- Moving atmf021.tile5.nc .........OK
- Moving atmf021.tile6.nc .........OK
- Moving sfcf024.tile1.nc .........OK
- Moving sfcf024.tile2.nc .........OK
- Moving sfcf024.tile3.nc .........OK
- Moving sfcf024.tile4.nc .........OK
- Moving sfcf024.tile5.nc .........OK
- Moving sfcf024.tile6.nc .........OK
- Moving atmf024.tile1.nc .........OK
- Moving atmf024.tile2.nc .........OK
- Moving atmf024.tile3.nc .........OK
- Moving atmf024.tile4.nc .........OK
- Moving atmf024.tile5.nc .........OK
- Moving atmf024.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-23-21600.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
-
-[0] The total amount of wall time                        = 232.250470
-[0] The maximum resident set size (KB)                   = 553672
-
-Test 005 cpld_control_c96_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_control_c192_p8
-Checking test 006 cpld_control_c192_p8 results ....
-Moving baseline 006 cpld_control_c192_p8 files ....
- Moving sfcf036.tile1.nc .........OK
- Moving sfcf036.tile2.nc .........OK
- Moving sfcf036.tile3.nc .........OK
- Moving sfcf036.tile4.nc .........OK
- Moving sfcf036.tile5.nc .........OK
- Moving sfcf036.tile6.nc .........OK
- Moving atmf036.tile1.nc .........OK
- Moving atmf036.tile2.nc .........OK
- Moving atmf036.tile3.nc .........OK
- Moving atmf036.tile4.nc .........OK
- Moving atmf036.tile5.nc .........OK
- Moving atmf036.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-23-64800.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
-
-[0] The total amount of wall time                        = 984.974976
-[0] The maximum resident set size (KB)                   = 741840
-
-Test 006 cpld_control_c192_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_control_c384_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_control_c384_p8
-Checking test 007 cpld_control_c384_p8 results ....
-Moving baseline 007 cpld_control_c384_p8 files ....
- Moving sfcf006.nc .........OK
- Moving atmf006.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/MOM.res_1.nc .........OK
- Moving RESTART/MOM.res_2.nc .........OK
- Moving RESTART/MOM.res_3.nc .........OK
- Moving RESTART/iced.2021-03-22-43200.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
-
-[0] The total amount of wall time                        = 1109.218165
-[0] The maximum resident set size (KB)                   = 1272092
-
-Test 007 cpld_control_c384_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/cpld_debug_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/cpld_debug_p8
-Checking test 008 cpld_debug_p8 results ....
-Moving baseline 008 cpld_debug_p8 files ....
- Moving sfcf006.tile1.nc .........OK
- Moving sfcf006.tile2.nc .........OK
- Moving sfcf006.tile3.nc .........OK
- Moving sfcf006.tile4.nc .........OK
- Moving sfcf006.tile5.nc .........OK
- Moving sfcf006.tile6.nc .........OK
- Moving atmf006.tile1.nc .........OK
- Moving atmf006.tile2.nc .........OK
- Moving atmf006.tile3.nc .........OK
- Moving atmf006.tile4.nc .........OK
- Moving atmf006.tile5.nc .........OK
- Moving atmf006.tile6.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2021-03-22-43200.nc .........OK
- Moving RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
-
-[0] The total amount of wall time                        = 705.937330
-[0] The maximum resident set size (KB)                   = 610280
-
-Test 008 cpld_debug_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control
-Checking test 009 control results ....
-Moving baseline 009 control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 139.824290
-[0] The maximum resident set size (KB)                   = 472784
-
-Test 009 control PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_CubedSphereGrid
-Checking test 010 control_CubedSphereGrid results ....
-Moving baseline 010 control_CubedSphereGrid files ....
- Moving sfcf000.tile1.nc .........OK
- Moving sfcf000.tile2.nc .........OK
- Moving sfcf000.tile3.nc .........OK
- Moving sfcf000.tile4.nc .........OK
- Moving sfcf000.tile5.nc .........OK
- Moving sfcf000.tile6.nc .........OK
- Moving sfcf024.tile1.nc .........OK
- Moving sfcf024.tile2.nc .........OK
- Moving sfcf024.tile3.nc .........OK
- Moving sfcf024.tile4.nc .........OK
- Moving sfcf024.tile5.nc .........OK
- Moving sfcf024.tile6.nc .........OK
- Moving atmf000.tile1.nc .........OK
- Moving atmf000.tile2.nc .........OK
- Moving atmf000.tile3.nc .........OK
- Moving atmf000.tile4.nc .........OK
- Moving atmf000.tile5.nc .........OK
- Moving atmf000.tile6.nc .........OK
- Moving atmf024.tile1.nc .........OK
- Moving atmf024.tile2.nc .........OK
- Moving atmf024.tile3.nc .........OK
- Moving atmf024.tile4.nc .........OK
- Moving atmf024.tile5.nc .........OK
- Moving atmf024.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 135.066669
-[0] The maximum resident set size (KB)                   = 471892
-
-Test 010 control_CubedSphereGrid PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_latlon
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_latlon
-Checking test 011 control_latlon results ....
-Moving baseline 011 control_latlon files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 136.521346
-[0] The maximum resident set size (KB)                   = 469748
-
-Test 011 control_latlon PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_wrtGauss_netcdf_parallel
-Checking test 012 control_wrtGauss_netcdf_parallel results ....
-Moving baseline 012 control_wrtGauss_netcdf_parallel files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 142.343431
-[0] The maximum resident set size (KB)                   = 467800
-
-Test 012 control_wrtGauss_netcdf_parallel PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c48
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_c48
-Checking test 013 control_c48 results ....
-Moving baseline 013 control_c48 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 439.688762
-[0] The maximum resident set size (KB)                   = 658908
-
-Test 013 control_c48 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_c192
-Checking test 014 control_c192 results ....
-Moving baseline 014 control_c192 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 550.125929
-[0] The maximum resident set size (KB)                   = 577172
-
-Test 014 control_c192 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c384
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_c384
-Checking test 015 control_c384 results ....
-Moving baseline 015 control_c384 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
-
-[0] The total amount of wall time                        = 1037.682095
-[0] The maximum resident set size (KB)                   = 861672
-
-Test 015 control_c384 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_c384gdas
-Checking test 016 control_c384gdas results ....
-Moving baseline 016 control_c384gdas files ....
- Moving sfcf000.nc .........OK
- Moving sfcf006.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf006.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF06 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF06 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 906.621462
-[0] The maximum resident set size (KB)                   = 996156
-
-Test 016 control_c384gdas PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_stochy
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_stochy
-Checking test 017 control_stochy results ....
-Moving baseline 017 control_stochy files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
-
-[0] The total amount of wall time                        = 92.122540
-[0] The maximum resident set size (KB)                   = 473536
-
-Test 017 control_stochy PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_lndp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_lndp
-Checking test 018 control_lndp results ....
-Moving baseline 018 control_lndp files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
-
-[0] The total amount of wall time                        = 84.666389
-[0] The maximum resident set size (KB)                   = 472640
-
-Test 018 control_lndp PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_iovr4
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_iovr4
-Checking test 019 control_iovr4 results ....
-Moving baseline 019 control_iovr4 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 140.792369
-[0] The maximum resident set size (KB)                   = 469244
-
-Test 019 control_iovr4 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_iovr5
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_iovr5
-Checking test 020 control_iovr5 results ....
-Moving baseline 020 control_iovr5 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 138.956254
-[0] The maximum resident set size (KB)                   = 467596
-
-Test 020 control_iovr5 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_p8
-Checking test 021 control_p8 results ....
-Moving baseline 021 control_p8 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 152.571548
-[0] The maximum resident set size (KB)                   = 495548
-
-Test 021 control_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_p7_rrtmgp
-Checking test 022 control_p7_rrtmgp results ....
-Moving baseline 022 control_p7_rrtmgp files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 202.179054
-[0] The maximum resident set size (KB)                   = 594220
-
-Test 022 control_p7_rrtmgp PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_control
-Checking test 023 regional_control results ....
-Moving baseline 023 regional_control files ....
- Moving dynf000.nc .........OK
- Moving dynf024.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf024.nc .........OK
- Moving PRSLEV.GrbF00 .........OK
- Moving PRSLEV.GrbF24 .........OK
- Moving NATLEV.GrbF00 .........OK
- Moving NATLEV.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 346.909992
-[0] The maximum resident set size (KB)                   = 572908
-
-Test 023 regional_control PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_noquilt
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_noquilt
-Checking test 024 regional_noquilt results ....
-Moving baseline 024 regional_noquilt files ....
- Moving atmos_4xdaily.nc .........OK
- Moving fv3_history2d.nc .........OK
- Moving fv3_history.nc .........OK
- Moving RESTART/fv_core.res.tile1_new.nc .........OK
- Moving RESTART/fv_tracer.res.tile1_new.nc .........OK
-
-[0] The total amount of wall time                        = 370.226871
-[0] The maximum resident set size (KB)                   = 611548
-
-Test 024 regional_noquilt PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_hafs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_hafs
-Checking test 025 regional_hafs results ....
-Moving baseline 025 regional_hafs files ....
- Moving dynf000.nc .........OK
- Moving dynf024.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf024.nc .........OK
- Moving HURPRS.GrbF00 .........OK
- Moving HURPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 347.840499
-[0] The maximum resident set size (KB)                   = 574800
-
-Test 025 regional_hafs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_netcdf_parallel
-Checking test 026 regional_netcdf_parallel results ....
-Moving baseline 026 regional_netcdf_parallel files ....
- Moving dynf000.nc .........OK
- Moving dynf024.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf024.nc .........OK
-
-[0] The total amount of wall time                        = 345.562919
-[0] The maximum resident set size (KB)                   = 573468
-
-Test 026 regional_netcdf_parallel PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_RRTMGP
-Checking test 027 regional_RRTMGP results ....
-Moving baseline 027 regional_RRTMGP files ....
- Moving dynf000.nc .........OK
- Moving dynf024.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf024.nc .........OK
- Moving PRSLEV.GrbF00 .........OK
- Moving PRSLEV.GrbF24 .........OK
- Moving NATLEV.GrbF00 .........OK
- Moving NATLEV.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 453.769591
-[0] The maximum resident set size (KB)                   = 700216
-
-Test 027 regional_RRTMGP PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_control
-Checking test 028 rap_control results ....
-Moving baseline 028 rap_control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 393.636520
-[0] The maximum resident set size (KB)                   = 838584
-
-Test 028 rap_control PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_sfcdiff
-Checking test 029 rap_sfcdiff results ....
-Moving baseline 029 rap_sfcdiff files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 396.500828
-[0] The maximum resident set size (KB)                   = 843204
-
-Test 029 rap_sfcdiff PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hrrr_control
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hrrr_control
-Checking test 030 hrrr_control results ....
-Moving baseline 030 hrrr_control files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 378.500026
-[0] The maximum resident set size (KB)                   = 840204
-
-Test 030 hrrr_control PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rrfs_v1beta
-Checking test 031 rrfs_v1beta results ....
-Moving baseline 031 rrfs_v1beta files ....
- Moving sfcf000.nc .........OK
- Moving sfcf021.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf021.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF21 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF21 .........OK
- Moving GFSPRS.GrbF24 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 389.872859
-[0] The maximum resident set size (KB)                   = 833264
-
-Test 031 rrfs_v1beta PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rrfs_conus13km_hrrr_warm
-Checking test 032 rrfs_conus13km_hrrr_warm results ....
-Moving baseline 032 rrfs_conus13km_hrrr_warm files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving sfcf002.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
- Moving atmf002.nc .........OK
-
-[0] The total amount of wall time                        = 180.982223
-[0] The maximum resident set size (KB)                   = 664784
-
-Test 032 rrfs_conus13km_hrrr_warm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rrfs_conus13km_radar_tten_warm
-Checking test 033 rrfs_conus13km_radar_tten_warm results ....
-Moving baseline 033 rrfs_conus13km_radar_tten_warm files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving sfcf002.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
- Moving atmf002.nc .........OK
-
-[0] The total amount of wall time                        = 181.760120
-[0] The maximum resident set size (KB)                   = 666208
-
-Test 033 rrfs_conus13km_radar_tten_warm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_rrtmgp
-Checking test 034 control_rrtmgp results ....
-Moving baseline 034 control_rrtmgp files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 223.009426
-[0] The maximum resident set size (KB)                   = 586516
-
-Test 034 control_rrtmgp PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp_c192
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_rrtmgp_c192
-Checking test 035 control_rrtmgp_c192 results ....
-Moving baseline 035 control_rrtmgp_c192 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
-
-[0] The total amount of wall time                        = 606.888890
-[0] The maximum resident set size (KB)                   = 802968
-
-Test 035 control_rrtmgp_c192 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_csawmg
-Checking test 036 control_csawmg results ....
-Moving baseline 036 control_csawmg files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 362.630540
-[0] The maximum resident set size (KB)                   = 532176
-
-Test 036 control_csawmg PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_csawmgt
-Checking test 037 control_csawmgt results ....
-Moving baseline 037 control_csawmgt files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 358.891618
-[0] The maximum resident set size (KB)                   = 529648
-
-Test 037 control_csawmgt PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_flake
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_flake
-Checking test 038 control_flake results ....
-Moving baseline 038 control_flake files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 244.200183
-[0] The maximum resident set size (KB)                   = 543328
-
-Test 038 control_flake PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_ras
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_ras
-Checking test 039 control_ras results ....
-Moving baseline 039 control_ras files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 190.879981
-[0] The maximum resident set size (KB)                   = 501860
-
-Test 039 control_ras PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson
-Checking test 040 control_thompson results ....
-Moving baseline 040 control_thompson files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 239.809449
-[0] The maximum resident set size (KB)                   = 855944
-
-Test 040 control_thompson PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson_no_aero
-Checking test 041 control_thompson_no_aero results ....
-Moving baseline 041 control_thompson_no_aero files ....
- Moving sfcf000.nc .........OK
- Moving sfcf024.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf024.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF24 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF24 .........OK
-
-[0] The total amount of wall time                        = 229.271164
-[0] The maximum resident set size (KB)                   = 847720
-
-Test 041 control_thompson_no_aero PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wam_repro
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_wam_repro
-Checking test 042 control_wam results ....
-Moving baseline 042 control_wam files ....
- Moving sfcf024.nc .........OK
- Moving atmf024.nc .........OK
-
-[0] The total amount of wall time                        = 128.774819
-[0] The maximum resident set size (KB)                   = 232608
-
-Test 042 control_wam PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_debug
-Checking test 043 control_debug results ....
-Moving baseline 043 control_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 167.587538
-[0] The maximum resident set size (KB)                   = 538008
-
-Test 043 control_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_CubedSphereGrid_debug
-Checking test 044 control_CubedSphereGrid_debug results ....
-Moving baseline 044 control_CubedSphereGrid_debug files ....
- Moving sfcf000.tile1.nc .........OK
- Moving sfcf000.tile2.nc .........OK
- Moving sfcf000.tile3.nc .........OK
- Moving sfcf000.tile4.nc .........OK
- Moving sfcf000.tile5.nc .........OK
- Moving sfcf000.tile6.nc .........OK
- Moving sfcf001.tile1.nc .........OK
- Moving sfcf001.tile2.nc .........OK
- Moving sfcf001.tile3.nc .........OK
- Moving sfcf001.tile4.nc .........OK
- Moving sfcf001.tile5.nc .........OK
- Moving sfcf001.tile6.nc .........OK
- Moving atmf000.tile1.nc .........OK
- Moving atmf000.tile2.nc .........OK
- Moving atmf000.tile3.nc .........OK
- Moving atmf000.tile4.nc .........OK
- Moving atmf000.tile5.nc .........OK
- Moving atmf000.tile6.nc .........OK
- Moving atmf001.tile1.nc .........OK
- Moving atmf001.tile2.nc .........OK
- Moving atmf001.tile3.nc .........OK
- Moving atmf001.tile4.nc .........OK
- Moving atmf001.tile5.nc .........OK
- Moving atmf001.tile6.nc .........OK
-
-[0] The total amount of wall time                        = 181.504908
-[0] The maximum resident set size (KB)                   = 538520
-
-Test 044 control_CubedSphereGrid_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_wrtGauss_netcdf_parallel_debug
-Checking test 045 control_wrtGauss_netcdf_parallel_debug results ....
-Moving baseline 045 control_wrtGauss_netcdf_parallel_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 170.880018
-[0] The maximum resident set size (KB)                   = 539300
-
-Test 045 control_wrtGauss_netcdf_parallel_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_stochy_debug
-Checking test 046 control_stochy_debug results ....
-Moving baseline 046 control_stochy_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 191.828973
-[0] The maximum resident set size (KB)                   = 547048
-
-Test 046 control_stochy_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_lndp_debug
-Checking test 047 control_lndp_debug results ....
-Moving baseline 047 control_lndp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 171.515002
-[0] The maximum resident set size (KB)                   = 542056
-
-Test 047 control_lndp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_rrtmgp_debug
-Checking test 048 control_rrtmgp_debug results ....
-Moving baseline 048 control_rrtmgp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 186.476566
-[0] The maximum resident set size (KB)                   = 639392
-
-Test 048 control_rrtmgp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_csawmg_debug
-Checking test 049 control_csawmg_debug results ....
-Moving baseline 049 control_csawmg_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 268.697109
-[0] The maximum resident set size (KB)                   = 571840
-
-Test 049 control_csawmg_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_csawmgt_debug
-Checking test 050 control_csawmgt_debug results ....
-Moving baseline 050 control_csawmgt_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 265.316110
-[0] The maximum resident set size (KB)                   = 572584
-
-Test 050 control_csawmgt_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_ras_debug
-Checking test 051 control_ras_debug results ....
-Moving baseline 051 control_ras_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 174.091512
-[0] The maximum resident set size (KB)                   = 551864
-
-Test 051 control_ras_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_diag_debug
-Checking test 052 control_diag_debug results ....
-Moving baseline 052 control_diag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 177.009092
-[0] The maximum resident set size (KB)                   = 596348
-
-Test 052 control_diag_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_debug_p8
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_debug_p8
-Checking test 053 control_debug_p8 results ....
-Moving baseline 053 control_debug_p8 files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 183.160682
-[0] The maximum resident set size (KB)                   = 557976
-
-Test 053 control_debug_p8 PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson_debug
-Checking test 054 control_thompson_debug results ....
-Moving baseline 054 control_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 197.040756
-[0] The maximum resident set size (KB)                   = 897200
-
-Test 054 control_thompson_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson_no_aero_debug
-Checking test 055 control_thompson_no_aero_debug results ....
-Moving baseline 055 control_thompson_no_aero_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 189.732361
-[0] The maximum resident set size (KB)                   = 896512
-
-Test 055 control_thompson_no_aero_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson_extdiag_debug
-Checking test 056 control_thompson_extdiag_debug results ....
-Moving baseline 056 control_thompson_extdiag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 206.746302
-[0] The maximum resident set size (KB)                   = 927160
-
-Test 056 control_thompson_extdiag_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_thompson_progcld_thompson_debug
-Checking test 057 control_thompson_progcld_thompson_debug results ....
-Moving baseline 057 control_thompson_progcld_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 196.384089
-[0] The maximum resident set size (KB)                   = 899248
-
-Test 057 control_thompson_progcld_thompson_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/fv3_regional_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/regional_debug
-Checking test 058 regional_debug results ....
-Moving baseline 058 regional_debug files ....
- Moving dynf000.nc .........OK
- Moving dynf001.nc .........OK
- Moving phyf000.nc .........OK
- Moving phyf001.nc .........OK
-
-[0] The total amount of wall time                        = 283.411979
-[0] The maximum resident set size (KB)                   = 599140
-
-Test 058 regional_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_control_debug
-Checking test 059 rap_control_debug results ....
-Moving baseline 059 rap_control_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 304.372296
-[0] The maximum resident set size (KB)                   = 903304
-
-Test 059 rap_control_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_diag_debug
-Checking test 060 rap_diag_debug results ....
-Moving baseline 060 rap_diag_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 320.979339
-[0] The maximum resident set size (KB)                   = 992108
-
-Test 060 rap_diag_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_cires_ugwp_debug
-Checking test 061 rap_cires_ugwp_debug results ....
-Moving baseline 061 rap_cires_ugwp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 312.079602
-[0] The maximum resident set size (KB)                   = 903332
-
-Test 061 rap_cires_ugwp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_noah_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_noah_debug
-Checking test 062 rap_noah_debug results ....
-Moving baseline 062 rap_noah_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 301.523014
-[0] The maximum resident set size (KB)                   = 906928
-
-Test 062 rap_noah_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_rrtmgp_debug
-Checking test 063 rap_rrtmgp_debug results ....
-Moving baseline 063 rap_rrtmgp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 519.639698
-[0] The maximum resident set size (KB)                   = 1002624
-
-Test 063 rap_rrtmgp_debug PASS Tries: 2
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_lndp_debug
-Checking test 064 rap_lndp_debug results ....
-Moving baseline 064 rap_lndp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 307.538457
-[0] The maximum resident set size (KB)                   = 906580
-
-Test 064 rap_lndp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_sfcdiff_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_sfcdiff_debug
-Checking test 065 rap_sfcdiff_debug results ....
-Moving baseline 065 rap_sfcdiff_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 306.541609
-[0] The maximum resident set size (KB)                   = 906012
-
-Test 065 rap_sfcdiff_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_flake_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_flake_debug
-Checking test 066 rap_flake_debug results ....
-Moving baseline 066 rap_flake_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 304.390004
-[0] The maximum resident set size (KB)                   = 902988
-
-Test 066 rap_flake_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_noah_sfcdiff_cires_ugwp_debug
-Checking test 067 rap_noah_sfcdiff_cires_ugwp_debug results ....
-Moving baseline 067 rap_noah_sfcdiff_cires_ugwp_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 507.620366
-[0] The maximum resident set size (KB)                   = 901848
-
-Test 067 rap_noah_sfcdiff_cires_ugwp_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rap_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rap_progcld_thompson_debug
-Checking test 068 rap_progcld_thompson_debug results ....
-Moving baseline 068 rap_progcld_thompson_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 305.475789
-[0] The maximum resident set size (KB)                   = 907688
-
-Test 068 rap_progcld_thompson_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/rrfs_v1beta_debug
-Checking test 069 rrfs_v1beta_debug results ....
-Moving baseline 069 rrfs_v1beta_debug files ....
- Moving sfcf000.nc .........OK
- Moving sfcf001.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf001.nc .........OK
-
-[0] The total amount of wall time                        = 303.200138
-[0] The maximum resident set size (KB)                   = 905628
-
-Test 069 rrfs_v1beta_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_wam_debug
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_wam_debug
-Checking test 070 control_wam_debug results ....
-Moving baseline 070 control_wam_debug files ....
- Moving sfcf019.nc .........OK
- Moving atmf019.nc .........OK
-
-[0] The total amount of wall time                        = 322.816472
-[0] The maximum resident set size (KB)                   = 259248
-
-Test 070 control_wam_debug PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_atm
-Checking test 071 hafs_regional_atm results ....
-Moving baseline 071 hafs_regional_atm files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
-
-[0] The total amount of wall time                        = 607.332524
-[0] The maximum resident set size (KB)                   = 730720
-
-Test 071 hafs_regional_atm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_atm_thompson_gfdlsf
-Checking test 072 hafs_regional_atm_thompson_gfdlsf results ....
-Moving baseline 072 hafs_regional_atm_thompson_gfdlsf files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
-
-[0] The total amount of wall time                        = 275.663641
-[0] The maximum resident set size (KB)                   = 1083696
-
-Test 072 hafs_regional_atm_thompson_gfdlsf PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_atm_ocn
-Checking test 073 hafs_regional_atm_ocn results ....
-Moving baseline 073 hafs_regional_atm_ocn files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving archv.2019_241_06.a .........OK
- Moving archs.2019_241_06.a .........OK
- Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
-
-[0] The total amount of wall time                        = 391.630687
-[0] The maximum resident set size (KB)                   = 740160
-
-Test 073 hafs_regional_atm_ocn PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_wav
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_atm_wav
-Checking test 074 hafs_regional_atm_wav results ....
-Moving baseline 074 hafs_regional_atm_wav files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving out_grd.ww3 .........OK
- Moving out_pnt.ww3 .........OK
-
-[0] The total amount of wall time                        = 815.261291
-[0] The maximum resident set size (KB)                   = 738740
-
-Test 074 hafs_regional_atm_wav PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_atm_ocn_wav
-Checking test 075 hafs_regional_atm_ocn_wav results ....
-Moving baseline 075 hafs_regional_atm_ocn_wav files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving archv.2019_241_06.a .........OK
- Moving archs.2019_241_06.a .........OK
- Moving out_grd.ww3 .........OK
- Moving out_pnt.ww3 .........OK
-
-[0] The total amount of wall time                        = 900.128575
-[0] The maximum resident set size (KB)                   = 745100
-
-Test 075 hafs_regional_atm_ocn_wav PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_1nest_atm
-Checking test 076 hafs_regional_1nest_atm results ....
-Moving baseline 076 hafs_regional_1nest_atm files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving atm.nest02.f006.nc .........OK
- Moving sfc.nest02.f006.nc .........OK
-
-[0] The total amount of wall time                        = 654.463836
-[0] The maximum resident set size (KB)                   = 314940
-
-Test 076 hafs_regional_1nest_atm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_telescopic_2nests_atm
-Checking test 077 hafs_regional_telescopic_2nests_atm results ....
-Moving baseline 077 hafs_regional_telescopic_2nests_atm files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving atm.nest02.f006.nc .........OK
- Moving sfc.nest02.f006.nc .........OK
- Moving atm.nest03.f006.nc .........OK
- Moving sfc.nest03.f006.nc .........OK
-
-[0] The total amount of wall time                        = 791.102514
-[0] The maximum resident set size (KB)                   = 328972
-
-Test 077 hafs_regional_telescopic_2nests_atm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_global_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_global_1nest_atm
-Checking test 078 hafs_global_1nest_atm results ....
-Moving baseline 078 hafs_global_1nest_atm files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving atm.nest02.f006.nc .........OK
- Moving sfc.nest02.f006.nc .........OK
-
-[0] The total amount of wall time                        = 662.326343
-[0] The maximum resident set size (KB)                   = 221784
-
-Test 078 hafs_global_1nest_atm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_global_multiple_4nests_atm
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_global_multiple_4nests_atm
-Checking test 079 hafs_global_multiple_4nests_atm results ....
-Moving baseline 079 hafs_global_multiple_4nests_atm files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving atm.nest02.f006.nc .........OK
- Moving sfc.nest02.f006.nc .........OK
- Moving atm.nest03.f006.nc .........OK
- Moving atm.nest03.f006.nc .........OK
- Moving sfc.nest04.f006.nc .........OK
- Moving sfc.nest04.f006.nc .........OK
- Moving atm.nest05.f006.nc .........OK
- Moving sfc.nest05.f006.nc .........OK
-
-[0] The total amount of wall time                        = 1318.542362
-[0] The maximum resident set size (KB)                   = 298036
-
-Test 079 hafs_global_multiple_4nests_atm PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_docn
-Checking test 080 hafs_regional_docn results ....
-Moving baseline 080 hafs_regional_docn files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
- Moving ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
-
-[0] The total amount of wall time                        = 375.413501
-[0] The maximum resident set size (KB)                   = 745216
-
-Test 080 hafs_regional_docn PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_docn_oisst
-Checking test 081 hafs_regional_docn_oisst results ....
-Moving baseline 081 hafs_regional_docn_oisst files ....
- Moving atmf006.nc .........OK
- Moving sfcf006.nc .........OK
- Moving ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
- Moving ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
- Moving ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
-
-[0] The total amount of wall time                        = 373.834237
-[0] The maximum resident set size (KB)                   = 739292
-
-Test 081 hafs_regional_docn_oisst PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/hafs_regional_datm_cdeps
-Checking test 082 hafs_regional_datm_cdeps results ....
-Moving baseline 082 hafs_regional_datm_cdeps files ....
- Moving ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
- Moving ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
- Moving ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
-
-[0] The total amount of wall time                        = 1086.602323
-[0] The maximum resident set size (KB)                   = 896452
-
-Test 082 hafs_regional_datm_cdeps PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_control_cfsr
-Checking test 083 datm_cdeps_control_cfsr results ....
-Moving baseline 083 datm_cdeps_control_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 174.835387
-[0] The maximum resident set size (KB)                   = 723204
-
-Test 083 datm_cdeps_control_cfsr PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_control_gefs
-Checking test 084 datm_cdeps_control_gefs results ....
-Moving baseline 084 datm_cdeps_control_gefs files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 167.850574
-[0] The maximum resident set size (KB)                   = 625568
-
-Test 084 datm_cdeps_control_gefs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_stochy_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_stochy_gefs
-Checking test 085 datm_cdeps_stochy_gefs results ....
-Moving baseline 085 datm_cdeps_stochy_gefs files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 170.351067
-[0] The maximum resident set size (KB)                   = 625680
-
-Test 085 datm_cdeps_stochy_gefs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_bulk_cfsr
-Checking test 086 datm_cdeps_bulk_cfsr results ....
-Moving baseline 086 datm_cdeps_bulk_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 173.769327
-[0] The maximum resident set size (KB)                   = 719180
-
-Test 086 datm_cdeps_bulk_cfsr PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_bulk_gefs
-Checking test 087 datm_cdeps_bulk_gefs results ....
-Moving baseline 087 datm_cdeps_bulk_gefs files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 169.557243
-[0] The maximum resident set size (KB)                   = 624244
-
-Test 087 datm_cdeps_bulk_gefs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_mx025_cfsr
-Checking test 088 datm_cdeps_mx025_cfsr results ....
-Moving baseline 088 datm_cdeps_mx025_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/MOM.res_1.nc .........OK
- Moving RESTART/MOM.res_2.nc .........OK
- Moving RESTART/MOM.res_3.nc .........OK
- Moving RESTART/iced.2011-10-01-43200.nc .........OK
- Moving RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
-
-[0] The total amount of wall time                        = 352.345770
-[0] The maximum resident set size (KB)                   = 574328
-
-Test 088 datm_cdeps_mx025_cfsr PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_mx025_gefs
-Checking test 089 datm_cdeps_mx025_gefs results ....
-Moving baseline 089 datm_cdeps_mx025_gefs files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/MOM.res_1.nc .........OK
- Moving RESTART/MOM.res_2.nc .........OK
- Moving RESTART/MOM.res_3.nc .........OK
- Moving RESTART/iced.2011-10-01-43200.nc .........OK
- Moving RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
-
-[0] The total amount of wall time                        = 339.476119
-[0] The maximum resident set size (KB)                   = 539704
-
-Test 089 datm_cdeps_mx025_gefs PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_3072x1536_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_3072x1536_cfsr
-Checking test 090 datm_cdeps_3072x1536_cfsr results ....
-Moving baseline 090 datm_cdeps_3072x1536_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-02-00000.nc .........OK
- Moving RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
-
-[0] The total amount of wall time                        = 248.531261
-[0] The maximum resident set size (KB)                   = 1834616
-
-Test 090 datm_cdeps_3072x1536_cfsr PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/datm_cdeps_debug_cfsr
-Checking test 091 datm_cdeps_debug_cfsr results ....
-Moving baseline 091 datm_cdeps_debug_cfsr files ....
- Moving RESTART/MOM.res.nc .........OK
- Moving RESTART/iced.2011-10-01-21600.nc .........OK
- Moving RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
-
-[0] The total amount of wall time                        = 500.609308
-[0] The maximum resident set size (KB)                   = 727664
-
-Test 091 datm_cdeps_debug_cfsr PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_atmwav
-Checking test 092 control_atmwav results ....
-Moving baseline 092 control_atmwav files ....
- Moving sfcf000.nc .........OK
- Moving sfcf012.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf012.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF12 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF12 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving 20210322.180000.restart.glo_1deg .........OK
-
-[0] The total amount of wall time                        = 93.575139
-[0] The maximum resident set size (KB)                   = 489872
-
-Test 092 control_atmwav PASS
-
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220214/control_c384gdas_wav
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_1101/control_c384gdas_wav
-Checking test 093 control_c384gdas_wav results ....
-Moving baseline 093 control_c384gdas_wav files ....
- Moving sfcf000.nc .........OK
- Moving sfcf003.nc .........OK
- Moving atmf000.nc .........OK
- Moving atmf003.nc .........OK
- Moving GFSFLX.GrbF00 .........OK
- Moving GFSFLX.GrbF03 .........OK
- Moving GFSPRS.GrbF00 .........OK
- Moving GFSPRS.GrbF03 .........OK
- Moving RESTART/coupler.res .........OK
- Moving RESTART/fv_core.res.nc .........OK
- Moving RESTART/fv_core.res.tile1.nc .........OK
- Moving RESTART/fv_core.res.tile2.nc .........OK
- Moving RESTART/fv_core.res.tile3.nc .........OK
- Moving RESTART/fv_core.res.tile4.nc .........OK
- Moving RESTART/fv_core.res.tile5.nc .........OK
- Moving RESTART/fv_core.res.tile6.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Moving RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Moving RESTART/fv_tracer.res.tile1.nc .........OK
- Moving RESTART/fv_tracer.res.tile2.nc .........OK
- Moving RESTART/fv_tracer.res.tile3.nc .........OK
- Moving RESTART/fv_tracer.res.tile4.nc .........OK
- Moving RESTART/fv_tracer.res.tile5.nc .........OK
- Moving RESTART/fv_tracer.res.tile6.nc .........OK
- Moving RESTART/phy_data.tile1.nc .........OK
- Moving RESTART/phy_data.tile2.nc .........OK
- Moving RESTART/phy_data.tile3.nc .........OK
- Moving RESTART/phy_data.tile4.nc .........OK
- Moving RESTART/phy_data.tile5.nc .........OK
- Moving RESTART/phy_data.tile6.nc .........OK
- Moving RESTART/sfc_data.tile1.nc .........OK
- Moving RESTART/sfc_data.tile2.nc .........OK
- Moving RESTART/sfc_data.tile3.nc .........OK
- Moving RESTART/sfc_data.tile4.nc .........OK
- Moving RESTART/sfc_data.tile5.nc .........OK
- Moving RESTART/sfc_data.tile6.nc .........OK
- Moving 20210322.030000.restart.aoc_9km .........OK
- Moving 20210322.030000.restart.gnh_10m .........OK
- Moving 20210322.030000.restart.gsh_15m .........OK
-
-[0] The total amount of wall time                        = 613.639791
-[0] The maximum resident set size (KB)                   = 1050652
-
-Test 093 control_c384gdas_wav PASS
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_2threads_p8
+Checking test 002 cpld_2threads_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
+
+[0] The total amount of wall time                        = 231.060779
+[0] The maximum resident set size (KB)                   = 639300
+
+Test 002 cpld_2threads_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_decomp_p8
+Checking test 003 cpld_decomp_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
+
+[0] The total amount of wall time                        = 246.371875
+[0] The maximum resident set size (KB)                   = 554512
+
+Test 003 cpld_decomp_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_mpi_p8
+Checking test 004 cpld_mpi_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
+
+[0] The total amount of wall time                        = 208.046266
+[0] The maximum resident set size (KB)                   = 536276
+
+Test 004 cpld_mpi_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_p7_rrtmgp
+Checking test 005 cpld_control_p7_rrtmgp results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_grd.glo_1deg .........OK
+ Comparing 20210323.060000.out_pnt.points .........OK
+ Comparing 20210323.060000.restart.glo_1deg .........OK
+
+[0] The total amount of wall time                        = 289.412041
+[0] The maximum resident set size (KB)                   = 653480
+
+Test 005 cpld_control_p7_rrtmgp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p7
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_p7
+Checking test 006 cpld_bmark_p7 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing 20130401.060000.out_grd.gwes_30m .........OK
+ Comparing 20130401.060000.out_pnt.points .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+
+[0] The total amount of wall time                        = 1008.765261
+[0] The maximum resident set size (KB)                   = 1268340
+
+Test 006 cpld_bmark_p7 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_p8
+Checking test 007 cpld_bmark_p8 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing 20130401.060000.out_grd.gwes_30m .........OK
+ Comparing 20130401.060000.out_pnt.points .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+
+[0] The total amount of wall time                        = 1009.114691
+[0] The maximum resident set size (KB)                   = 1271004
+
+Test 007 cpld_bmark_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_mpi_p8
+Checking test 008 cpld_bmark_mpi_p8 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing 20130401.060000.out_grd.gwes_30m .........OK
+ Comparing 20130401.060000.out_pnt.points .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+
+[0] The total amount of wall time                        = 1008.999599
+[0] The maximum resident set size (KB)                   = 1273312
+
+Test 008 cpld_bmark_mpi_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c96_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c96_p8
+Checking test 009 cpld_control_c96_p8 results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+
+[0] The total amount of wall time                        = 233.911751
+[0] The maximum resident set size (KB)                   = 549820
+
+Test 009 cpld_control_c96_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c96_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c96_p8
+Checking test 010 cpld_restart_c96_p8 results ....
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+
+[0] The total amount of wall time                        = 126.770620
+[0] The maximum resident set size (KB)                   = 340652
+
+Test 010 cpld_restart_c96_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c192_p8
+Checking test 011 cpld_control_c192_p8 results ....
+ Comparing sfcf036.tile1.nc .........OK
+ Comparing sfcf036.tile2.nc .........OK
+ Comparing sfcf036.tile3.nc .........OK
+ Comparing sfcf036.tile4.nc .........OK
+ Comparing sfcf036.tile5.nc .........OK
+ Comparing sfcf036.tile6.nc .........OK
+ Comparing atmf036.tile1.nc .........OK
+ Comparing atmf036.tile2.nc .........OK
+ Comparing atmf036.tile3.nc .........OK
+ Comparing atmf036.tile4.nc .........OK
+ Comparing atmf036.tile5.nc .........OK
+ Comparing atmf036.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-64800.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
+
+[0] The total amount of wall time                        = 988.866429
+[0] The maximum resident set size (KB)                   = 739052
+
+Test 011 cpld_control_c192_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c192_p8
+Checking test 012 cpld_restart_c192_p8 results ....
+ Comparing sfcf036.tile1.nc .........OK
+ Comparing sfcf036.tile2.nc .........OK
+ Comparing sfcf036.tile3.nc .........OK
+ Comparing sfcf036.tile4.nc .........OK
+ Comparing sfcf036.tile5.nc .........OK
+ Comparing sfcf036.tile6.nc .........OK
+ Comparing atmf036.tile1.nc .........OK
+ Comparing atmf036.tile2.nc .........OK
+ Comparing atmf036.tile3.nc .........OK
+ Comparing atmf036.tile4.nc .........OK
+ Comparing atmf036.tile5.nc .........OK
+ Comparing atmf036.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-64800.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
+
+[0] The total amount of wall time                        = 620.361939
+[0] The maximum resident set size (KB)                   = 828324
+
+Test 012 cpld_restart_c192_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c384_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c384_p8
+Checking test 013 cpld_control_c384_p8 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2021-03-22-43200.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
+
+[0] The total amount of wall time                        = 1107.840100
+[0] The maximum resident set size (KB)                   = 1275520
+
+Test 013 cpld_control_c384_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c384_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c384_p8
+Checking test 014 cpld_restart_c384_p8 results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2021-03-22-43200.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
+
+[0] The total amount of wall time                        = 601.317393
+[0] The maximum resident set size (KB)                   = 1233840
+
+Test 014 cpld_restart_c384_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_debug_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_debug_p8
+Checking test 015 cpld_debug_p8 results ....
+ Comparing sfcf006.tile1.nc .........OK
+ Comparing sfcf006.tile2.nc .........OK
+ Comparing sfcf006.tile3.nc .........OK
+ Comparing sfcf006.tile4.nc .........OK
+ Comparing sfcf006.tile5.nc .........OK
+ Comparing sfcf006.tile6.nc .........OK
+ Comparing atmf006.tile1.nc .........OK
+ Comparing atmf006.tile2.nc .........OK
+ Comparing atmf006.tile3.nc .........OK
+ Comparing atmf006.tile4.nc .........OK
+ Comparing atmf006.tile5.nc .........OK
+ Comparing atmf006.tile6.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-22-43200.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
+
+[0] The total amount of wall time                        = 704.938739
+[0] The maximum resident set size (KB)                   = 607624
+
+Test 015 cpld_debug_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control
+Checking test 016 control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 141.718615
+[0] The maximum resident set size (KB)                   = 468332
+
+Test 016 control PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_decomp
+Checking test 017 control_decomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 145.591709
+[0] The maximum resident set size (KB)                   = 473152
+
+Test 017 control_decomp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2dwrtdecomp
+Checking test 018 control_2dwrtdecomp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+
+[0] The total amount of wall time                        = 134.506593
+[0] The maximum resident set size (KB)                   = 470852
+
+Test 018 control_2dwrtdecomp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads
+Checking test 019 control_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 129.593650
+[0] The maximum resident set size (KB)                   = 512200
+
+Test 019 control_2threads PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_restart
+Checking test 020 control_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 73.852335
+[0] The maximum resident set size (KB)                   = 212988
+
+Test 020 control_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_fhzero
+Checking test 021 control_fhzero results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf021.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 133.120062
+[0] The maximum resident set size (KB)                   = 472468
+
+Test 021 control_fhzero PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_CubedSphereGrid
+Checking test 022 control_CubedSphereGrid results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 135.744734
+[0] The maximum resident set size (KB)                   = 472132
+
+Test 022 control_CubedSphereGrid PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_latlon
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_latlon
+Checking test 023 control_latlon results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 137.577266
+[0] The maximum resident set size (KB)                   = 467556
+
+Test 023 control_latlon PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wrtGauss_netcdf_parallel
+Checking test 024 control_wrtGauss_netcdf_parallel results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 141.784249
+[0] The maximum resident set size (KB)                   = 468704
+
+Test 024 control_wrtGauss_netcdf_parallel PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c48
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c48
+Checking test 025 control_c48 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 437.840977
+[0] The maximum resident set size (KB)                   = 658520
+
+Test 025 control_c48 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c192
+Checking test 026 control_c192 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 551.450918
+[0] The maximum resident set size (KB)                   = 574424
+
+Test 026 control_c192 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384
+Checking test 027 control_c384 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 1032.443555
+[0] The maximum resident set size (KB)                   = 856176
+
+Test 027 control_c384 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384gdas
+Checking test 028 control_c384gdas results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF06 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF06 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 891.174537
+[0] The maximum resident set size (KB)                   = 991332
+
+Test 028 control_c384gdas PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy
+Checking test 029 control_stochy results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 92.055453
+[0] The maximum resident set size (KB)                   = 470264
+
+Test 029 control_stochy PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy_restart
+Checking test 030 control_stochy_restart results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 50.563766
+[0] The maximum resident set size (KB)                   = 271980
+
+Test 030 control_stochy_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_lndp
+Checking test 031 control_lndp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 84.392980
+[0] The maximum resident set size (KB)                   = 473372
+
+Test 031 control_lndp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr4
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_iovr4
+Checking test 032 control_iovr4 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 141.296118
+[0] The maximum resident set size (KB)                   = 468684
+
+Test 032 control_iovr4 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr5
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_iovr5
+Checking test 033 control_iovr5 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 138.726884
+[0] The maximum resident set size (KB)                   = 470548
+
+Test 033 control_iovr5 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_p8
+Checking test 034 control_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 152.421897
+[0] The maximum resident set size (KB)                   = 495708
+
+Test 034 control_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_restart_p8
+Checking test 035 control_restart_p8 results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 83.130962
+[0] The maximum resident set size (KB)                   = 310200
+
+Test 035 control_restart_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_decomp_p8
+Checking test 036 control_decomp_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 158.879156
+[0] The maximum resident set size (KB)                   = 487444
+
+Test 036 control_decomp_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads_p8
+Checking test 037 control_2threads_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 142.495847
+[0] The maximum resident set size (KB)                   = 566572
+
+Test 037 control_2threads_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_p7_rrtmgp
+Checking test 038 control_p7_rrtmgp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 201.967502
+[0] The maximum resident set size (KB)                   = 592152
+
+Test 038 control_p7_rrtmgp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_control
+Checking test 039 regional_control results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF24 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 346.932710
+[0] The maximum resident set size (KB)                   = 575544
+
+Test 039 regional_control PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_restart
+Checking test 040 regional_restart results ....
+ Comparing dynf024.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing PRSLEV.GrbF24 .........OK
+ Comparing NATLEV.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 191.629768
+[0] The maximum resident set size (KB)                   = 572668
+
+Test 040 regional_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_control_2dwrtdecomp
+Checking test 041 regional_control_2dwrtdecomp results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+
+[0] The total amount of wall time                        = 343.177414
+[0] The maximum resident set size (KB)                   = 569584
+
+Test 041 regional_control_2dwrtdecomp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_noquilt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_noquilt
+Checking test 042 regional_noquilt results ....
+ Comparing atmos_4xdaily.nc .........OK
+ Comparing fv3_history2d.nc .........OK
+ Comparing fv3_history.nc .........OK
+ Comparing RESTART/fv_core.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+
+[0] The total amount of wall time                        = 371.119616
+[0] The maximum resident set size (KB)                   = 611032
+
+Test 042 regional_noquilt PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_2threads
+Checking test 043 regional_2threads results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF24 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 194.935147
+[0] The maximum resident set size (KB)                   = 578684
+
+Test 043 regional_2threads PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_hafs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_hafs
+Checking test 044 regional_hafs results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing HURPRS.GrbF00 .........OK
+ Comparing HURPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 345.807094
+[0] The maximum resident set size (KB)                   = 569296
+
+Test 044 regional_hafs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_netcdf_parallel
+Checking test 045 regional_netcdf_parallel results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
+
+[0] The total amount of wall time                        = 344.453609
+[0] The maximum resident set size (KB)                   = 572288
+
+Test 045 regional_netcdf_parallel PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_RRTMGP
+Checking test 046 regional_RRTMGP results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF24 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 452.938495
+[0] The maximum resident set size (KB)                   = 695232
+
+Test 046 regional_RRTMGP PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_control
+Checking test 047 rap_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 394.968712
+[0] The maximum resident set size (KB)                   = 838716
+
+Test 047 rap_control PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_2threads
+Checking test 048 rap_2threads results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 372.200559
+[0] The maximum resident set size (KB)                   = 897280
+
+Test 048 rap_2threads PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_restart
+Checking test 049 rap_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 202.731629
+[0] The maximum resident set size (KB)                   = 589568
+
+Test 049 rap_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff
+Checking test 050 rap_sfcdiff results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 392.697571
+[0] The maximum resident set size (KB)                   = 839760
+
+Test 050 rap_sfcdiff PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff_restart
+Checking test 051 rap_sfcdiff_restart results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 201.515308
+[0] The maximum resident set size (KB)                   = 587252
+
+Test 051 rap_sfcdiff_restart PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hrrr_control
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hrrr_control
+Checking test 052 hrrr_control results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 380.441442
+[0] The maximum resident set size (KB)                   = 835952
+
+Test 052 hrrr_control PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_v1beta
+Checking test 053 rrfs_v1beta results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 392.015925
+[0] The maximum resident set size (KB)                   = 835540
+
+Test 053 rrfs_v1beta PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_conus13km_hrrr_warm
+Checking test 054 rrfs_conus13km_hrrr_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+[0] The total amount of wall time                        = 180.363937
+[0] The maximum resident set size (KB)                   = 662136
+
+Test 054 rrfs_conus13km_hrrr_warm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_conus13km_radar_tten_warm
+Checking test 055 rrfs_conus13km_radar_tten_warm results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+[0] The total amount of wall time                        = 183.113977
+[0] The maximum resident set size (KB)                   = 665684
+
+Test 055 rrfs_conus13km_radar_tten_warm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp
+Checking test 056 control_rrtmgp results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 222.897153
+[0] The maximum resident set size (KB)                   = 592084
+
+Test 056 control_rrtmgp PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_c192
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp_c192
+Checking test 057 control_rrtmgp_c192 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+[0] The total amount of wall time                        = 606.989592
+[0] The maximum resident set size (KB)                   = 802264
+
+Test 057 control_rrtmgp_c192 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmg
+Checking test 058 control_csawmg results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 362.312140
+[0] The maximum resident set size (KB)                   = 530132
+
+Test 058 control_csawmg PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmgt
+Checking test 059 control_csawmgt results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 360.357171
+[0] The maximum resident set size (KB)                   = 530480
+
+Test 059 control_csawmgt PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_flake
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_flake
+Checking test 060 control_flake results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 244.601435
+[0] The maximum resident set size (KB)                   = 542644
+
+Test 060 control_flake PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_ras
+Checking test 061 control_ras results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 190.470602
+[0] The maximum resident set size (KB)                   = 500636
+
+Test 061 control_ras PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson
+Checking test 062 control_thompson results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 239.780677
+[0] The maximum resident set size (KB)                   = 855036
+
+Test 062 control_thompson PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_no_aero
+Checking test 063 control_thompson_no_aero results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+[0] The total amount of wall time                        = 228.792013
+[0] The maximum resident set size (KB)                   = 853872
+
+Test 063 control_thompson_no_aero PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_repro
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wam_repro
+Checking test 064 control_wam results ....
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
+
+[0] The total amount of wall time                        = 126.589439
+[0] The maximum resident set size (KB)                   = 230616
+
+Test 064 control_wam PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_debug
+Checking test 065 control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 167.927801
+[0] The maximum resident set size (KB)                   = 538104
+
+Test 065 control_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads_debug
+Checking test 066 control_2threads_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 154.428442
+[0] The maximum resident set size (KB)                   = 581612
+
+Test 066 control_2threads_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_CubedSphereGrid_debug
+Checking test 067 control_CubedSphereGrid_debug results ....
+ Comparing sfcf000.tile1.nc .........OK
+ Comparing sfcf000.tile2.nc .........OK
+ Comparing sfcf000.tile3.nc .........OK
+ Comparing sfcf000.tile4.nc .........OK
+ Comparing sfcf000.tile5.nc .........OK
+ Comparing sfcf000.tile6.nc .........OK
+ Comparing sfcf001.tile1.nc .........OK
+ Comparing sfcf001.tile2.nc .........OK
+ Comparing sfcf001.tile3.nc .........OK
+ Comparing sfcf001.tile4.nc .........OK
+ Comparing sfcf001.tile5.nc .........OK
+ Comparing sfcf001.tile6.nc .........OK
+ Comparing atmf000.tile1.nc .........OK
+ Comparing atmf000.tile2.nc .........OK
+ Comparing atmf000.tile3.nc .........OK
+ Comparing atmf000.tile4.nc .........OK
+ Comparing atmf000.tile5.nc .........OK
+ Comparing atmf000.tile6.nc .........OK
+ Comparing atmf001.tile1.nc .........OK
+ Comparing atmf001.tile2.nc .........OK
+ Comparing atmf001.tile3.nc .........OK
+ Comparing atmf001.tile4.nc .........OK
+ Comparing atmf001.tile5.nc .........OK
+ Comparing atmf001.tile6.nc .........OK
+
+[0] The total amount of wall time                        = 182.332754
+[0] The maximum resident set size (KB)                   = 539392
+
+Test 067 control_CubedSphereGrid_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wrtGauss_netcdf_parallel_debug
+Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc ............ALT CHECK......OK
+
+[0] The total amount of wall time                        = 170.427890
+[0] The maximum resident set size (KB)                   = 541260
+
+Test 068 control_wrtGauss_netcdf_parallel_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy_debug
+Checking test 069 control_stochy_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 190.905291
+[0] The maximum resident set size (KB)                   = 542836
+
+Test 069 control_stochy_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_lndp_debug
+Checking test 070 control_lndp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 171.576756
+[0] The maximum resident set size (KB)                   = 546400
+
+Test 070 control_lndp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp_debug
+Checking test 071 control_rrtmgp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 186.143281
+[0] The maximum resident set size (KB)                   = 636000
+
+Test 071 control_rrtmgp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmg_debug
+Checking test 072 control_csawmg_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 268.779135
+[0] The maximum resident set size (KB)                   = 577864
+
+Test 072 control_csawmg_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmgt_debug
+Checking test 073 control_csawmgt_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 264.304771
+[0] The maximum resident set size (KB)                   = 575440
+
+Test 073 control_csawmgt_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_ras_debug
+Checking test 074 control_ras_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 173.611451
+[0] The maximum resident set size (KB)                   = 555572
+
+Test 074 control_ras_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_diag_debug
+Checking test 075 control_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 175.844821
+[0] The maximum resident set size (KB)                   = 594672
+
+Test 075 control_diag_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug_p8
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_debug_p8
+Checking test 076 control_debug_p8 results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 182.721944
+[0] The maximum resident set size (KB)                   = 557500
+
+Test 076 control_debug_p8 PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_debug
+Checking test 077 control_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 197.123535
+[0] The maximum resident set size (KB)                   = 899104
+
+Test 077 control_thompson_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_no_aero_debug
+Checking test 078 control_thompson_no_aero_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 189.364468
+[0] The maximum resident set size (KB)                   = 896412
+
+Test 078 control_thompson_no_aero_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug_extdiag
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_extdiag_debug
+Checking test 079 control_thompson_extdiag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 206.780258
+[0] The maximum resident set size (KB)                   = 930492
+
+Test 079 control_thompson_extdiag_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_progcld_thompson_debug
+Checking test 080 control_thompson_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 197.131237
+[0] The maximum resident set size (KB)                   = 900116
+
+Test 080 control_thompson_progcld_thompson_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_debug
+Checking test 081 regional_debug results ....
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+
+[0] The total amount of wall time                        = 282.085483
+[0] The maximum resident set size (KB)                   = 600520
+
+Test 081 regional_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_control_debug
+Checking test 082 rap_control_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 304.324363
+[0] The maximum resident set size (KB)                   = 906808
+
+Test 082 rap_control_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_unified_drag_suite_debug
+Checking test 083 rap_unified_drag_suite_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 304.566612
+[0] The maximum resident set size (KB)                   = 905552
+
+Test 083 rap_unified_drag_suite_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_diag_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_diag_debug
+Checking test 084 rap_diag_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 319.920442
+[0] The maximum resident set size (KB)                   = 990860
+
+Test 084 rap_diag_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_cires_ugwp_debug
+Checking test 085 rap_cires_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 310.050578
+[0] The maximum resident set size (KB)                   = 910360
+
+Test 085 rap_cires_ugwp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_unified_ugwp_debug
+Checking test 086 rap_unified_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 310.623462
+[0] The maximum resident set size (KB)                   = 905048
+
+Test 086 rap_unified_ugwp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_noah_debug
+Checking test 087 rap_noah_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 301.223543
+[0] The maximum resident set size (KB)                   = 902152
+
+Test 087 rap_noah_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_rrtmgp_debug
+Checking test 088 rap_rrtmgp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 518.748697
+[0] The maximum resident set size (KB)                   = 1006572
+
+Test 088 rap_rrtmgp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_lndp_debug
+Checking test 089 rap_lndp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 307.008339
+[0] The maximum resident set size (KB)                   = 906332
+
+Test 089 rap_lndp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff_debug
+Checking test 090 rap_sfcdiff_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 304.363459
+[0] The maximum resident set size (KB)                   = 903656
+
+Test 090 rap_sfcdiff_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_flake_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_flake_debug
+Checking test 091 rap_flake_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 304.142671
+[0] The maximum resident set size (KB)                   = 905304
+
+Test 091 rap_flake_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_noah_sfcdiff_cires_ugwp_debug
+Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 508.051705
+[0] The maximum resident set size (KB)                   = 905804
+
+Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_progcld_thompson_debug
+Checking test 093 rap_progcld_thompson_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 305.223939
+[0] The maximum resident set size (KB)                   = 907620
+
+Test 093 rap_progcld_thompson_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_v1beta_debug
+Checking test 094 rrfs_v1beta_debug results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+[0] The total amount of wall time                        = 303.640524
+[0] The maximum resident set size (KB)                   = 904820
+
+Test 094 rrfs_v1beta_debug PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm
+Checking test 096 hafs_regional_atm results ....
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
+
+[0] The total amount of wall time                        = 605.042526
+[0] The maximum resident set size (KB)                   = 725892
+
+Test 096 hafs_regional_atm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_thompson_gfdlsf
+Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+
+[0] The total amount of wall time                        = 276.488115
+[0] The maximum resident set size (KB)                   = 1084500
+
+Test 097 hafs_regional_atm_thompson_gfdlsf PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_ocn
+Checking test 098 hafs_regional_atm_ocn results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+
+[0] The total amount of wall time                        = 395.705296
+[0] The maximum resident set size (KB)                   = 739056
+
+Test 098 hafs_regional_atm_ocn PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_wav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_wav
+Checking test 099 hafs_regional_atm_wav results ....
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+
+[0] The total amount of wall time                        = 820.480627
+[0] The maximum resident set size (KB)                   = 737504
+
+Test 099 hafs_regional_atm_wav PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_ocn_wav
+Checking test 100 hafs_regional_atm_ocn_wav results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing archv.2019_241_06.a .........OK
+ Comparing archs.2019_241_06.a .........OK
+ Comparing out_grd.ww3 .........OK
+ Comparing out_pnt.ww3 .........OK
+
+[0] The total amount of wall time                        = 895.119830
+[0] The maximum resident set size (KB)                   = 746552
+
+Test 100 hafs_regional_atm_ocn_wav PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_1nest_atm
+Checking test 101 hafs_regional_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
+
+[0] The total amount of wall time                        = 657.367501
+[0] The maximum resident set size (KB)                   = 308392
+
+Test 101 hafs_regional_1nest_atm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_telescopic_2nests_atm
+Checking test 102 hafs_regional_telescopic_2nests_atm results ....
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing atm.nest03.f006.nc .........OK
+ Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
+
+[0] The total amount of wall time                        = 790.848344
+[0] The maximum resident set size (KB)                   = 326168
+
+Test 102 hafs_regional_telescopic_2nests_atm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_global_1nest_atm
+Checking test 103 hafs_global_1nest_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest02.f006.nc .........OK
+
+[0] The total amount of wall time                        = 665.430613
+[0] The maximum resident set size (KB)                   = 223172
+
+Test 103 hafs_global_1nest_atm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_multiple_4nests_atm
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_global_multiple_4nests_atm
+Checking test 104 hafs_global_multiple_4nests_atm results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
+ Comparing atm.nest03.f006.nc .........OK
+ Comparing atm.nest03.f006.nc .........OK
+ Comparing sfc.nest04.f006.nc .........OK
+ Comparing sfc.nest04.f006.nc .........OK
+ Comparing atm.nest05.f006.nc .........OK
+ Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
+
+[0] The total amount of wall time                        = 1334.095527
+[0] The maximum resident set size (KB)                   = 300416
+
+Test 104 hafs_global_multiple_4nests_atm PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_docn
+Checking test 105 hafs_regional_docn results ....
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+[0] The total amount of wall time                        = 374.511703
+[0] The maximum resident set size (KB)                   = 740956
+
+Test 105 hafs_regional_docn PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_docn_oisst
+Checking test 106 hafs_regional_docn_oisst results ....
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
+ Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
+ Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
+
+[0] The total amount of wall time                        = 373.863900
+[0] The maximum resident set size (KB)                   = 748088
+
+Test 106 hafs_regional_docn_oisst PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_datm_cdeps
+Checking test 107 hafs_regional_datm_cdeps results ....
+ Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
+ Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
+ Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
+
+[0] The total amount of wall time                        = 1088.790491
+[0] The maximum resident set size (KB)                   = 897376
+
+Test 107 hafs_regional_datm_cdeps PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_control_cfsr
+Checking test 108 datm_cdeps_control_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 173.418931
+[0] The maximum resident set size (KB)                   = 724412
+
+Test 108 datm_cdeps_control_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_restart_cfsr
+Checking test 109 datm_cdeps_restart_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 118.294812
+[0] The maximum resident set size (KB)                   = 724176
+
+Test 109 datm_cdeps_restart_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_control_gefs
+Checking test 110 datm_cdeps_control_gefs results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 167.274079
+[0] The maximum resident set size (KB)                   = 624452
+
+Test 110 datm_cdeps_control_gefs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_stochy_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_stochy_gefs
+Checking test 111 datm_cdeps_stochy_gefs results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 169.525802
+[0] The maximum resident set size (KB)                   = 626304
+
+Test 111 datm_cdeps_stochy_gefs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_bulk_cfsr
+Checking test 112 datm_cdeps_bulk_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 173.563570
+[0] The maximum resident set size (KB)                   = 743312
+
+Test 112 datm_cdeps_bulk_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_bulk_gefs
+Checking test 113 datm_cdeps_bulk_gefs results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 168.449351
+[0] The maximum resident set size (KB)                   = 626076
+
+Test 113 datm_cdeps_bulk_gefs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_mx025_cfsr
+Checking test 114 datm_cdeps_mx025_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2011-10-01-43200.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
+
+[0] The total amount of wall time                        = 358.293307
+[0] The maximum resident set size (KB)                   = 565652
+
+Test 114 datm_cdeps_mx025_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_mx025_gefs
+Checking test 115 datm_cdeps_mx025_gefs results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/MOM.res_1.nc .........OK
+ Comparing RESTART/MOM.res_2.nc .........OK
+ Comparing RESTART/MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2011-10-01-43200.nc .........OK
+ Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
+
+[0] The total amount of wall time                        = 351.446065
+[0] The maximum resident set size (KB)                   = 541164
+
+Test 115 datm_cdeps_mx025_gefs PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_multiple_files_cfsr
+Checking test 116 datm_cdeps_multiple_files_cfsr results ....
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 173.758603
+[0] The maximum resident set size (KB)                   = 739412
+
+Test 116 datm_cdeps_multiple_files_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_3072x1536_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_3072x1536_cfsr
+Checking test 117 datm_cdeps_3072x1536_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
+
+[0] The total amount of wall time                        = 247.726615
+[0] The maximum resident set size (KB)                   = 1897156
+
+Test 117 datm_cdeps_3072x1536_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_debug_cfsr
+Checking test 118 datm_cdeps_debug_cfsr results ....
+ Comparing RESTART/MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-01-21600.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
+
+[0] The total amount of wall time                        = 498.758945
+[0] The maximum resident set size (KB)                   = 728140
+
+Test 118 datm_cdeps_debug_cfsr PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_atmwav
+Checking test 119 control_atmwav results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing 20210322.180000.restart.glo_1deg .........OK
+
+[0] The total amount of wall time                        = 91.882987
+[0] The maximum resident set size (KB)                   = 489012
+
+Test 119 control_atmwav PASS
+
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384gdas_wav
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384gdas_wav
+Checking test 120 control_c384gdas_wav results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf003.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf003.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF03 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF03 .........OK
+ Comparing RESTART/coupler.res .........OK
+ Comparing RESTART/fv_core.res.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc .........OK
+ Comparing RESTART/fv_core.res.tile2.nc .........OK
+ Comparing RESTART/fv_core.res.tile3.nc .........OK
+ Comparing RESTART/fv_core.res.tile4.nc .........OK
+ Comparing RESTART/fv_core.res.tile5.nc .........OK
+ Comparing RESTART/fv_core.res.tile6.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/phy_data.tile1.nc .........OK
+ Comparing RESTART/phy_data.tile2.nc .........OK
+ Comparing RESTART/phy_data.tile3.nc .........OK
+ Comparing RESTART/phy_data.tile4.nc .........OK
+ Comparing RESTART/phy_data.tile5.nc .........OK
+ Comparing RESTART/phy_data.tile6.nc .........OK
+ Comparing RESTART/sfc_data.tile1.nc .........OK
+ Comparing RESTART/sfc_data.tile2.nc .........OK
+ Comparing RESTART/sfc_data.tile3.nc .........OK
+ Comparing RESTART/sfc_data.tile4.nc .........OK
+ Comparing RESTART/sfc_data.tile5.nc .........OK
+ Comparing RESTART/sfc_data.tile6.nc .........OK
+ Comparing 20210322.030000.restart.aoc_9km .........OK
+ Comparing 20210322.030000.restart.gnh_10m .........OK
+ Comparing 20210322.030000.restart.gsh_15m .........OK
+
+[0] The total amount of wall time                        = 627.605967
+[0] The maximum resident set size (KB)                   = 1051188
+
+Test 120 control_c384gdas_wav PASS
+
+FAILED TESTS: 
+Test compile_009 failed in run_compile failed 
+
+REGRESSION TEST FAILED
+Wed Feb 16 05:55:43 UTC 2022
+Elapsed time: 01h:43m:06s. Have a nice day!
+Wed Feb 16 13:26:20 UTC 2022
+Start Regression test
+
+Compile 001 elapsed time 285 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_debug
+working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_54521/control_wam_debug
+Checking test 001 control_wam_debug results ....
+ Comparing sfcf019.nc .........OK
+ Comparing atmf019.nc .........OK
+
+[0] The total amount of wall time                        = 323.242475
+[0] The maximum resident set size (KB)                   = 263200
+
+Test 001 control_wam_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Feb 14 16:36:38 UTC 2022
-Elapsed time: 01h:51m:00s. Have a nice day!
+Wed Feb 16 13:38:59 UTC 2022
+Elapsed time: 00h:12m:41s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -479,7 +479,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20220214
+BL_DATE=20220215
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]] || [[ $MACHINE_ID = s4.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 else


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description

This PR only updates the submopdule pointers for ccpp-physics and fv3atm for the changes described in https://github.com/NCAR/ccpp-physics/pull/859.

### Issue(s) addressed

Fixes https://github.com/NCAR/ccpp-physics/issues/860

## Testing

Regression tests were run on Hera with Intel and GNU. For GNU, all results were b4b identical. For Intel, results were identical in DEBUG mode. The PROD results for physics suites using Grell-Freitas were different with Intel, but all tests ran to completion and run-to-run/restart reproducibility was tested as well. This is expected because of some of the optimizations that were made to the actual code to run efficiently on GPUs (for example, replace string switches with integer switches).

Full regression tests will be run on all tier-1 platforms at the time of commit.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [x] wcoss_dell_p3
- [n/a] opnReqTest for newly added/changed feature
- [x] CI

## Dependencies

- waiting on https://github.com/NCAR/ccpp-physics/pull/859
- waiting on https://github.com/NOAA-EMC/fv3atm/pull/479
