### PR TITLE
Enable Thompson microphysics with UFS-Aerosols and update GOCART

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "FV3"]
-  path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3
@@ -37,4 +33,8 @@
 [submodule "GOCART"]
   path = GOCART
   url = https://github.com/GEOS-ESM/GOCART
+  branch = develop
+[submodule "FV3"]
+  path = FV3
+  url = https://github.com/rmontuoro/fv3atm
   branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "FV3"]
+  path = FV3
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3
@@ -33,8 +37,4 @@
 [submodule "GOCART"]
   path = GOCART
   url = https://github.com/GEOS-ESM/GOCART
-  branch = develop
-[submodule "FV3"]
-  path = FV3
-  url = https://github.com/rmontuoro/fv3atm
   branch = develop

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,15 +1,15 @@
-Tue Feb 15 14:26:50 MST 2022
+Fri Feb 18 13:01:18 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 741 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 488 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 254 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 407 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 388 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 740 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 493 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 260 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,14 +56,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 274.224632
-0:The maximum resident set size (KB)                   = 432548
+0:The total amount of wall time                        = 277.286154
+0:The maximum resident set size (KB)                   = 432764
 
 Test 001 control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -102,14 +102,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 144.026464
-0:The maximum resident set size (KB)                   = 182268
+0:The total amount of wall time                        = 137.276731
+0:The maximum resident set size (KB)                   = 182172
 
 Test 002 control_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,14 +148,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 818.558762
-0:The maximum resident set size (KB)                   = 668988
+0:The total amount of wall time                        = 819.535783
+0:The maximum resident set size (KB)                   = 669004
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -166,14 +166,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 171.488495
-0:The maximum resident set size (KB)                   = 427044
+0:The total amount of wall time                        = 176.000723
+0:The maximum resident set size (KB)                   = 426784
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,14 +184,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 326.365109
-0:The maximum resident set size (KB)                   = 485140
+0:The total amount of wall time                        = 342.863456
+0:The maximum resident set size (KB)                   = 485512
 
 Test 005 control_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -202,14 +202,14 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 324.614523
-0:The maximum resident set size (KB)                   = 529780
+0:The total amount of wall time                        = 341.424861
+0:The maximum resident set size (KB)                   = 529776
 
 Test 006 control_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -220,14 +220,14 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 363.600038
-0:The maximum resident set size (KB)                   = 794812
+0:The total amount of wall time                        = 364.706965
+0:The maximum resident set size (KB)                   = 794820
 
 Test 007 control_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -238,14 +238,14 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 348.330554
-0:The maximum resident set size (KB)                   = 788688
+0:The total amount of wall time                        = 347.676386
+0:The maximum resident set size (KB)                   = 788732
 
 Test 008 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -256,14 +256,14 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 291.711861
-0:The maximum resident set size (KB)                   = 445572
+0:The total amount of wall time                        = 290.128595
+0:The maximum resident set size (KB)                   = 445168
 
 Test 009 control_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_p8
 Checking test 010 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -310,14 +310,14 @@ Checking test 010 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 278.888373
-0:The maximum resident set size (KB)                   = 490344
+0:The total amount of wall time                        = 285.911336
+0:The maximum resident set size (KB)                   = 490328
 
 Test 010 control_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -364,14 +364,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 700.007512
-0:The maximum resident set size (KB)                   = 773172
+0:The total amount of wall time                        = 689.602830
+0:The maximum resident set size (KB)                   = 773148
 
 Test 011 rap_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_2threads
 Checking test 012 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -418,14 +418,14 @@ Checking test 012 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 1201.445749
-0:The maximum resident set size (KB)                   = 839860
+0:The total amount of wall time                        = 1212.691764
+0:The maximum resident set size (KB)                   = 839884
 
 Test 012 rap_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_restart
 Checking test 013 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -464,14 +464,14 @@ Checking test 013 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 344.485250
-0:The maximum resident set size (KB)                   = 520864
+0:The total amount of wall time                        = 344.509672
+0:The maximum resident set size (KB)                   = 520832
 
 Test 013 rap_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_sfcdiff
 Checking test 014 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -518,14 +518,14 @@ Checking test 014 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 695.914588
-0:The maximum resident set size (KB)                   = 773092
+0:The total amount of wall time                        = 691.042536
+0:The maximum resident set size (KB)                   = 772976
 
 Test 014 rap_sfcdiff PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_sfcdiff_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_sfcdiff_restart
 Checking test 015 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 346.334351
-0:The maximum resident set size (KB)                   = 520680
+0:The total amount of wall time                        = 343.464322
+0:The maximum resident set size (KB)                   = 520492
 
 Test 015 rap_sfcdiff_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/hrrr_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/hrrr_control
 Checking test 016 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -618,14 +618,14 @@ Checking test 016 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 665.990889
-0:The maximum resident set size (KB)                   = 770968
+0:The total amount of wall time                        = 668.509670
+0:The maximum resident set size (KB)                   = 770988
 
 Test 016 hrrr_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -672,14 +672,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 682.021618
-0:The maximum resident set size (KB)                   = 770616
+0:The total amount of wall time                        = 684.117020
+0:The maximum resident set size (KB)                   = 770632
 
 Test 017 rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rrfs_conus13km_hrrr_warm
 Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -688,14 +688,14 @@ Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 318.420795
-0:The maximum resident set size (KB)                   = 591576
+0:The total amount of wall time                        = 318.954170
+0:The maximum resident set size (KB)                   = 591596
 
 Test 018 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -704,250 +704,250 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 321.209667
-0:The maximum resident set size (KB)                   = 594276
+0:The total amount of wall time                        = 321.038304
+0:The maximum resident set size (KB)                   = 595120
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 80.241797
-0:The maximum resident set size (KB)                   = 423456
+0:The total amount of wall time                        = 80.160352
+0:The maximum resident set size (KB)                   = 423472
 
 Test 020 control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 93.912913
-0:The maximum resident set size (KB)                   = 480832
+0:The total amount of wall time                        = 86.092092
+0:The maximum resident set size (KB)                   = 480920
 
 Test 021 control_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/regional_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 130.487799
-0:The maximum resident set size (KB)                   = 534540
+0:The total amount of wall time                        = 130.007673
+0:The maximum resident set size (KB)                   = 534416
 
 Test 022 regional_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.313031
-0:The maximum resident set size (KB)                   = 795360
+0:The total amount of wall time                        = 144.822144
+0:The maximum resident set size (KB)                   = 795368
 
 Test 023 rap_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 153.015617
-0:The maximum resident set size (KB)                   = 878200
+0:The total amount of wall time                        = 152.876729
+0:The maximum resident set size (KB)                   = 878284
 
 Test 024 rap_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 232.269262
-0:The maximum resident set size (KB)                   = 793984
+0:The total amount of wall time                        = 232.653940
+0:The maximum resident set size (KB)                   = 794020
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rap_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rap_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 152.550608
-0:The maximum resident set size (KB)                   = 795348
+0:The total amount of wall time                        = 144.570969
+0:The maximum resident set size (KB)                   = 795412
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.418251
-0:The maximum resident set size (KB)                   = 790200
+0:The total amount of wall time                        = 143.608564
+0:The maximum resident set size (KB)                   = 790280
 
 Test 027 rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 108.930975
-0:The maximum resident set size (KB)                   = 781400
+0:The total amount of wall time                        = 94.709810
+0:The maximum resident set size (KB)                   = 781396
 
 Test 028 control_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.669833
-0:The maximum resident set size (KB)                   = 776756
+0:The total amount of wall time                        = 91.457401
+0:The maximum resident set size (KB)                   = 776800
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_extdiag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 108.078191
-0:The maximum resident set size (KB)                   = 823076
+0:The total amount of wall time                        = 101.205455
+0:The maximum resident set size (KB)                   = 823072
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 94.075291
-0:The maximum resident set size (KB)                   = 781408
+0:The total amount of wall time                        = 93.824418
+0:The maximum resident set size (KB)                   = 781388
 
-Test 031 control_thompson_progcld_thompson_debug PASS Tries: 2
+Test 031 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_rrtmgp_debug
 Checking test 032 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 89.783809
-0:The maximum resident set size (KB)                   = 518932
+0:The total amount of wall time                        = 87.509864
+0:The maximum resident set size (KB)                   = 518776
 
 Test 032 control_rrtmgp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_ras_debug
 Checking test 033 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 83.114245
-0:The maximum resident set size (KB)                   = 433368
+0:The total amount of wall time                        = 82.788216
+0:The maximum resident set size (KB)                   = 433444
 
 Test 033 control_ras_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_stochy_debug
 Checking test 034 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.776800
-0:The maximum resident set size (KB)                   = 427412
+0:The total amount of wall time                        = 90.383929
+0:The maximum resident set size (KB)                   = 427376
 
 Test 034 control_stochy_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_debug_p8
 Checking test 035 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 96.146801
-0:The maximum resident set size (KB)                   = 483856
+0:The total amount of wall time                        = 87.591788
+0:The maximum resident set size (KB)                   = 483836
 
 Test 035 control_debug_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/control_wam_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/control_wam_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 142.667524
-0:The maximum resident set size (KB)                   = 169988
+0:The total amount of wall time                        = 143.371830
+0:The maximum resident set size (KB)                   = 169896
 
 Test 036 control_wam_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/cpld_control_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/cpld_control_c96_p8
 Checking test 037 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 037 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 367.925787
-0:The maximum resident set size (KB)                   = 517672
+0:The total amount of wall time                        = 367.926804
+0:The maximum resident set size (KB)                   = 517664
 
 Test 037 cpld_control_c96_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_58431/cpld_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_60873/cpld_debug_p8
 Checking test 038 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,12 +1066,12 @@ Checking test 038 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 334.899861
-0:The maximum resident set size (KB)                   = 535664
+0:The total amount of wall time                        = 334.849132
+0:The maximum resident set size (KB)                   = 535616
 
 Test 038 cpld_debug_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 14:56:27 MST 2022
-Elapsed time: 00h:29m:38s. Have a nice day!
+Fri Feb 18 13:33:40 MST 2022
+Elapsed time: 00h:32m:23s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,23 +1,23 @@
-Tue Feb 15 15:31:15 MST 2022
+Fri Feb 18 12:46:15 MST 2022
 Start Regression test
 
-Compile 001 elapsed time 989 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 409 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 746 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 715 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 809 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 597 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 380 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 361 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 289 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 732 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 997 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 405 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 754 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 718 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 802 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 586 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 372 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 355 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 283 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 737 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 011 elapsed time 728 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 443 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 220 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 608 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 439 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 228 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 622 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 251.474652
-0:The maximum resident set size (KB)                   = 535508
+0:The total amount of wall time                        = 249.473719
+0:The maximum resident set size (KB)                   = 535592
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_2threads_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 477.193518
-0:The maximum resident set size (KB)                   = 630632
+0:The total amount of wall time                        = 476.115650
+0:The maximum resident set size (KB)                   = 630684
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_decomp_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 247.674144
-0:The maximum resident set size (KB)                   = 531864
+0:The total amount of wall time                        = 252.183217
+0:The maximum resident set size (KB)                   = 531656
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_mpi_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 214.410807
-0:The maximum resident set size (KB)                   = 505896
+0:The total amount of wall time                        = 213.709421
+0:The maximum resident set size (KB)                   = 505868
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 316.492428
-0:The maximum resident set size (KB)                   = 631272
+0:The total amount of wall time                        = 312.176851
+0:The maximum resident set size (KB)                   = 631160
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_p7
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 977.018668
-0:The maximum resident set size (KB)                   = 1206520
+0:The total amount of wall time                        = 964.487721
+0:The maximum resident set size (KB)                   = 1207080
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 979.622591
-0:The maximum resident set size (KB)                   = 1205296
+0:The total amount of wall time                        = 972.942414
+0:The maximum resident set size (KB)                   = 1206224
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_bmark_mpi_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 977.394379
-0:The maximum resident set size (KB)                   = 1208760
+0:The total amount of wall time                        = 964.722151
+0:The maximum resident set size (KB)                   = 1207876
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 244.000564
-0:The maximum resident set size (KB)                   = 522628
+0:The total amount of wall time                        = 242.621573
+0:The maximum resident set size (KB)                   = 522680
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c96_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 128.695564
-0:The maximum resident set size (KB)                   = 313580
+0:The total amount of wall time                        = 129.407043
+0:The maximum resident set size (KB)                   = 313544
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c192_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 1026.299489
-0:The maximum resident set size (KB)                   = 692476
+0:The total amount of wall time                        = 1027.259999
+0:The maximum resident set size (KB)                   = 692704
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c192_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-0:The total amount of wall time                        = 645.409426
-0:The maximum resident set size (KB)                   = 754720
+0:The total amount of wall time                        = 643.913705
+0:The maximum resident set size (KB)                   = 754364
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_control_c384_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 1061.625251
-0:The maximum resident set size (KB)                   = 1232348
+0:The total amount of wall time                        = 1103.066222
+0:The maximum resident set size (KB)                   = 1231464
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_restart_c384_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 576.319311
-0:The maximum resident set size (KB)                   = 1179592
+0:The total amount of wall time                        = 581.058022
+0:The maximum resident set size (KB)                   = 1181200
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/cpld_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-0:The total amount of wall time                        = 653.886781
-0:The maximum resident set size (KB)                   = 584992
+0:The total amount of wall time                        = 652.841171
+0:The maximum resident set size (KB)                   = 584596
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 145.923617
-0:The maximum resident set size (KB)                   = 445432
+0:The total amount of wall time                        = 146.827100
+0:The maximum resident set size (KB)                   = 445476
 
 Test 016 control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_decomp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 150.679924
-0:The maximum resident set size (KB)                   = 443876
+0:The total amount of wall time                        = 147.870304
+0:The maximum resident set size (KB)                   = 443684
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2dwrtdecomp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 139.090440
-0:The maximum resident set size (KB)                   = 445812
+0:The total amount of wall time                        = 139.912208
+0:The maximum resident set size (KB)                   = 445992
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 319.603682
-0:The maximum resident set size (KB)                   = 492108
+0:The total amount of wall time                        = 320.880671
+0:The maximum resident set size (KB)                   = 492572
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 75.280105
-0:The maximum resident set size (KB)                   = 188920
+0:The total amount of wall time                        = 77.279771
+0:The maximum resident set size (KB)                   = 189524
 
 Test 020 control_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_fhzero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 138.751568
-0:The maximum resident set size (KB)                   = 445568
+0:The total amount of wall time                        = 135.367022
+0:The maximum resident set size (KB)                   = 445512
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_CubedSphereGrid
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 141.905640
-0:The maximum resident set size (KB)                   = 445780
+0:The total amount of wall time                        = 138.898791
+0:The maximum resident set size (KB)                   = 445808
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_latlon
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,17 +1191,17 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 144.444532
-0:The maximum resident set size (KB)                   = 445392
+0:The total amount of wall time                        = 141.985742
+0:The maximum resident set size (KB)                   = 445684
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wrtGauss_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.593840
-0:The maximum resident set size (KB)                   = 445616
+0:The total amount of wall time                        = 150.065838
+0:The maximum resident set size (KB)                   = 445428
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c48
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 422.070148
-0:The maximum resident set size (KB)                   = 629012
+0:The total amount of wall time                        = 421.154504
+0:The maximum resident set size (KB)                   = 629784
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 586.711537
-0:The maximum resident set size (KB)                   = 540136
+0:The total amount of wall time                        = 587.684711
+0:The maximum resident set size (KB)                   = 539988
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c384
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 1089.973156
-0:The maximum resident set size (KB)                   = 795948
+0:The total amount of wall time                        = 1072.088381
+0:The maximum resident set size (KB)                   = 795812
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_c384gdas
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 939.036986
+0:The total amount of wall time                        = 941.502505
 0:The maximum resident set size (KB)                   = 948052
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 96.142206
-0:The maximum resident set size (KB)                   = 442776
+0:The total amount of wall time                        = 96.599151
+0:The maximum resident set size (KB)                   = 442720
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 50.497511
-0:The maximum resident set size (KB)                   = 221688
+0:The total amount of wall time                        = 50.887696
+0:The maximum resident set size (KB)                   = 221828
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_lndp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 87.024819
-0:The maximum resident set size (KB)                   = 450432
+0:The total amount of wall time                        = 87.412410
+0:The maximum resident set size (KB)                   = 450296
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_iovr4
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 145.768456
-0:The maximum resident set size (KB)                   = 445484
+0:The total amount of wall time                        = 149.972440
+0:The maximum resident set size (KB)                   = 445412
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_iovr5
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.615419
-0:The maximum resident set size (KB)                   = 445504
+0:The total amount of wall time                        = 146.255474
+0:The maximum resident set size (KB)                   = 445524
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 162.402577
-0:The maximum resident set size (KB)                   = 485104
+0:The total amount of wall time                        = 162.228024
+0:The maximum resident set size (KB)                   = 485192
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_restart_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 86.376107
-0:The maximum resident set size (KB)                   = 291124
+0:The total amount of wall time                        = 87.968260
+0:The maximum resident set size (KB)                   = 291096
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_decomp_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 167.063405
-0:The maximum resident set size (KB)                   = 479680
+0:The total amount of wall time                        = 166.548649
+0:The maximum resident set size (KB)                   = 479740
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 357.626681
-0:The maximum resident set size (KB)                   = 568656
+0:The total amount of wall time                        = 358.893829
+0:The maximum resident set size (KB)                   = 569368
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_p7_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 231.100886
-0:The maximum resident set size (KB)                   = 585900
+0:The total amount of wall time                        = 230.952888
+0:The maximum resident set size (KB)                   = 585860
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 349.550351
-0:The maximum resident set size (KB)                   = 568984
+0:The total amount of wall time                        = 349.669454
+0:The maximum resident set size (KB)                   = 569016
 
 Test 039 regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 191.844704
-0:The maximum resident set size (KB)                   = 559468
+0:The total amount of wall time                        = 190.426314
+0:The maximum resident set size (KB)                   = 559148
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_control_2dwrtdecomp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-0:The total amount of wall time                        = 346.261000
-0:The maximum resident set size (KB)                   = 568420
+0:The total amount of wall time                        = 345.689968
+0:The maximum resident set size (KB)                   = 568480
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_noquilt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 367.798203
-0:The maximum resident set size (KB)                   = 576376
+0:The total amount of wall time                        = 368.657494
+0:The maximum resident set size (KB)                   = 575624
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 928.230841
-0:The maximum resident set size (KB)                   = 554936
+0:The total amount of wall time                        = 928.904328
+0:The maximum resident set size (KB)                   = 555088
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_hafs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 356.634445
-0:The maximum resident set size (KB)                   = 557552
+0:The total amount of wall time                        = 343.271430
+0:The maximum resident set size (KB)                   = 557548
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_netcdf_parallel
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 346.531545
-0:The maximum resident set size (KB)                   = 558104
+0:The total amount of wall time                        = 340.032389
+0:The maximum resident set size (KB)                   = 557928
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_RRTMGP
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-0:The total amount of wall time                        = 475.795632
-0:The maximum resident set size (KB)                   = 681788
+0:The total amount of wall time                        = 506.051159
+0:The maximum resident set size (KB)                   = 681796
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 414.043640
-0:The maximum resident set size (KB)                   = 808232
+0:The total amount of wall time                        = 411.115295
+0:The maximum resident set size (KB)                   = 807940
 
 Test 047 rap_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_2threads
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 874.404234
-0:The maximum resident set size (KB)                   = 873332
+0:The total amount of wall time                        = 873.285193
+0:The maximum resident set size (KB)                   = 873520
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 207.509885
-0:The maximum resident set size (KB)                   = 561760
+0:The total amount of wall time                        = 208.402886
+0:The maximum resident set size (KB)                   = 562176
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 409.927553
-0:The maximum resident set size (KB)                   = 808100
+0:The total amount of wall time                        = 412.430321
+0:The maximum resident set size (KB)                   = 807944
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff_restart
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.300022
-0:The maximum resident set size (KB)                   = 562064
+0:The total amount of wall time                        = 209.401894
+0:The maximum resident set size (KB)                   = 562500
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hrrr_control
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 395.742769
-0:The maximum resident set size (KB)                   = 806640
+0:The total amount of wall time                        = 396.178791
+0:The maximum resident set size (KB)                   = 806664
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_v1beta
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 403.143243
-0:The maximum resident set size (KB)                   = 805320
+0:The total amount of wall time                        = 405.605915
+0:The maximum resident set size (KB)                   = 805636
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_conus13km_hrrr_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 185.222061
-0:The maximum resident set size (KB)                   = 638272
+0:The total amount of wall time                        = 186.691940
+0:The maximum resident set size (KB)                   = 638584
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_conus13km_radar_tten_warm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 186.903123
+0:The total amount of wall time                        = 187.558565
 0:The maximum resident set size (KB)                   = 639940
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 262.164009
-0:The maximum resident set size (KB)                   = 578536
+0:The total amount of wall time                        = 260.541466
+0:The maximum resident set size (KB)                   = 578592
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp_c192
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 697.255609
-0:The maximum resident set size (KB)                   = 781220
+0:The total amount of wall time                        = 695.443312
+0:The maximum resident set size (KB)                   = 781256
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmg
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 390.328108
-0:The maximum resident set size (KB)                   = 518516
+0:The total amount of wall time                        = 405.407590
+0:The maximum resident set size (KB)                   = 518596
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmgt
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 397.852852
-0:The maximum resident set size (KB)                   = 518324
+0:The total amount of wall time                        = 399.161097
+0:The maximum resident set size (KB)                   = 518196
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_flake
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 262.865886
-0:The maximum resident set size (KB)                   = 515576
+0:The total amount of wall time                        = 251.132600
+0:The maximum resident set size (KB)                   = 515548
 
 Test 060 control_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_ras
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 205.419756
-0:The maximum resident set size (KB)                   = 477140
+0:The total amount of wall time                        = 206.748264
+0:The maximum resident set size (KB)                   = 476880
 
 Test 061 control_ras PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 261.048209
-0:The maximum resident set size (KB)                   = 826340
+0:The total amount of wall time                        = 261.819562
+0:The maximum resident set size (KB)                   = 826200
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_no_aero
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 248.136786
-0:The maximum resident set size (KB)                   = 818704
+0:The total amount of wall time                        = 247.875773
+0:The maximum resident set size (KB)                   = 819080
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wam_repro
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 137.530147
-0:The maximum resident set size (KB)                   = 200972
+0:The total amount of wall time                        = 137.167201
+0:The maximum resident set size (KB)                   = 201076
 
 Test 064 control_wam PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.681719
-0:The maximum resident set size (KB)                   = 507800
+0:The total amount of wall time                        = 154.878527
+0:The maximum resident set size (KB)                   = 507752
 
 Test 065 control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_2threads_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 273.193591
-0:The maximum resident set size (KB)                   = 558188
+0:The total amount of wall time                        = 272.968586
+0:The maximum resident set size (KB)                   = 555000
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_CubedSphereGrid_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2428,428 +2428,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 172.419452
-0:The maximum resident set size (KB)                   = 507632
+0:The total amount of wall time                        = 169.393806
+0:The maximum resident set size (KB)                   = 507436
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wrtGauss_netcdf_parallel_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.354520
-0:The maximum resident set size (KB)                   = 507692
+0:The total amount of wall time                        = 158.126473
+0:The maximum resident set size (KB)                   = 507764
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_stochy_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 180.546738
-0:The maximum resident set size (KB)                   = 510524
+0:The total amount of wall time                        = 177.511028
+0:The maximum resident set size (KB)                   = 510500
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 159.658715
-0:The maximum resident set size (KB)                   = 519788
+0:The total amount of wall time                        = 159.659878
+0:The maximum resident set size (KB)                   = 519848
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 174.641512
-0:The maximum resident set size (KB)                   = 616388
+0:The total amount of wall time                        = 173.372634
+0:The maximum resident set size (KB)                   = 616376
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmg_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 254.310586
-0:The maximum resident set size (KB)                   = 553912
+0:The total amount of wall time                        = 251.583178
+0:The maximum resident set size (KB)                   = 553708
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_csawmgt_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 251.175424
-0:The maximum resident set size (KB)                   = 553500
+0:The total amount of wall time                        = 247.697281
+0:The maximum resident set size (KB)                   = 553572
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_ras_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 163.592182
-0:The maximum resident set size (KB)                   = 516980
+0:The total amount of wall time                        = 161.948341
+0:The maximum resident set size (KB)                   = 516988
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 167.204683
-0:The maximum resident set size (KB)                   = 562144
+0:The total amount of wall time                        = 163.710049
+0:The maximum resident set size (KB)                   = 562088
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_debug_p8
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 170.640590
-0:The maximum resident set size (KB)                   = 548032
+0:The total amount of wall time                        = 168.783257
+0:The maximum resident set size (KB)                   = 547972
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 186.178204
-0:The maximum resident set size (KB)                   = 864204
+0:The total amount of wall time                        = 182.010799
+0:The maximum resident set size (KB)                   = 864292
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_no_aero_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 178.571258
-0:The maximum resident set size (KB)                   = 860620
+0:The total amount of wall time                        = 176.143670
+0:The maximum resident set size (KB)                   = 860736
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_extdiag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 191.642866
-0:The maximum resident set size (KB)                   = 895080
+0:The total amount of wall time                        = 191.155375
+0:The maximum resident set size (KB)                   = 895272
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_thompson_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 182.033319
-0:The maximum resident set size (KB)                   = 864336
+0:The total amount of wall time                        = 182.475090
+0:The maximum resident set size (KB)                   = 864280
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/regional_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 259.093359
-0:The maximum resident set size (KB)                   = 591204
+0:The total amount of wall time                        = 259.146355
+0:The maximum resident set size (KB)                   = 591360
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_control_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.688497
-0:The maximum resident set size (KB)                   = 871248
+0:The total amount of wall time                        = 280.886388
+0:The maximum resident set size (KB)                   = 871068
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_unified_drag_suite_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.447459
-0:The maximum resident set size (KB)                   = 871180
+0:The total amount of wall time                        = 281.327375
+0:The maximum resident set size (KB)                   = 871324
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_diag_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 300.422763
-0:The maximum resident set size (KB)                   = 965916
+0:The total amount of wall time                        = 295.611573
+0:The maximum resident set size (KB)                   = 966036
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.939829
-0:The maximum resident set size (KB)                   = 875924
+0:The total amount of wall time                        = 286.425148
+0:The maximum resident set size (KB)                   = 876176
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_unified_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.443892
-0:The maximum resident set size (KB)                   = 871360
+0:The total amount of wall time                        = 286.751166
+0:The maximum resident set size (KB)                   = 871332
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_noah_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 281.300021
-0:The maximum resident set size (KB)                   = 870936
+0:The total amount of wall time                        = 279.102321
+0:The maximum resident set size (KB)                   = 870920
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_rrtmgp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 483.308813
-0:The maximum resident set size (KB)                   = 986684
+0:The total amount of wall time                        = 480.081004
+0:The maximum resident set size (KB)                   = 986688
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_lndp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.247954
-0:The maximum resident set size (KB)                   = 871912
+0:The total amount of wall time                        = 283.088474
+0:The maximum resident set size (KB)                   = 871984
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_sfcdiff_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 283.850259
-0:The maximum resident set size (KB)                   = 870976
+0:The total amount of wall time                        = 284.359272
+0:The maximum resident set size (KB)                   = 870860
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_flake_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.376331
-0:The maximum resident set size (KB)                   = 871048
+0:The total amount of wall time                        = 280.692534
+0:The maximum resident set size (KB)                   = 871264
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 473.030527
-0:The maximum resident set size (KB)                   = 870276
+0:The total amount of wall time                        = 467.429208
+0:The maximum resident set size (KB)                   = 870196
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rap_progcld_thompson_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.063557
-0:The maximum resident set size (KB)                   = 871268
+0:The total amount of wall time                        = 281.342239
+0:The maximum resident set size (KB)                   = 871336
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/rrfs_v1beta_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.500745
-0:The maximum resident set size (KB)                   = 868840
+0:The total amount of wall time                        = 279.914295
+0:The maximum resident set size (KB)                   = 869024
 
 Test 094 rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_wam_debug
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 299.733527
-0:The maximum resident set size (KB)                   = 232528
+0:The total amount of wall time                        = 297.287408
+0:The maximum resident set size (KB)                   = 232628
 
 Test 095 control_wam_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 508.463439
-0:The maximum resident set size (KB)                   = 670312
+0:The total amount of wall time                        = 499.547004
+0:The maximum resident set size (KB)                   = 669912
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_thompson_gfdlsf
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 585.584589
-0:The maximum resident set size (KB)                   = 1026892
+0:The total amount of wall time                        = 583.570099
+0:The maximum resident set size (KB)                   = 1026676
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_ocn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2858,90 +2858,90 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 414.187749
-0:The maximum resident set size (KB)                   = 686156
+0:The total amount of wall time                        = 408.679118
+0:The maximum resident set size (KB)                   = 685712
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 965.462502
-0:The maximum resident set size (KB)                   = 684912
+0:The total amount of wall time                        = 945.684862
+0:The maximum resident set size (KB)                   = 685068
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_atm_ocn_wav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 1041.391915
-0:The maximum resident set size (KB)                   = 685492
+0:The total amount of wall time                        = 1036.678738
+0:The maximum resident set size (KB)                   = 685976
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 1017.729079
-0:The maximum resident set size (KB)                   = 270544
+0:The total amount of wall time                        = 1010.600587
+0:The maximum resident set size (KB)                   = 270072
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_telescopic_2nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1046.155525
-0:The maximum resident set size (KB)                   = 279964
+0:The total amount of wall time                        = 1060.608441
+0:The maximum resident set size (KB)                   = 279708
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_global_1nest_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 667.876371
-0:The maximum resident set size (KB)                   = 167332
+0:The total amount of wall time                        = 665.989570
+0:The maximum resident set size (KB)                   = 167032
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_global_multiple_4nests_atm
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 1237.472171
-0:The maximum resident set size (KB)                   = 235304
+0:The total amount of wall time                        = 1234.616034
+0:The maximum resident set size (KB)                   = 235444
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_docn
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2967,14 +2967,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 353.904422
-0:The maximum resident set size (KB)                   = 688384
+0:The total amount of wall time                        = 354.306298
+0:The maximum resident set size (KB)                   = 687128
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_docn_oisst
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2982,105 +2982,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 352.493028
-0:The maximum resident set size (KB)                   = 687396
+0:The total amount of wall time                        = 344.492709
+0:The maximum resident set size (KB)                   = 686984
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/hafs_regional_datm_cdeps
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1289.435220
-0:The maximum resident set size (KB)                   = 868312
+0:The total amount of wall time                        = 1298.136643
+0:The maximum resident set size (KB)                   = 867152
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_control_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.572018
-0:The maximum resident set size (KB)                   = 692244
+0:The total amount of wall time                        = 164.355809
+0:The maximum resident set size (KB)                   = 692204
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_restart_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.493853
-0:The maximum resident set size (KB)                   = 702788
+0:The total amount of wall time                        = 101.464631
+0:The maximum resident set size (KB)                   = 702680
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_control_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.451286
-0:The maximum resident set size (KB)                   = 589216
+0:The total amount of wall time                        = 159.151533
+0:The maximum resident set size (KB)                   = 588336
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_stochy_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.584988
-0:The maximum resident set size (KB)                   = 589908
+0:The total amount of wall time                        = 160.176594
+0:The maximum resident set size (KB)                   = 589652
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_bulk_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.855568
-0:The maximum resident set size (KB)                   = 691732
+0:The total amount of wall time                        = 165.167933
+0:The maximum resident set size (KB)                   = 691712
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_bulk_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.071092
-0:The maximum resident set size (KB)                   = 589264
+0:The total amount of wall time                        = 158.135415
+0:The maximum resident set size (KB)                   = 589608
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_mx025_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3089,14 +3089,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 351.943612
-0:The maximum resident set size (KB)                   = 513068
+0:The total amount of wall time                        = 347.249642
+0:The maximum resident set size (KB)                   = 511292
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_mx025_gefs
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3105,51 +3105,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 347.311654
-0:The maximum resident set size (KB)                   = 492784
+0:The total amount of wall time                        = 347.626612
+0:The maximum resident set size (KB)                   = 491456
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_multiple_files_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.783421
-0:The maximum resident set size (KB)                   = 691472
+0:The total amount of wall time                        = 159.470153
+0:The maximum resident set size (KB)                   = 691252
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_3072x1536_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 251.063726
-0:The maximum resident set size (KB)                   = 1841492
+0:The total amount of wall time                        = 264.826020
+0:The maximum resident set size (KB)                   = 1843316
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/datm_cdeps_debug_cfsr
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 455.729219
-0:The maximum resident set size (KB)                   = 699448
+0:The total amount of wall time                        = 456.310867
+0:The maximum resident set size (KB)                   = 699396
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
-working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_7086/control_atmwav
+working dir  = /glade/scratch/dtcufsrt/FV3_RT/rt_21573/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3193,12 +3193,12 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 133.403617
-0:The maximum resident set size (KB)                   = 462988
+0:The total amount of wall time                        = 134.430012
+0:The maximum resident set size (KB)                   = 462744
 
 Test 119 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 16:39:03 MST 2022
-Elapsed time: 01h:07m:49s. Have a nice day!
+Fri Feb 18 13:55:01 MST 2022
+Elapsed time: 01h:08m:47s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,23 +1,23 @@
-Tue Feb 15 19:07:51 EST 2022
+Fri Feb 18 14:53:15 EST 2022
 Start Regression test
 
-Compile 001 elapsed time 603 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 230 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 489 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 476 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 230 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 221 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 491 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 653 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 273 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 502 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 555 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 497 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 252 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 248 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 220 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 505 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 011 elapsed time 505 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 292 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 138 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 457 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 340 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 143 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 462 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 243.679836
-  0: The maximum resident set size (KB)                   = 516048
+  0: The total amount of wall time                        = 266.842678
+  0: The maximum resident set size (KB)                   = 515788
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_2threads_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 291.810131
-  0: The maximum resident set size (KB)                   = 610812
+  0: The total amount of wall time                        = 305.559450
+  0: The maximum resident set size (KB)                   = 610620
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_decomp_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 234.146306
-  0: The maximum resident set size (KB)                   = 516092
+  0: The total amount of wall time                        = 249.308733
+  0: The maximum resident set size (KB)                   = 516044
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_mpi_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 196.344320
-  0: The maximum resident set size (KB)                   = 472772
+  0: The total amount of wall time                        = 215.900712
+  0: The maximum resident set size (KB)                   = 472876
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 297.572189
-  0: The maximum resident set size (KB)                   = 587932
+  0: The total amount of wall time                        = 313.842853
+  0: The maximum resident set size (KB)                   = 587976
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_p7
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 928.382959
-  0: The maximum resident set size (KB)                   = 1159132
+  0: The total amount of wall time                        = 975.977696
+  0: The maximum resident set size (KB)                   = 1158956
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 978.100095
-  0: The maximum resident set size (KB)                   = 1158392
+  0: The total amount of wall time                        = 1002.535048
+  0: The maximum resident set size (KB)                   = 1158852
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_bmark_mpi_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 972.619623
-  0: The maximum resident set size (KB)                   = 1161064
+  0: The total amount of wall time                        = 954.969205
+  0: The maximum resident set size (KB)                   = 1160716
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 229.849789
-  0: The maximum resident set size (KB)                   = 515836
+  0: The total amount of wall time                        = 240.389352
+  0: The maximum resident set size (KB)                   = 515528
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c96_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 120.874960
-  0: The maximum resident set size (KB)                   = 305516
+  0: The total amount of wall time                        = 165.401545
+  0: The maximum resident set size (KB)                   = 305496
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 983.536453
-  0: The maximum resident set size (KB)                   = 660200
+  0: The total amount of wall time                        = 1036.102916
+  0: The maximum resident set size (KB)                   = 684040
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c192_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 670.585766
-  0: The maximum resident set size (KB)                   = 756948
+  0: The total amount of wall time                        = 646.273962
+  0: The maximum resident set size (KB)                   = 756824
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_control_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1075.831742
-  0: The maximum resident set size (KB)                   = 1183140
+  0: The total amount of wall time                        = 1103.293530
+  0: The maximum resident set size (KB)                   = 1183252
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_restart_c384_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 603.130037
-  0: The maximum resident set size (KB)                   = 1146920
+  0: The total amount of wall time                        = 651.708210
+  0: The maximum resident set size (KB)                   = 1147168
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/cpld_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 629.159934
-  0: The maximum resident set size (KB)                   = 577856
+  0: The total amount of wall time                        = 637.848683
+  0: The maximum resident set size (KB)                   = 577332
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.131469
-  0: The maximum resident set size (KB)                   = 436608
+  0: The total amount of wall time                        = 135.065627
+  0: The maximum resident set size (KB)                   = 436476
 
 Test 016 control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_decomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 137.199801
-  0: The maximum resident set size (KB)                   = 435892
+  0: The total amount of wall time                        = 139.933723
+  0: The maximum resident set size (KB)                   = 435768
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2dwrtdecomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 153.272650
-  0: The maximum resident set size (KB)                   = 436592
+  0: The total amount of wall time                        = 129.573440
+  0: The maximum resident set size (KB)                   = 436732
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 198.453568
- 0: The maximum resident set size (KB)                   = 487652
+ 0: The total amount of wall time                        = 171.875683
+ 0: The maximum resident set size (KB)                   = 487272
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 106.561114
-  0: The maximum resident set size (KB)                   = 172284
+  0: The total amount of wall time                        = 70.405311
+  0: The maximum resident set size (KB)                   = 172460
 
 Test 020 control_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_fhzero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.132674
-  0: The maximum resident set size (KB)                   = 436616
+  0: The total amount of wall time                        = 127.098893
+  0: The maximum resident set size (KB)                   = 436452
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_CubedSphereGrid
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.987937
-  0: The maximum resident set size (KB)                   = 437860
+  0: The total amount of wall time                        = 129.331940
+  0: The maximum resident set size (KB)                   = 437880
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_latlon
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 128.565536
-  0: The maximum resident set size (KB)                   = 436528
+  0: The total amount of wall time                        = 130.516967
+  0: The maximum resident set size (KB)                   = 436624
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wrtGauss_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 135.540179
-  0: The maximum resident set size (KB)                   = 436560
+  0: The total amount of wall time                        = 156.076118
+  0: The maximum resident set size (KB)                   = 436612
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c48
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 352.752100
-0: The maximum resident set size (KB)                   = 632020
+0: The total amount of wall time                        = 353.733073
+0: The maximum resident set size (KB)                   = 631988
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 536.574194
-  0: The maximum resident set size (KB)                   = 540180
+  0: The total amount of wall time                        = 538.343516
+  0: The maximum resident set size (KB)                   = 540224
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 913.221872
-  0: The maximum resident set size (KB)                   = 794332
+  0: The total amount of wall time                        = 924.947738
+  0: The maximum resident set size (KB)                   = 794648
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384gdas
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 825.580138
-  0: The maximum resident set size (KB)                   = 938796
+  0: The total amount of wall time                        = 856.036790
+  0: The maximum resident set size (KB)                   = 938752
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 113.466368
-  0: The maximum resident set size (KB)                   = 439828
+  0: The total amount of wall time                        = 117.179915
+  0: The maximum resident set size (KB)                   = 439872
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 74.005616
-  0: The maximum resident set size (KB)                   = 190216
+  0: The total amount of wall time                        = 53.486662
+  0: The maximum resident set size (KB)                   = 190416
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_lndp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.086305
-  0: The maximum resident set size (KB)                   = 443196
+  0: The total amount of wall time                        = 80.683833
+  0: The maximum resident set size (KB)                   = 443232
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_iovr4
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 155.276789
+  0: The total amount of wall time                        = 134.600992
   0: The maximum resident set size (KB)                   = 436572
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_iovr5
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 159.259550
-  0: The maximum resident set size (KB)                   = 436656
+  0: The total amount of wall time                        = 159.627723
+  0: The maximum resident set size (KB)                   = 436584
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 146.231476
-  0: The maximum resident set size (KB)                   = 469108
+  0: The total amount of wall time                        = 165.922338
+  0: The maximum resident set size (KB)                   = 469136
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_restart_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 80.819898
+  0: The total amount of wall time                        = 107.209267
   0: The maximum resident set size (KB)                   = 278200
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_decomp_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.603909
-  0: The maximum resident set size (KB)                   = 462224
+  0: The total amount of wall time                        = 175.838265
+  0: The maximum resident set size (KB)                   = 462268
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 192.694041
- 0: The maximum resident set size (KB)                   = 546992
+ 0: The total amount of wall time                        = 207.204821
+ 0: The maximum resident set size (KB)                   = 546916
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_p7_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.890258
-  0: The maximum resident set size (KB)                   = 568204
+  0: The total amount of wall time                        = 211.298618
+  0: The maximum resident set size (KB)                   = 568300
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 364.140643
- 0: The maximum resident set size (KB)                   = 540884
+ 0: The total amount of wall time                        = 337.171041
+ 0: The maximum resident set size (KB)                   = 540864
 
 Test 039 regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 209.031808
- 0: The maximum resident set size (KB)                   = 539108
+ 0: The total amount of wall time                        = 183.894717
+ 0: The maximum resident set size (KB)                   = 539080
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_control_2dwrtdecomp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 329.788459
+ 0: The total amount of wall time                        = 332.851687
  0: The maximum resident set size (KB)                   = 540804
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_noquilt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 351.071797
- 0: The maximum resident set size (KB)                   = 548148
+ 0: The total amount of wall time                        = 354.345127
+ 0: The maximum resident set size (KB)                   = 548208
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 263.778365
- 0: The maximum resident set size (KB)                   = 543188
+ 0: The total amount of wall time                        = 267.838947
+ 0: The maximum resident set size (KB)                   = 543160
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_hafs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 360.150615
- 0: The maximum resident set size (KB)                   = 540384
+ 0: The total amount of wall time                        = 333.228742
+ 0: The maximum resident set size (KB)                   = 540368
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_netcdf_parallel
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 333.860950
- 0: The maximum resident set size (KB)                   = 539096
+ 0: The total amount of wall time                        = 370.692183
+ 0: The maximum resident set size (KB)                   = 539012
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_RRTMGP
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 448.891341
- 0: The maximum resident set size (KB)                   = 666480
+ 0: The total amount of wall time                        = 458.881901
+ 0: The maximum resident set size (KB)                   = 666516
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 372.704484
-  0: The maximum resident set size (KB)                   = 805404
+  0: The total amount of wall time                        = 377.459858
+  0: The maximum resident set size (KB)                   = 805236
 
 Test 047 rap_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_2threads
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 492.648996
- 0: The maximum resident set size (KB)                   = 867516
+ 0: The total amount of wall time                        = 499.154206
+ 0: The maximum resident set size (KB)                   = 867332
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.476274
-  0: The maximum resident set size (KB)                   = 543500
+  0: The total amount of wall time                        = 215.463517
+  0: The maximum resident set size (KB)                   = 543284
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 400.816984
-  0: The maximum resident set size (KB)                   = 804876
+  0: The total amount of wall time                        = 376.111756
+  0: The maximum resident set size (KB)                   = 804916
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff_restart
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.805968
-  0: The maximum resident set size (KB)                   = 543276
+  0: The total amount of wall time                        = 218.001216
+  0: The maximum resident set size (KB)                   = 543204
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hrrr_control
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 355.940367
-  0: The maximum resident set size (KB)                   = 802792
+  0: The total amount of wall time                        = 363.298462
+  0: The maximum resident set size (KB)                   = 802884
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_v1beta
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 364.090293
-  0: The maximum resident set size (KB)                   = 801696
+  0: The total amount of wall time                        = 402.198676
+  0: The maximum resident set size (KB)                   = 801760
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_conus13km_hrrr_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 174.132347
-  0: The maximum resident set size (KB)                   = 613900
+  0: The total amount of wall time                        = 193.477592
+  0: The maximum resident set size (KB)                   = 613720
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_conus13km_radar_tten_warm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 175.881179
-  0: The maximum resident set size (KB)                   = 616436
+  0: The total amount of wall time                        = 180.478039
+  0: The maximum resident set size (KB)                   = 616448
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 212.239367
-  0: The maximum resident set size (KB)                   = 562804
+  0: The total amount of wall time                        = 238.068423
+  0: The maximum resident set size (KB)                   = 562736
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp_c192
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 585.834848
-  0: The maximum resident set size (KB)                   = 774776
+  0: The total amount of wall time                        = 595.566634
+  0: The maximum resident set size (KB)                   = 774796
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmgt
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_csawmgt
 Checking test 058 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 365.055974
-  0: The maximum resident set size (KB)                   = 504520
+  0: The total amount of wall time                        = 346.293427
+  0: The maximum resident set size (KB)                   = 504524
 
 Test 058 control_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_flake
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_flake
 Checking test 059 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 237.072094
-  0: The maximum resident set size (KB)                   = 508352
+  0: The total amount of wall time                        = 242.140401
+  0: The maximum resident set size (KB)                   = 508248
 
 Test 059 control_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_ras
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_ras
 Checking test 060 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 207.213408
-  0: The maximum resident set size (KB)                   = 471492
+  0: The total amount of wall time                        = 187.592195
+  0: The maximum resident set size (KB)                   = 471568
 
 Test 060 control_ras PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson
 Checking test 061 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 225.970913
-  0: The maximum resident set size (KB)                   = 820728
+  0: The total amount of wall time                        = 231.735623
+  0: The maximum resident set size (KB)                   = 820800
 
 Test 061 control_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_no_aero
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson_no_aero
 Checking test 062 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,54 +2336,54 @@ Checking test 062 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.697931
-  0: The maximum resident set size (KB)                   = 815084
+  0: The total amount of wall time                        = 217.652235
+  0: The maximum resident set size (KB)                   = 815128
 
 Test 062 control_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wam_repro
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_wam_repro
 Checking test 063 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.346604
-  0: The maximum resident set size (KB)                   = 181380
+  0: The total amount of wall time                        = 120.333955
+  0: The maximum resident set size (KB)                   = 181528
 
 Test 063 control_wam PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_debug
 Checking test 064 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.564805
-  0: The maximum resident set size (KB)                   = 503284
+  0: The total amount of wall time                        = 149.268731
+  0: The maximum resident set size (KB)                   = 503304
 
 Test 064 control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_2threads_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_2threads_debug
 Checking test 065 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 251.653220
- 0: The maximum resident set size (KB)                   = 557452
+ 0: The total amount of wall time                        = 257.502600
+ 0: The maximum resident set size (KB)                   = 554084
 
 Test 065 control_2threads_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_CubedSphereGrid_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_CubedSphereGrid_debug
 Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2410,428 +2410,428 @@ Checking test 066 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.950153
-  0: The maximum resident set size (KB)                   = 503696
+  0: The total amount of wall time                        = 156.654637
+  0: The maximum resident set size (KB)                   = 503512
 
 Test 066 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_wrtGauss_netcdf_parallel_debug
 Checking test 067 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.942441
-  0: The maximum resident set size (KB)                   = 503188
+  0: The total amount of wall time                        = 177.369442
+  0: The maximum resident set size (KB)                   = 503396
 
 Test 067 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_stochy_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_stochy_debug
 Checking test 068 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.049954
-  0: The maximum resident set size (KB)                   = 508596
+  0: The total amount of wall time                        = 168.678736
+  0: The maximum resident set size (KB)                   = 508420
 
 Test 068 control_stochy_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_lndp_debug
 Checking test 069 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.120631
-  0: The maximum resident set size (KB)                   = 509484
+  0: The total amount of wall time                        = 150.363864
+  0: The maximum resident set size (KB)                   = 509440
 
 Test 069 control_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_rrtmgp_debug
 Checking test 070 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.409738
-  0: The maximum resident set size (KB)                   = 608944
+  0: The total amount of wall time                        = 164.430904
+  0: The maximum resident set size (KB)                   = 608880
 
 Test 070 control_rrtmgp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmg_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_csawmg_debug
 Checking test 071 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 254.591017
-  0: The maximum resident set size (KB)                   = 545656
+  0: The total amount of wall time                        = 254.395554
+  0: The maximum resident set size (KB)                   = 545740
 
 Test 071 control_csawmg_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_csawmgt_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_csawmgt_debug
 Checking test 072 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 235.716272
-  0: The maximum resident set size (KB)                   = 545360
+  0: The total amount of wall time                        = 254.957365
+  0: The maximum resident set size (KB)                   = 545276
 
 Test 072 control_csawmgt_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_ras_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_ras_debug
 Checking test 073 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.034063
-  0: The maximum resident set size (KB)                   = 516080
+  0: The total amount of wall time                        = 151.698341
+  0: The maximum resident set size (KB)                   = 516216
 
 Test 073 control_ras_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_diag_debug
 Checking test 074 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.457119
-  0: The maximum resident set size (KB)                   = 561412
+  0: The total amount of wall time                        = 155.343603
+  0: The maximum resident set size (KB)                   = 561300
 
 Test 074 control_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_debug_p8
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_debug_p8
 Checking test 075 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.150677
-  0: The maximum resident set size (KB)                   = 530148
+  0: The total amount of wall time                        = 173.807295
+  0: The maximum resident set size (KB)                   = 530020
 
 Test 075 control_debug_p8 PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson_debug
 Checking test 076 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.623264
-  0: The maximum resident set size (KB)                   = 864440
+  0: The total amount of wall time                        = 175.200095
+  0: The maximum resident set size (KB)                   = 864576
 
 Test 076 control_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_no_aero_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson_no_aero_debug
 Checking test 077 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.233336
-  0: The maximum resident set size (KB)                   = 859692
+  0: The total amount of wall time                        = 171.184138
+  0: The maximum resident set size (KB)                   = 859592
 
 Test 077 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_extdiag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson_extdiag_debug
 Checking test 078 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.871630
-  0: The maximum resident set size (KB)                   = 892804
+  0: The total amount of wall time                        = 186.471348
+  0: The maximum resident set size (KB)                   = 893088
 
 Test 078 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_thompson_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_thompson_progcld_thompson_debug
 Checking test 079 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.143231
-  0: The maximum resident set size (KB)                   = 864204
+  0: The total amount of wall time                        = 179.038950
+  0: The maximum resident set size (KB)                   = 864376
 
 Test 079 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/regional_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/regional_debug
 Checking test 080 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 259.410932
- 0: The maximum resident set size (KB)                   = 567184
+ 0: The total amount of wall time                        = 262.746145
+ 0: The maximum resident set size (KB)                   = 567060
 
 Test 080 regional_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_control_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_control_debug
 Checking test 081 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.472080
-  0: The maximum resident set size (KB)                   = 871684
+  0: The total amount of wall time                        = 279.242241
+  0: The maximum resident set size (KB)                   = 871628
 
 Test 081 rap_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_unified_drag_suite_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_unified_drag_suite_debug
 Checking test 082 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.412851
-  0: The maximum resident set size (KB)                   = 871684
+  0: The total amount of wall time                        = 279.768793
+  0: The maximum resident set size (KB)                   = 871696
 
 Test 082 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_diag_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_diag_debug
 Checking test 083 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.864285
-  0: The maximum resident set size (KB)                   = 954652
+  0: The total amount of wall time                        = 295.385485
+  0: The maximum resident set size (KB)                   = 954568
 
 Test 083 rap_diag_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_cires_ugwp_debug
 Checking test 084 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.216756
-  0: The maximum resident set size (KB)                   = 874392
+  0: The total amount of wall time                        = 285.842272
+  0: The maximum resident set size (KB)                   = 874292
 
 Test 084 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_unified_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_unified_ugwp_debug
 Checking test 085 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.425399
-  0: The maximum resident set size (KB)                   = 871708
+  0: The total amount of wall time                        = 280.529601
+  0: The maximum resident set size (KB)                   = 871980
 
 Test 085 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_noah_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_noah_debug
 Checking test 086 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.966622
-  0: The maximum resident set size (KB)                   = 870688
+  0: The total amount of wall time                        = 275.132496
+  0: The maximum resident set size (KB)                   = 870680
 
 Test 086 rap_noah_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_rrtmgp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_rrtmgp_debug
 Checking test 087 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 471.646553
-  0: The maximum resident set size (KB)                   = 978180
+  0: The total amount of wall time                        = 478.356095
+  0: The maximum resident set size (KB)                   = 978116
 
 Test 087 rap_rrtmgp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_lndp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_lndp_debug
 Checking test 088 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.533220
-  0: The maximum resident set size (KB)                   = 872540
+  0: The total amount of wall time                        = 281.638897
+  0: The maximum resident set size (KB)                   = 872616
 
 Test 088 rap_lndp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_sfcdiff_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_sfcdiff_debug
 Checking test 089 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.413185
-  0: The maximum resident set size (KB)                   = 871424
+  0: The total amount of wall time                        = 282.653692
+  0: The maximum resident set size (KB)                   = 871536
 
 Test 089 rap_sfcdiff_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_flake_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_flake_debug
 Checking test 090 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.682261
-  0: The maximum resident set size (KB)                   = 871984
+  0: The total amount of wall time                        = 278.772313
+  0: The maximum resident set size (KB)                   = 871720
 
 Test 090 rap_flake_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 091 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 458.434193
-  0: The maximum resident set size (KB)                   = 870704
+  0: The total amount of wall time                        = 463.320287
+  0: The maximum resident set size (KB)                   = 870572
 
 Test 091 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rap_progcld_thompson_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rap_progcld_thompson_debug
 Checking test 092 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.614448
-  0: The maximum resident set size (KB)                   = 871920
+  0: The total amount of wall time                        = 274.268641
+  0: The maximum resident set size (KB)                   = 871616
 
 Test 092 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/rrfs_v1beta_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/rrfs_v1beta_debug
 Checking test 093 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.948477
-  0: The maximum resident set size (KB)                   = 869296
+  0: The total amount of wall time                        = 276.341277
+  0: The maximum resident set size (KB)                   = 868988
 
 Test 093 rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_wam_debug
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_wam_debug
 Checking test 094 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 316.115908
+  0: The total amount of wall time                        = 291.162465
   0: The maximum resident set size (KB)                   = 212024
 
 Test 094 control_wam_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_atm
 Checking test 095 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 273.421568
-  0: The maximum resident set size (KB)                   = 657592
+  0: The total amount of wall time                        = 362.797399
+  0: The maximum resident set size (KB)                   = 657716
 
 Test 095 hafs_regional_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_atm_thompson_gfdlsf
 Checking test 096 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 336.022377
-  0: The maximum resident set size (KB)                   = 1020264
+  0: The total amount of wall time                        = 375.987509
+  0: The maximum resident set size (KB)                   = 1019976
 
 Test 096 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_ocn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_atm_ocn
 Checking test 097 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2840,28 +2840,28 @@ Checking test 097 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 409.579382
-  0: The maximum resident set size (KB)                   = 662348
+  0: The total amount of wall time                        = 472.413326
+  0: The maximum resident set size (KB)                   = 662316
 
 Test 097 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_atm_wav
 Checking test 098 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 858.769000
-  0: The maximum resident set size (KB)                   = 663796
+  0: The total amount of wall time                        = 932.747369
+  0: The maximum resident set size (KB)                   = 663776
 
 Test 098 hafs_regional_atm_wav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_atm_ocn_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_atm_ocn_wav
 Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2870,28 +2870,28 @@ Checking test 099 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 967.237777
-  0: The maximum resident set size (KB)                   = 667016
+  0: The total amount of wall time                        = 1119.659783
+  0: The maximum resident set size (KB)                   = 666860
 
 Test 099 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_1nest_atm
 Checking test 100 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 512.687854
-  0: The maximum resident set size (KB)                   = 258264
+  0: The total amount of wall time                        = 592.375165
+  0: The maximum resident set size (KB)                   = 257796
 
 Test 100 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_telescopic_2nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_telescopic_2nests_atm
 Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2900,28 +2900,28 @@ Checking test 101 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 534.660011
-  0: The maximum resident set size (KB)                   = 263204
+  0: The total amount of wall time                        = 633.740440
+  0: The maximum resident set size (KB)                   = 262640
 
 Test 101 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_global_1nest_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_global_1nest_atm
 Checking test 102 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 279.082776
-  0: The maximum resident set size (KB)                   = 162632
+  0: The total amount of wall time                        = 301.563985
+  0: The maximum resident set size (KB)                   = 162748
 
 Test 102 hafs_global_1nest_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_global_multiple_4nests_atm
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_global_multiple_4nests_atm
 Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2934,14 +2934,14 @@ Checking test 103 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 667.364351
-  0: The maximum resident set size (KB)                   = 219080
+  0: The total amount of wall time                        = 755.413278
+  0: The maximum resident set size (KB)                   = 233048
 
 Test 103 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_docn
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_docn
 Checking test 104 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2949,14 +2949,14 @@ Checking test 104 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 347.539869
-  0: The maximum resident set size (KB)                   = 662072
+  0: The total amount of wall time                        = 444.030049
+  0: The maximum resident set size (KB)                   = 662020
 
 Test 104 hafs_regional_docn PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_docn_oisst
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_docn_oisst
 Checking test 105 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2964,105 +2964,105 @@ Checking test 105 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.939027
-  0: The maximum resident set size (KB)                   = 661960
+  0: The total amount of wall time                        = 442.506210
+  0: The maximum resident set size (KB)                   = 662036
 
 Test 105 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/hafs_regional_datm_cdeps
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/hafs_regional_datm_cdeps
 Checking test 106 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1034.620846
-  0: The maximum resident set size (KB)                   = 806972
+  0: The total amount of wall time                        = 1058.359960
+  0: The maximum resident set size (KB)                   = 807124
 
 Test 106 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_control_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_control_cfsr
 Checking test 107 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.669850
- 0: The maximum resident set size (KB)                   = 664356
+ 0: The total amount of wall time                        = 152.369325
+ 0: The maximum resident set size (KB)                   = 683416
 
 Test 107 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_restart_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_restart_cfsr
 Checking test 108 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 84.722146
- 0: The maximum resident set size (KB)                   = 683308
+ 0: The total amount of wall time                        = 85.236712
+ 0: The maximum resident set size (KB)                   = 664228
 
 Test 108 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_control_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_control_gefs
 Checking test 109 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.566347
- 0: The maximum resident set size (KB)                   = 563656
+ 0: The total amount of wall time                        = 159.064170
+ 0: The maximum resident set size (KB)                   = 563716
 
 Test 109 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_stochy_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_stochy_gefs
 Checking test 110 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.964605
- 0: The maximum resident set size (KB)                   = 569612
+ 0: The total amount of wall time                        = 150.140503
+ 0: The maximum resident set size (KB)                   = 565776
 
 Test 110 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_bulk_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_bulk_cfsr
 Checking test 111 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.738854
- 0: The maximum resident set size (KB)                   = 688984
+ 0: The total amount of wall time                        = 153.973060
+ 0: The maximum resident set size (KB)                   = 683380
 
 Test 111 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_bulk_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_bulk_gefs
 Checking test 112 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.862553
- 0: The maximum resident set size (KB)                   = 567636
+ 0: The total amount of wall time                        = 151.069589
+ 0: The maximum resident set size (KB)                   = 567736
 
 Test 112 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_mx025_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_mx025_cfsr
 Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3071,14 +3071,14 @@ Checking test 113 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 340.172076
-  0: The maximum resident set size (KB)                   = 482796
+  0: The total amount of wall time                        = 399.982684
+  0: The maximum resident set size (KB)                   = 482564
 
 Test 113 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_mx025_gefs
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_mx025_gefs
 Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3087,51 +3087,51 @@ Checking test 114 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 341.392784
-  0: The maximum resident set size (KB)                   = 449856
+  0: The total amount of wall time                        = 362.696869
+  0: The maximum resident set size (KB)                   = 449784
 
 Test 114 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_multiple_files_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_multiple_files_cfsr
 Checking test 115 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.154385
- 0: The maximum resident set size (KB)                   = 683144
+ 0: The total amount of wall time                        = 153.415726
+ 0: The maximum resident set size (KB)                   = 683268
 
 Test 115 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_3072x1536_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_3072x1536_cfsr
 Checking test 116 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 200.451765
- 0: The maximum resident set size (KB)                   = 1835724
+ 0: The total amount of wall time                        = 233.713886
+ 0: The maximum resident set size (KB)                   = 1835780
 
 Test 116 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/datm_cdeps_debug_cfsr
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/datm_cdeps_debug_cfsr
 Checking test 117 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 364.342141
- 0: The maximum resident set size (KB)                   = 680968
+ 0: The total amount of wall time                        = 365.016122
+ 0: The maximum resident set size (KB)                   = 688316
 
 Test 117 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_atmwav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_atmwav
 Checking test 118 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3175,14 +3175,14 @@ Checking test 118 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 119.625471
-  0: The maximum resident set size (KB)                   = 449532
+  0: The total amount of wall time                        = 118.258574
+  0: The maximum resident set size (KB)                   = 449640
 
 Test 118 control_atmwav PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
-working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_18350/control_c384gdas_wav
+working dir  = /lustre/f2/scratch/emc.nemspara/FV3_RT/rt_47511/control_c384gdas_wav
 Checking test 119 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3228,12 +3228,12 @@ Checking test 119 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 1384.624113
-  0: The maximum resident set size (KB)                   = 957076
+  0: The total amount of wall time                        = 1451.416745
+  0: The maximum resident set size (KB)                   = 958368
 
 Test 119 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 20:35:39 EST 2022
-Elapsed time: 01h:27m:49s. Have a nice day!
+Fri Feb 18 16:20:12 EST 2022
+Elapsed time: 01h:26m:58s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,15 +1,15 @@
-Tue Feb 15 19:05:49 UTC 2022
+Fri Feb 18 20:02:01 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 300 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 004 elapsed time 106 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 233 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 123 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 284 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 004 elapsed time 95 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 220 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 117 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,14 +56,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 807.432720
-  0: The maximum resident set size (KB)                   = 443156
+  0: The total amount of wall time                        = 823.853391
+  0: The maximum resident set size (KB)                   = 440472
 
 Test 001 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -102,14 +102,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 389.166269
-  0: The maximum resident set size (KB)                   = 177568
+  0: The total amount of wall time                        = 388.117477
+  0: The maximum resident set size (KB)                   = 180708
 
 Test 002 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,14 +148,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 674.805435
-0: The maximum resident set size (KB)                   = 690816
+0: The total amount of wall time                        = 677.678447
+0: The maximum resident set size (KB)                   = 691128
 
 Test 003 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -166,14 +166,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 625.062652
-  0: The maximum resident set size (KB)                   = 447492
+  0: The total amount of wall time                        = 625.656729
+  0: The maximum resident set size (KB)                   = 445208
 
 Test 004 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,14 +184,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1391.612954
-  0: The maximum resident set size (KB)                   = 492776
+  0: The total amount of wall time                        = 1362.833090
+  0: The maximum resident set size (KB)                   = 488540
 
 Test 005 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -202,14 +202,14 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 832.837061
-  0: The maximum resident set size (KB)                   = 538620
+  0: The total amount of wall time                        = 847.571854
+  0: The maximum resident set size (KB)                   = 541860
 
 Test 006 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -220,14 +220,14 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 985.025303
-  0: The maximum resident set size (KB)                   = 801932
+  0: The total amount of wall time                        = 992.933805
+  0: The maximum resident set size (KB)                   = 804896
 
 Test 007 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -238,14 +238,14 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 950.340740
-  0: The maximum resident set size (KB)                   = 796396
+  0: The total amount of wall time                        = 958.318993
+  0: The maximum resident set size (KB)                   = 799360
 
 Test 008 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -256,14 +256,14 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 805.753128
-  0: The maximum resident set size (KB)                   = 448908
+  0: The total amount of wall time                        = 793.107223
+  0: The maximum resident set size (KB)                   = 448196
 
 Test 009 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_p8
 Checking test 010 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -310,14 +310,14 @@ Checking test 010 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 798.873597
-  0: The maximum resident set size (KB)                   = 476256
+  0: The total amount of wall time                        = 811.390502
+  0: The maximum resident set size (KB)                   = 477360
 
 Test 010 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -364,14 +364,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1390.142322
-  0: The maximum resident set size (KB)                   = 785772
+  0: The total amount of wall time                        = 1408.026205
+  0: The maximum resident set size (KB)                   = 790608
 
 Test 011 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_2threads
 Checking test 012 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -418,14 +418,14 @@ Checking test 012 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1413.811857
- 0: The maximum resident set size (KB)                   = 846024
+ 0: The total amount of wall time                        = 1416.006674
+ 0: The maximum resident set size (KB)                   = 850052
 
 Test 012 rap_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_restart
 Checking test 013 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -464,14 +464,14 @@ Checking test 013 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 666.075535
-  0: The maximum resident set size (KB)                   = 533036
+  0: The total amount of wall time                        = 677.919110
+  0: The maximum resident set size (KB)                   = 533080
 
 Test 013 rap_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_sfcdiff
 Checking test 014 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -518,14 +518,14 @@ Checking test 014 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1387.120301
-  0: The maximum resident set size (KB)                   = 788436
+  0: The total amount of wall time                        = 1392.233528
+  0: The maximum resident set size (KB)                   = 787904
 
 Test 014 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_sfcdiff_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_sfcdiff_restart
 Checking test 015 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 678.798878
-  0: The maximum resident set size (KB)                   = 535132
+  0: The total amount of wall time                        = 655.756164
+  0: The maximum resident set size (KB)                   = 532872
 
 Test 015 rap_sfcdiff_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/hrrr_control
 Checking test 016 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -618,14 +618,14 @@ Checking test 016 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1356.238015
-  0: The maximum resident set size (KB)                   = 782268
+  0: The total amount of wall time                        = 1390.698108
+  0: The maximum resident set size (KB)                   = 787564
 
 Test 016 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -672,14 +672,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1378.026667
-  0: The maximum resident set size (KB)                   = 784848
+  0: The total amount of wall time                        = 1387.753300
+  0: The maximum resident set size (KB)                   = 782996
 
 Test 017 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rrfs_conus13km_hrrr_warm
 Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -688,14 +688,14 @@ Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1537.012025
-  0: The maximum resident set size (KB)                   = 627932
+  0: The total amount of wall time                        = 1586.371885
+  0: The maximum resident set size (KB)                   = 627308
 
 Test 018 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -704,250 +704,250 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1541.935576
-  0: The maximum resident set size (KB)                   = 630208
+  0: The total amount of wall time                        = 1538.933620
+  0: The maximum resident set size (KB)                   = 637424
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 100.270532
-  0: The maximum resident set size (KB)                   = 436596
+  0: The total amount of wall time                        = 98.452100
+  0: The maximum resident set size (KB)                   = 440476
 
 Test 020 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 125.436539
-  0: The maximum resident set size (KB)                   = 494344
+  0: The total amount of wall time                        = 126.114717
+  0: The maximum resident set size (KB)                   = 494896
 
 Test 021 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 126.505351
- 0: The maximum resident set size (KB)                   = 545840
+ 0: The total amount of wall time                        = 129.066696
+ 0: The maximum resident set size (KB)                   = 545852
 
 Test 022 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.238228
+  0: The total amount of wall time                        = 168.581103
   0: The maximum resident set size (KB)                   = 805400
 
 Test 023 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 203.922455
-  0: The maximum resident set size (KB)                   = 890304
+  0: The total amount of wall time                        = 204.257800
+  0: The maximum resident set size (KB)                   = 888644
 
 Test 024 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.338297
-  0: The maximum resident set size (KB)                   = 803620
+  0: The total amount of wall time                        = 269.423920
+  0: The maximum resident set size (KB)                   = 806572
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 168.340687
-  0: The maximum resident set size (KB)                   = 803900
+  0: The total amount of wall time                        = 167.651424
+  0: The maximum resident set size (KB)                   = 802924
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.344122
-  0: The maximum resident set size (KB)                   = 800848
+  0: The total amount of wall time                        = 167.186426
+  0: The maximum resident set size (KB)                   = 801748
 
 Test 027 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 114.465309
-  0: The maximum resident set size (KB)                   = 794988
+  0: The total amount of wall time                        = 113.820186
+  0: The maximum resident set size (KB)                   = 797712
 
 Test 028 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 111.909539
-  0: The maximum resident set size (KB)                   = 792580
+  0: The total amount of wall time                        = 110.492567
+  0: The maximum resident set size (KB)                   = 794748
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 132.412307
-  0: The maximum resident set size (KB)                   = 828716
+  0: The total amount of wall time                        = 136.500821
+  0: The maximum resident set size (KB)                   = 828764
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 110.836178
-  0: The maximum resident set size (KB)                   = 795064
+  0: The total amount of wall time                        = 114.240901
+  0: The maximum resident set size (KB)                   = 796516
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_rrtmgp_debug
 Checking test 032 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.490232
-  0: The maximum resident set size (KB)                   = 536464
+  0: The total amount of wall time                        = 106.829724
+  0: The maximum resident set size (KB)                   = 538316
 
 Test 032 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_ras_debug
 Checking test 033 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.293748
-  0: The maximum resident set size (KB)                   = 449000
+  0: The total amount of wall time                        = 100.679743
+  0: The maximum resident set size (KB)                   = 451616
 
 Test 033 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_stochy_debug
 Checking test 034 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.678930
-  0: The maximum resident set size (KB)                   = 438648
+  0: The total amount of wall time                        = 116.058429
+  0: The maximum resident set size (KB)                   = 442624
 
 Test 034 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_debug_p8
 Checking test 035 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.481971
-  0: The maximum resident set size (KB)                   = 478116
+  0: The total amount of wall time                        = 106.073822
+  0: The maximum resident set size (KB)                   = 477344
 
 Test 035 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 179.933537
-  0: The maximum resident set size (KB)                   = 188212
+  0: The total amount of wall time                        = 179.250501
+  0: The maximum resident set size (KB)                   = 182764
 
 Test 036 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/cpld_control_c96_p8
 Checking test 037 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 037 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1094.253906
-  0: The maximum resident set size (KB)                   = 504052
+  0: The total amount of wall time                        = 1105.999227
+  0: The maximum resident set size (KB)                   = 503872
 
 Test 037 cpld_control_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/GNU/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10711/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_29078/cpld_debug_p8
 Checking test 038 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,12 +1066,12 @@ Checking test 038 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 558.276381
-  0: The maximum resident set size (KB)                   = 513104
+  0: The total amount of wall time                        = 557.427874
+  0: The maximum resident set size (KB)                   = 516964
 
 Test 038 cpld_debug_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 19:53:06 UTC 2022
-Elapsed time: 00h:47m:18s. Have a nice day!
+Fri Feb 18 21:05:33 UTC 2022
+Elapsed time: 01h:03m:33s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,24 +1,24 @@
-Tue Feb 15 19:46:20 UTC 2022
+Fri Feb 18 19:47:14 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 469 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 181 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 613 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 410 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 333 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 533 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 538 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 401 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 410 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 211 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 168 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 391 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 412 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 576 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 783 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 517 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 834 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 645 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 659 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 675 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 683 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 729 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 428 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 407 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 539 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 198 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 374 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 420 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +83,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 218.458712
-  0: The maximum resident set size (KB)                   = 563320
+  0: The total amount of wall time                        = 213.829511
+  0: The maximum resident set size (KB)                   = 563944
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -143,14 +143,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 246.410751
-  0: The maximum resident set size (KB)                   = 642032
+  0: The total amount of wall time                        = 244.893267
+  0: The maximum resident set size (KB)                   = 644984
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 214.941898
-  0: The maximum resident set size (KB)                   = 562176
+  0: The total amount of wall time                        = 216.281039
+  0: The maximum resident set size (KB)                   = 562156
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_mpi_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -263,14 +263,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 184.007988
-  0: The maximum resident set size (KB)                   = 533044
+  0: The total amount of wall time                        = 184.109802
+  0: The maximum resident set size (KB)                   = 536536
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -323,14 +323,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 256.389425
-  0: The maximum resident set size (KB)                   = 664184
+  0: The total amount of wall time                        = 253.946019
+  0: The maximum resident set size (KB)                   = 663200
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -375,14 +375,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 869.950990
-  0: The maximum resident set size (KB)                   = 1227132
+  0: The total amount of wall time                        = 863.971900
+  0: The maximum resident set size (KB)                   = 1226752
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -427,14 +427,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 871.459322
-  0: The maximum resident set size (KB)                   = 1228016
+  0: The total amount of wall time                        = 863.840432
+  0: The maximum resident set size (KB)                   = 1229316
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_bmark_mpi_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -479,14 +479,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 849.770747
-  0: The maximum resident set size (KB)                   = 1231332
+  0: The total amount of wall time                        = 849.277149
+  0: The maximum resident set size (KB)                   = 1234068
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -548,14 +548,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 211.465655
-  0: The maximum resident set size (KB)                   = 556288
+  0: The total amount of wall time                        = 203.961237
+  0: The maximum resident set size (KB)                   = 554112
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -605,14 +605,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 111.273357
-  0: The maximum resident set size (KB)                   = 324352
+  0: The total amount of wall time                        = 112.862454
+  0: The maximum resident set size (KB)                   = 322564
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -662,14 +662,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 848.412694
-  0: The maximum resident set size (KB)                   = 726304
+  0: The total amount of wall time                        = 845.113269
+  0: The maximum resident set size (KB)                   = 726164
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 573.778107
-  0: The maximum resident set size (KB)                   = 828784
+  0: The total amount of wall time                        = 579.829726
+  0: The maximum resident set size (KB)                   = 829952
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -769,14 +769,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 998.060455
-  0: The maximum resident set size (KB)                   = 1242128
+  0: The total amount of wall time                        = 1002.226333
+  0: The maximum resident set size (KB)                   = 1241332
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_restart_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -819,14 +819,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 575.312625
-  0: The maximum resident set size (KB)                   = 1204012
+  0: The total amount of wall time                        = 554.729835
+  0: The maximum resident set size (KB)                   = 1198256
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -876,14 +876,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 601.832893
-  0: The maximum resident set size (KB)                   = 612140
+  0: The total amount of wall time                        = 605.704621
+  0: The maximum resident set size (KB)                   = 613496
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -930,14 +930,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.981262
-  0: The maximum resident set size (KB)                   = 457284
+  0: The total amount of wall time                        = 128.078449
+  0: The maximum resident set size (KB)                   = 465120
 
 Test 016 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -980,28 +980,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.738014
-  0: The maximum resident set size (KB)                   = 464960
+  0: The total amount of wall time                        = 135.063613
+  0: The maximum resident set size (KB)                   = 460596
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 124.369300
-  0: The maximum resident set size (KB)                   = 462264
+  0: The total amount of wall time                        = 120.749841
+  0: The maximum resident set size (KB)                   = 465508
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1044,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 151.083120
- 0: The maximum resident set size (KB)                   = 509568
+ 0: The total amount of wall time                        = 150.483161
+ 0: The maximum resident set size (KB)                   = 513528
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1090,14 +1090,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 65.105552
-  0: The maximum resident set size (KB)                   = 204780
+  0: The total amount of wall time                        = 64.793159
+  0: The maximum resident set size (KB)                   = 200620
 
 Test 020 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_fhzero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1140,14 +1140,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.738669
-  0: The maximum resident set size (KB)                   = 464516
+  0: The total amount of wall time                        = 122.263417
+  0: The maximum resident set size (KB)                   = 461260
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.184942
-  0: The maximum resident set size (KB)                   = 460168
+  0: The total amount of wall time                        = 119.255411
+  0: The maximum resident set size (KB)                   = 458600
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1192,17 +1192,17 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.886910
-  0: The maximum resident set size (KB)                   = 462044
+  0: The total amount of wall time                        = 123.130781
+  0: The maximum resident set size (KB)                   = 463800
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1210,14 +1210,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 127.630515
-  0: The maximum resident set size (KB)                   = 463540
+  0: The total amount of wall time                        = 125.100214
+  0: The maximum resident set size (KB)                   = 466788
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1256,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 312.081977
-0: The maximum resident set size (KB)                   = 657968
+0: The total amount of wall time                        = 310.680335
+0: The maximum resident set size (KB)                   = 655652
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1274,14 +1274,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 469.015885
-  0: The maximum resident set size (KB)                   = 560300
+  0: The total amount of wall time                        = 471.238939
+  0: The maximum resident set size (KB)                   = 560436
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1292,14 +1292,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 770.516623
-  0: The maximum resident set size (KB)                   = 826908
+  0: The total amount of wall time                        = 784.161828
+  0: The maximum resident set size (KB)                   = 823196
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 676.725380
-  0: The maximum resident set size (KB)                   = 968852
+  0: The total amount of wall time                        = 679.283231
+  0: The maximum resident set size (KB)                   = 965892
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,28 +1360,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 84.894714
-  0: The maximum resident set size (KB)                   = 462172
+  0: The total amount of wall time                        = 87.379431
+  0: The maximum resident set size (KB)                   = 463104
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.356361
-  0: The maximum resident set size (KB)                   = 247020
+  0: The total amount of wall time                        = 44.528465
+  0: The maximum resident set size (KB)                   = 246688
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1392,14 +1392,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 74.049089
-  0: The maximum resident set size (KB)                   = 465576
+  0: The total amount of wall time                        = 76.722481
+  0: The maximum resident set size (KB)                   = 470028
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.919674
-  0: The maximum resident set size (KB)                   = 462220
+  0: The total amount of wall time                        = 126.257531
+  0: The maximum resident set size (KB)                   = 464964
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1436,14 +1436,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 129.310257
-  0: The maximum resident set size (KB)                   = 458896
+  0: The total amount of wall time                        = 127.899628
+  0: The maximum resident set size (KB)                   = 461772
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.620242
-  0: The maximum resident set size (KB)                   = 490708
+  0: The total amount of wall time                        = 142.322051
+  0: The maximum resident set size (KB)                   = 491316
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_restart_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1536,14 +1536,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 73.106904
-  0: The maximum resident set size (KB)                   = 293724
+  0: The total amount of wall time                        = 73.107542
+  0: The maximum resident set size (KB)                   = 287992
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,14 +1586,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.859904
-  0: The maximum resident set size (KB)                   = 489520
+  0: The total amount of wall time                        = 145.196620
+  0: The maximum resident set size (KB)                   = 482808
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1636,14 +1636,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 170.863910
- 0: The maximum resident set size (KB)                   = 564632
+ 0: The total amount of wall time                        = 173.123507
+ 0: The maximum resident set size (KB)                   = 568524
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.416551
-  0: The maximum resident set size (KB)                   = 594540
+  0: The total amount of wall time                        = 180.704107
+  0: The maximum resident set size (KB)                   = 592244
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1708,42 +1708,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 299.108703
- 0: The maximum resident set size (KB)                   = 577648
+ 0: The total amount of wall time                        = 300.605146
+ 0: The maximum resident set size (KB)                   = 578168
 
 Test 039 regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 170.787362
- 0: The maximum resident set size (KB)                   = 577748
+ 0: The total amount of wall time                        = 171.646148
+ 0: The maximum resident set size (KB)                   = 578304
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 306.991759
- 0: The maximum resident set size (KB)                   = 573036
+ 0: The total amount of wall time                        = 298.875004
+ 0: The maximum resident set size (KB)                   = 574424
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 315.029088
- 0: The maximum resident set size (KB)                   = 591180
+ 0: The total amount of wall time                        = 318.526308
+ 0: The maximum resident set size (KB)                   = 592332
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 234.275143
- 0: The maximum resident set size (KB)                   = 576988
+ 0: The total amount of wall time                        = 226.071305
+ 0: The maximum resident set size (KB)                   = 575184
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1785,28 +1785,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 298.220233
- 0: The maximum resident set size (KB)                   = 576896
+ 0: The total amount of wall time                        = 297.308353
+ 0: The maximum resident set size (KB)                   = 577724
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 299.552785
- 0: The maximum resident set size (KB)                   = 575012
+ 0: The total amount of wall time                        = 295.267467
+ 0: The maximum resident set size (KB)                   = 571756
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1817,14 +1817,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 373.951628
- 0: The maximum resident set size (KB)                   = 691520
+ 0: The total amount of wall time                        = 375.913227
+ 0: The maximum resident set size (KB)                   = 694104
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1871,14 +1871,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 347.381685
-  0: The maximum resident set size (KB)                   = 834060
+  0: The total amount of wall time                        = 351.307149
+  0: The maximum resident set size (KB)                   = 832720
 
 Test 047 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 438.200004
- 0: The maximum resident set size (KB)                   = 895972
+ 0: The total amount of wall time                        = 430.301486
+ 0: The maximum resident set size (KB)                   = 898340
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.395554
-  0: The maximum resident set size (KB)                   = 582052
+  0: The total amount of wall time                        = 177.270117
+  0: The maximum resident set size (KB)                   = 581184
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2025,14 +2025,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 365.966639
-  0: The maximum resident set size (KB)                   = 829160
+  0: The total amount of wall time                        = 350.212398
+  0: The maximum resident set size (KB)                   = 830928
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff_restart
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.368771
-  0: The maximum resident set size (KB)                   = 582220
+  0: The total amount of wall time                        = 182.795503
+  0: The maximum resident set size (KB)                   = 582888
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 347.858324
-  0: The maximum resident set size (KB)                   = 831684
+  0: The total amount of wall time                        = 340.803717
+  0: The maximum resident set size (KB)                   = 829672
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 360.327521
-  0: The maximum resident set size (KB)                   = 827488
+  0: The total amount of wall time                        = 345.045588
+  0: The maximum resident set size (KB)                   = 829984
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2195,14 +2195,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 169.651872
-  0: The maximum resident set size (KB)                   = 660436
+  0: The total amount of wall time                        = 171.294400
+  0: The maximum resident set size (KB)                   = 660772
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2211,14 +2211,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 170.641471
-  0: The maximum resident set size (KB)                   = 663592
+  0: The total amount of wall time                        = 180.606407
+  0: The maximum resident set size (KB)                   = 664292
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.210478
-  0: The maximum resident set size (KB)                   = 587976
+  0: The total amount of wall time                        = 192.449393
+  0: The maximum resident set size (KB)                   = 584764
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp_c192
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2247,14 +2247,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 507.112749
-  0: The maximum resident set size (KB)                   = 800936
+  0: The total amount of wall time                        = 524.130333
+  0: The maximum resident set size (KB)                   = 798420
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2265,14 +2265,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 318.157651
-  0: The maximum resident set size (KB)                   = 533324
+  0: The total amount of wall time                        = 312.298078
+  0: The maximum resident set size (KB)                   = 531696
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2283,14 +2283,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 312.453859
-  0: The maximum resident set size (KB)                   = 531868
+  0: The total amount of wall time                        = 312.054956
+  0: The maximum resident set size (KB)                   = 530964
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2301,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 230.550437
-  0: The maximum resident set size (KB)                   = 535896
+  0: The total amount of wall time                        = 230.220933
+  0: The maximum resident set size (KB)                   = 535496
 
 Test 060 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2319,14 +2319,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 166.029332
-  0: The maximum resident set size (KB)                   = 495360
+  0: The total amount of wall time                        = 169.636483
+  0: The maximum resident set size (KB)                   = 494600
 
 Test 061 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2337,14 +2337,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.438934
-  0: The maximum resident set size (KB)                   = 849104
+  0: The total amount of wall time                        = 207.203705
+  0: The maximum resident set size (KB)                   = 848224
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2355,54 +2355,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 203.333249
-  0: The maximum resident set size (KB)                   = 843256
+  0: The total amount of wall time                        = 205.545764
+  0: The maximum resident set size (KB)                   = 841336
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wam_repro
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 116.969887
-  0: The maximum resident set size (KB)                   = 223484
+  0: The total amount of wall time                        = 112.565214
+  0: The maximum resident set size (KB)                   = 227804
 
 Test 064 control_wam PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 138.548838
-  0: The maximum resident set size (KB)                   = 533412
+  0: The total amount of wall time                        = 145.627529
+  0: The maximum resident set size (KB)                   = 533748
 
 Test 065 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_2threads_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 209.554034
- 0: The maximum resident set size (KB)                   = 582240
+ 0: The total amount of wall time                        = 211.151860
+ 0: The maximum resident set size (KB)                   = 584056
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2429,428 +2429,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.700021
-  0: The maximum resident set size (KB)                   = 536160
+  0: The total amount of wall time                        = 153.705462
+  0: The maximum resident set size (KB)                   = 535340
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.829524
-  0: The maximum resident set size (KB)                   = 533420
+  0: The total amount of wall time                        = 140.963293
+  0: The maximum resident set size (KB)                   = 534568
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.695393
-  0: The maximum resident set size (KB)                   = 544144
+  0: The total amount of wall time                        = 162.675022
+  0: The maximum resident set size (KB)                   = 538668
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 144.422749
-  0: The maximum resident set size (KB)                   = 536856
+  0: The total amount of wall time                        = 146.048817
+  0: The maximum resident set size (KB)                   = 535060
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.796430
-  0: The maximum resident set size (KB)                   = 640892
+  0: The total amount of wall time                        = 158.623072
+  0: The maximum resident set size (KB)                   = 636036
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.132422
-  0: The maximum resident set size (KB)                   = 574416
+  0: The total amount of wall time                        = 222.440852
+  0: The maximum resident set size (KB)                   = 581504
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.271635
-  0: The maximum resident set size (KB)                   = 578868
+  0: The total amount of wall time                        = 219.779603
+  0: The maximum resident set size (KB)                   = 575000
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 147.919618
-  0: The maximum resident set size (KB)                   = 548700
+  0: The total amount of wall time                        = 149.230665
+  0: The maximum resident set size (KB)                   = 546980
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.264724
-  0: The maximum resident set size (KB)                   = 591620
+  0: The total amount of wall time                        = 149.377740
+  0: The maximum resident set size (KB)                   = 593672
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.342233
-  0: The maximum resident set size (KB)                   = 557584
+  0: The total amount of wall time                        = 152.837930
+  0: The maximum resident set size (KB)                   = 558628
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.297901
-  0: The maximum resident set size (KB)                   = 897180
+  0: The total amount of wall time                        = 165.350908
+  0: The maximum resident set size (KB)                   = 893368
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.869228
-  0: The maximum resident set size (KB)                   = 889460
+  0: The total amount of wall time                        = 161.891312
+  0: The maximum resident set size (KB)                   = 886292
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.760181
-  0: The maximum resident set size (KB)                   = 924312
+  0: The total amount of wall time                        = 177.463507
+  0: The maximum resident set size (KB)                   = 924952
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.896855
-  0: The maximum resident set size (KB)                   = 896816
+  0: The total amount of wall time                        = 166.915085
+  0: The maximum resident set size (KB)                   = 891876
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 236.004992
- 0: The maximum resident set size (KB)                   = 608780
+ 0: The total amount of wall time                        = 236.643895
+ 0: The maximum resident set size (KB)                   = 608272
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.346876
-  0: The maximum resident set size (KB)                   = 898420
+  0: The total amount of wall time                        = 261.424820
+  0: The maximum resident set size (KB)                   = 902092
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_unified_drag_suite_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.454394
-  0: The maximum resident set size (KB)                   = 898352
+  0: The total amount of wall time                        = 258.747430
+  0: The maximum resident set size (KB)                   = 898508
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.076663
-  0: The maximum resident set size (KB)                   = 985300
+  0: The total amount of wall time                        = 275.930502
+  0: The maximum resident set size (KB)                   = 983600
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.342087
-  0: The maximum resident set size (KB)                   = 901312
+  0: The total amount of wall time                        = 263.495333
+  0: The maximum resident set size (KB)                   = 900072
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_unified_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.900861
-  0: The maximum resident set size (KB)                   = 894624
+  0: The total amount of wall time                        = 269.482391
+  0: The maximum resident set size (KB)                   = 895220
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 253.076946
-  0: The maximum resident set size (KB)                   = 898684
+  0: The total amount of wall time                        = 252.116140
+  0: The maximum resident set size (KB)                   = 900208
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 443.269434
-  0: The maximum resident set size (KB)                   = 1002504
+  0: The total amount of wall time                        = 434.232648
+  0: The maximum resident set size (KB)                   = 1006692
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.292016
-  0: The maximum resident set size (KB)                   = 898420
+  0: The total amount of wall time                        = 264.808709
+  0: The maximum resident set size (KB)                   = 902416
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.548920
-  0: The maximum resident set size (KB)                   = 901104
+  0: The total amount of wall time                        = 257.900672
+  0: The maximum resident set size (KB)                   = 900476
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.182270
-  0: The maximum resident set size (KB)                   = 900468
+  0: The total amount of wall time                        = 252.576242
+  0: The maximum resident set size (KB)                   = 900480
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 427.369349
-  0: The maximum resident set size (KB)                   = 897528
+  0: The total amount of wall time                        = 424.163627
+  0: The maximum resident set size (KB)                   = 895052
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.367028
-  0: The maximum resident set size (KB)                   = 901876
+  0: The total amount of wall time                        = 257.530409
+  0: The maximum resident set size (KB)                   = 898368
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 255.634394
-  0: The maximum resident set size (KB)                   = 897352
+  0: The total amount of wall time                        = 260.325528
+  0: The maximum resident set size (KB)                   = 899696
 
 Test 094 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 276.821741
-  0: The maximum resident set size (KB)                   = 248508
+  0: The total amount of wall time                        = 274.353943
+  0: The maximum resident set size (KB)                   = 250224
 
 Test 095 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 275.130735
-  0: The maximum resident set size (KB)                   = 706960
+  0: The total amount of wall time                        = 269.876918
+  0: The maximum resident set size (KB)                   = 709132
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 321.450445
-  0: The maximum resident set size (KB)                   = 1056348
+  0: The total amount of wall time                        = 324.118355
+  0: The maximum resident set size (KB)                   = 1062224
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2859,28 +2859,28 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 366.933027
-  0: The maximum resident set size (KB)                   = 717584
+  0: The total amount of wall time                        = 364.267518
+  0: The maximum resident set size (KB)                   = 712752
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 866.086307
-  0: The maximum resident set size (KB)                   = 715076
+  0: The total amount of wall time                        = 839.788589
+  0: The maximum resident set size (KB)                   = 722096
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2889,58 +2889,58 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 951.000761
-  0: The maximum resident set size (KB)                   = 719984
+  0: The total amount of wall time                        = 947.714153
+  0: The maximum resident set size (KB)                   = 716068
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 413.162610
-  0: The maximum resident set size (KB)                   = 309144
+  0: The total amount of wall time                        = 414.235296
+  0: The maximum resident set size (KB)                   = 315568
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
- Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 442.861812
-  0: The maximum resident set size (KB)                   = 321092
+  0: The total amount of wall time                        = 431.193813
+  0: The maximum resident set size (KB)                   = 318832
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 193.295272
-  0: The maximum resident set size (KB)                   = 197664
+  0: The total amount of wall time                        = 192.300120
+  0: The maximum resident set size (KB)                   = 198628
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2953,14 +2953,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 529.210878
-  0: The maximum resident set size (KB)                   = 270348
+  0: The total amount of wall time                        = 531.880561
+  0: The maximum resident set size (KB)                   = 251736
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2968,14 +2968,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 350.253716
-  0: The maximum resident set size (KB)                   = 715408
+  0: The total amount of wall time                        = 342.588228
+  0: The maximum resident set size (KB)                   = 715348
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2983,105 +2983,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 350.341911
-  0: The maximum resident set size (KB)                   = 718736
+  0: The total amount of wall time                        = 348.730620
+  0: The maximum resident set size (KB)                   = 714728
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 946.591552
-  0: The maximum resident set size (KB)                   = 851916
+  0: The total amount of wall time                        = 939.394574
+  0: The maximum resident set size (KB)                   = 855520
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.094684
- 0: The maximum resident set size (KB)                   = 719704
+ 0: The total amount of wall time                        = 140.915052
+ 0: The maximum resident set size (KB)                   = 719028
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 94.763088
+ 0: The total amount of wall time                        = 91.538723
  0: The maximum resident set size (KB)                   = 719568
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.681801
- 0: The maximum resident set size (KB)                   = 622516
+ 0: The total amount of wall time                        = 140.062588
+ 0: The maximum resident set size (KB)                   = 621092
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.270731
- 0: The maximum resident set size (KB)                   = 620248
+ 0: The total amount of wall time                        = 138.996374
+ 0: The maximum resident set size (KB)                   = 621628
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.414221
- 0: The maximum resident set size (KB)                   = 738876
+ 0: The total amount of wall time                        = 143.930414
+ 0: The maximum resident set size (KB)                   = 719516
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.383719
- 0: The maximum resident set size (KB)                   = 618904
+ 0: The total amount of wall time                        = 137.561360
+ 0: The maximum resident set size (KB)                   = 620608
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3090,14 +3090,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 302.874651
-  0: The maximum resident set size (KB)                   = 569448
+  0: The total amount of wall time                        = 307.386614
+  0: The maximum resident set size (KB)                   = 567808
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3106,51 +3106,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 304.501556
-  0: The maximum resident set size (KB)                   = 536564
+  0: The total amount of wall time                        = 305.046580
+  0: The maximum resident set size (KB)                   = 533704
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_multiple_files_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.669241
- 0: The maximum resident set size (KB)                   = 719720
+ 0: The total amount of wall time                        = 146.117286
+ 0: The maximum resident set size (KB)                   = 719268
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.535720
- 0: The maximum resident set size (KB)                   = 1835212
+ 0: The total amount of wall time                        = 194.654718
+ 0: The maximum resident set size (KB)                   = 1835132
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 451.176329
- 0: The maximum resident set size (KB)                   = 724920
+ 0: The total amount of wall time                        = 442.445988
+ 0: The maximum resident set size (KB)                   = 725024
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3194,14 +3194,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 81.982290
-  0: The maximum resident set size (KB)                   = 496272
+  0: The total amount of wall time                        = 78.389385
+  0: The maximum resident set size (KB)                   = 496756
 
 Test 119 control_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3247,14 +3247,14 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 703.590722
-  0: The maximum resident set size (KB)                   = 1044940
+  0: The total amount of wall time                        = 700.823850
+  0: The maximum resident set size (KB)                   = 1044016
 
 Test 120 control_c384gdas_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_7526/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_3079/control_atm_aerosols
 Checking test 121 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3301,12 +3301,12 @@ Checking test 121 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 279.059002
-  0: The maximum resident set size (KB)                   = 900824
+  0: The total amount of wall time                        = 278.188168
+  0: The maximum resident set size (KB)                   = 888544
 
 Test 121 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 20:45:19 UTC 2022
-Elapsed time: 00h:59m:00s. Have a nice day!
+Fri Feb 18 20:56:31 UTC 2022
+Elapsed time: 01h:09m:17s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,24 +1,24 @@
-Thu Feb 10 00:47:00 UTC 2022
+Mon Feb 14 01:18:52 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 472 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 240 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 510 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 494 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 269 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 296 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 366 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 384 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 433 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 180 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 93 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 370 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 389 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 441 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 170 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 358 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 372 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 335 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 169 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 164 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 146 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 399 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 396 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 183 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 248 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 368 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 381 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +83,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 210.560101
-  0: The maximum resident set size (KB)                   = 558188
+  0: The total amount of wall time                        = 215.287688
+  0: The maximum resident set size (KB)                   = 558420
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -143,14 +143,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 243.271654
-  0: The maximum resident set size (KB)                   = 647448
+  0: The total amount of wall time                        = 243.063585
+  0: The maximum resident set size (KB)                   = 644808
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 210.300094
-  0: The maximum resident set size (KB)                   = 562996
+  0: The total amount of wall time                        = 218.003056
+  0: The maximum resident set size (KB)                   = 560420
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_mpi_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -263,14 +263,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 181.501479
-  0: The maximum resident set size (KB)                   = 538312
+  0: The total amount of wall time                        = 181.261205
+  0: The maximum resident set size (KB)                   = 539016
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -323,14 +323,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 253.102399
-  0: The maximum resident set size (KB)                   = 664084
+  0: The total amount of wall time                        = 249.991416
+  0: The maximum resident set size (KB)                   = 666316
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p7
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -375,14 +375,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 867.976857
-  0: The maximum resident set size (KB)                   = 1232224
+  0: The total amount of wall time                        = 865.004803
+  0: The maximum resident set size (KB)                   = 1229644
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -427,14 +427,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 858.850239
-  0: The maximum resident set size (KB)                   = 1233112
+  0: The total amount of wall time                        = 880.354957
+  0: The maximum resident set size (KB)                   = 1228344
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_bmark_mpi_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -479,14 +479,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 840.220890
-  0: The maximum resident set size (KB)                   = 1233948
+  0: The total amount of wall time                        = 841.600321
+  0: The maximum resident set size (KB)                   = 1232208
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -548,14 +548,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 203.468077
-  0: The maximum resident set size (KB)                   = 552780
+  0: The total amount of wall time                        = 211.470778
+  0: The maximum resident set size (KB)                   = 554944
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_restart_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -605,14 +605,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 112.419152
-  0: The maximum resident set size (KB)                   = 325024
+  0: The total amount of wall time                        = 113.554165
+  0: The maximum resident set size (KB)                   = 324404
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -662,14 +662,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 840.954625
-  0: The maximum resident set size (KB)                   = 725672
+  0: The total amount of wall time                        = 844.371835
+  0: The maximum resident set size (KB)                   = 726040
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_restart_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 555.748322
-  0: The maximum resident set size (KB)                   = 828532
+  0: The total amount of wall time                        = 580.573967
+  0: The maximum resident set size (KB)                   = 827416
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -769,14 +769,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1016.307037
-  0: The maximum resident set size (KB)                   = 1243292
+  0: The total amount of wall time                        = 1009.020098
+  0: The maximum resident set size (KB)                   = 1245120
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_restart_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -819,14 +819,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 540.411252
-  0: The maximum resident set size (KB)                   = 1202100
+  0: The total amount of wall time                        = 535.773739
+  0: The maximum resident set size (KB)                   = 1204436
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -876,14 +876,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 608.894544
-  0: The maximum resident set size (KB)                   = 611252
+  0: The total amount of wall time                        = 608.115861
+  0: The maximum resident set size (KB)                   = 612948
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -930,14 +930,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 122.892826
-  0: The maximum resident set size (KB)                   = 464668
+  0: The total amount of wall time                        = 124.092043
+  0: The maximum resident set size (KB)                   = 459948
 
 Test 016 control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_decomp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -980,28 +980,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.497209
-  0: The maximum resident set size (KB)                   = 464964
+  0: The total amount of wall time                        = 134.187791
+  0: The maximum resident set size (KB)                   = 464740
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 122.025236
-  0: The maximum resident set size (KB)                   = 460880
+  0: The total amount of wall time                        = 117.706155
+  0: The maximum resident set size (KB)                   = 458492
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1044,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 149.525310
- 0: The maximum resident set size (KB)                   = 513944
+ 0: The total amount of wall time                        = 151.566018
+ 0: The maximum resident set size (KB)                   = 514480
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1090,14 +1090,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 64.459432
-  0: The maximum resident set size (KB)                   = 201744
+  0: The total amount of wall time                        = 64.626966
+  0: The maximum resident set size (KB)                   = 204992
 
 Test 020 control_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_fhzero
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1140,14 +1140,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.807808
-  0: The maximum resident set size (KB)                   = 463044
+  0: The total amount of wall time                        = 119.518804
+  0: The maximum resident set size (KB)                   = 463072
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.015305
-  0: The maximum resident set size (KB)                   = 465652
+  0: The total amount of wall time                        = 118.784204
+  0: The maximum resident set size (KB)                   = 462496
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_latlon
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1192,17 +1192,17 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.414769
-  0: The maximum resident set size (KB)                   = 463744
+  0: The total amount of wall time                        = 120.611588
+  0: The maximum resident set size (KB)                   = 459548
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1210,14 +1210,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 127.349122
-  0: The maximum resident set size (KB)                   = 461232
+  0: The total amount of wall time                        = 123.705299
+  0: The maximum resident set size (KB)                   = 464852
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c48
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1256,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 313.607761
-0: The maximum resident set size (KB)                   = 663072
+0: The total amount of wall time                        = 308.619900
+0: The maximum resident set size (KB)                   = 658476
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1274,14 +1274,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 462.089905
-  0: The maximum resident set size (KB)                   = 560696
+  0: The total amount of wall time                        = 465.169341
+  0: The maximum resident set size (KB)                   = 558140
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1292,14 +1292,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 775.791623
-  0: The maximum resident set size (KB)                   = 815936
+  0: The total amount of wall time                        = 777.067537
+  0: The maximum resident set size (KB)                   = 823596
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384gdas
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 673.909796
-  0: The maximum resident set size (KB)                   = 960076
+  0: The total amount of wall time                        = 673.355420
+  0: The maximum resident set size (KB)                   = 963644
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,28 +1360,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 82.096987
-  0: The maximum resident set size (KB)                   = 462896
+  0: The total amount of wall time                        = 81.305178
+  0: The maximum resident set size (KB)                   = 466604
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_stochy_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 43.237790
-  0: The maximum resident set size (KB)                   = 247248
+  0: The total amount of wall time                        = 44.275525
+  0: The maximum resident set size (KB)                   = 249568
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_lndp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1392,14 +1392,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 75.067361
-  0: The maximum resident set size (KB)                   = 468860
+  0: The total amount of wall time                        = 75.535488
+  0: The maximum resident set size (KB)                   = 469272
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_iovr4
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 123.645826
-  0: The maximum resident set size (KB)                   = 464440
+  0: The total amount of wall time                        = 122.934583
+  0: The maximum resident set size (KB)                   = 462528
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_iovr5
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1436,14 +1436,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.988502
-  0: The maximum resident set size (KB)                   = 464192
+  0: The total amount of wall time                        = 123.920082
+  0: The maximum resident set size (KB)                   = 464732
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 137.717369
-  0: The maximum resident set size (KB)                   = 495452
+  0: The total amount of wall time                        = 137.973553
+  0: The maximum resident set size (KB)                   = 490664
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_restart_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1536,14 +1536,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 75.585489
-  0: The maximum resident set size (KB)                   = 289376
+  0: The total amount of wall time                        = 73.704691
+  0: The maximum resident set size (KB)                   = 286244
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_decomp_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,14 +1586,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.932594
-  0: The maximum resident set size (KB)                   = 491272
+  0: The total amount of wall time                        = 144.874912
+  0: The maximum resident set size (KB)                   = 491244
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_2threads_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1636,14 +1636,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 171.278653
- 0: The maximum resident set size (KB)                   = 571408
+ 0: The total amount of wall time                        = 170.218843
+ 0: The maximum resident set size (KB)                   = 568860
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p7_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.954445
-  0: The maximum resident set size (KB)                   = 590240
+  0: The total amount of wall time                        = 175.249829
+  0: The maximum resident set size (KB)                   = 589052
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1708,42 +1708,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 298.763531
- 0: The maximum resident set size (KB)                   = 579888
+ 0: The total amount of wall time                        = 300.671677
+ 0: The maximum resident set size (KB)                   = 579248
 
 Test 039 regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 167.634759
- 0: The maximum resident set size (KB)                   = 576108
+ 0: The total amount of wall time                        = 165.177120
+ 0: The maximum resident set size (KB)                   = 571936
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_control_2dwrtdecomp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 299.298252
- 0: The maximum resident set size (KB)                   = 572984
+ 0: The total amount of wall time                        = 300.449207
+ 0: The maximum resident set size (KB)                   = 576320
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 312.074511
- 0: The maximum resident set size (KB)                   = 589728
+ 0: The total amount of wall time                        = 313.672301
+ 0: The maximum resident set size (KB)                   = 590208
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 227.621512
- 0: The maximum resident set size (KB)                   = 571608
+ 0: The total amount of wall time                        = 222.362060
+ 0: The maximum resident set size (KB)                   = 578344
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_hafs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1785,28 +1785,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 297.520732
- 0: The maximum resident set size (KB)                   = 576676
+ 0: The total amount of wall time                        = 301.838778
+ 0: The maximum resident set size (KB)                   = 574760
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 297.545025
- 0: The maximum resident set size (KB)                   = 574556
+ 0: The total amount of wall time                        = 300.635509
+ 0: The maximum resident set size (KB)                   = 570548
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_RRTMGP
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1817,14 +1817,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 380.856449
- 0: The maximum resident set size (KB)                   = 696028
+ 0: The total amount of wall time                        = 376.922848
+ 0: The maximum resident set size (KB)                   = 702756
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1871,14 +1871,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 352.904026
-  0: The maximum resident set size (KB)                   = 834628
+  0: The total amount of wall time                        = 357.619233
+  0: The maximum resident set size (KB)                   = 833168
 
 Test 047 rap_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_2threads
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 438.242353
- 0: The maximum resident set size (KB)                   = 893808
+ 0: The total amount of wall time                        = 438.370765
+ 0: The maximum resident set size (KB)                   = 904804
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.339099
-  0: The maximum resident set size (KB)                   = 585280
+  0: The total amount of wall time                        = 176.664732
+  0: The maximum resident set size (KB)                   = 583960
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2025,14 +2025,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 359.338686
-  0: The maximum resident set size (KB)                   = 833448
+  0: The total amount of wall time                        = 350.473428
+  0: The maximum resident set size (KB)                   = 836304
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_sfcdiff_restart
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2071,14 +2071,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 183.934805
-  0: The maximum resident set size (KB)                   = 586400
+  0: The total amount of wall time                        = 177.602098
+  0: The maximum resident set size (KB)                   = 584936
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hrrr_control
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 337.964284
-  0: The maximum resident set size (KB)                   = 828448
+  0: The total amount of wall time                        = 347.321923
+  0: The maximum resident set size (KB)                   = 833412
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_v1beta
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 350.044860
-  0: The maximum resident set size (KB)                   = 830444
+  0: The total amount of wall time                        = 343.690409
+  0: The maximum resident set size (KB)                   = 830128
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2195,14 +2195,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 176.192928
-  0: The maximum resident set size (KB)                   = 662844
+  0: The total amount of wall time                        = 160.235422
+  0: The maximum resident set size (KB)                   = 662468
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2211,14 +2211,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 180.260110
-  0: The maximum resident set size (KB)                   = 666320
+  0: The total amount of wall time                        = 162.490284
+  0: The maximum resident set size (KB)                   = 662884
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.177792
-  0: The maximum resident set size (KB)                   = 586916
+  0: The total amount of wall time                        = 195.348284
+  0: The maximum resident set size (KB)                   = 587056
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp_c192
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_rrtmgp_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2247,14 +2247,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 503.470318
-  0: The maximum resident set size (KB)                   = 799980
+  0: The total amount of wall time                        = 508.794751
+  0: The maximum resident set size (KB)                   = 798264
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmg
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2265,14 +2265,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 306.926752
-  0: The maximum resident set size (KB)                   = 531884
+  0: The total amount of wall time                        = 314.818413
+  0: The maximum resident set size (KB)                   = 534320
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmgt
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2283,14 +2283,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 306.026732
-  0: The maximum resident set size (KB)                   = 529472
+  0: The total amount of wall time                        = 314.002369
+  0: The maximum resident set size (KB)                   = 533860
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_flake
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2301,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 227.874951
-  0: The maximum resident set size (KB)                   = 537528
+  0: The total amount of wall time                        = 224.915216
+  0: The maximum resident set size (KB)                   = 532980
 
 Test 060 control_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_ras
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2319,14 +2319,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.603055
-  0: The maximum resident set size (KB)                   = 493492
+  0: The total amount of wall time                        = 163.977770
+  0: The maximum resident set size (KB)                   = 492372
 
 Test 061 control_ras PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2337,14 +2337,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 214.291033
-  0: The maximum resident set size (KB)                   = 851048
+  0: The total amount of wall time                        = 209.110044
+  0: The maximum resident set size (KB)                   = 848068
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_no_aero
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2355,54 +2355,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.974241
-  0: The maximum resident set size (KB)                   = 844628
+  0: The total amount of wall time                        = 198.553870
+  0: The maximum resident set size (KB)                   = 842936
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wam_repro
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_wam_repro
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 119.216208
-  0: The maximum resident set size (KB)                   = 226388
+  0: The total amount of wall time                        = 117.241104
+  0: The maximum resident set size (KB)                   = 224780
 
 Test 064 control_wam PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 141.244472
-  0: The maximum resident set size (KB)                   = 532076
+  0: The total amount of wall time                        = 139.402339
+  0: The maximum resident set size (KB)                   = 529416
 
 Test 065 control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_2threads_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 210.093530
- 0: The maximum resident set size (KB)                   = 583176
+ 0: The total amount of wall time                        = 212.288180
+ 0: The maximum resident set size (KB)                   = 582168
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2429,458 +2429,458 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 151.435986
-  0: The maximum resident set size (KB)                   = 530364
+  0: The total amount of wall time                        = 151.764180
+  0: The maximum resident set size (KB)                   = 533744
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.287044
-  0: The maximum resident set size (KB)                   = 529524
+  0: The total amount of wall time                        = 143.082142
+  0: The maximum resident set size (KB)                   = 529244
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.330749
-  0: The maximum resident set size (KB)                   = 535140
+  0: The total amount of wall time                        = 163.853801
+  0: The maximum resident set size (KB)                   = 534212
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.533842
-  0: The maximum resident set size (KB)                   = 537080
+  0: The total amount of wall time                        = 146.039550
+  0: The maximum resident set size (KB)                   = 538700
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.137422
-  0: The maximum resident set size (KB)                   = 640268
+  0: The total amount of wall time                        = 158.522054
+  0: The maximum resident set size (KB)                   = 632540
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmg_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 219.493442
-  0: The maximum resident set size (KB)                   = 570268
+  0: The total amount of wall time                        = 223.708693
+  0: The maximum resident set size (KB)                   = 572336
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmgt_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.552946
-  0: The maximum resident set size (KB)                   = 575284
+  0: The total amount of wall time                        = 221.962354
+  0: The maximum resident set size (KB)                   = 572516
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_ras_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.983909
-  0: The maximum resident set size (KB)                   = 545608
+  0: The total amount of wall time                        = 150.657136
+  0: The maximum resident set size (KB)                   = 543840
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.324560
-  0: The maximum resident set size (KB)                   = 588532
+  0: The total amount of wall time                        = 155.050934
+  0: The maximum resident set size (KB)                   = 587920
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug_p8
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.992724
-  0: The maximum resident set size (KB)                   = 557516
+  0: The total amount of wall time                        = 155.504983
+  0: The maximum resident set size (KB)                   = 557536
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.390700
-  0: The maximum resident set size (KB)                   = 887072
+  0: The total amount of wall time                        = 162.356606
+  0: The maximum resident set size (KB)                   = 890240
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.557171
-  0: The maximum resident set size (KB)                   = 889096
+  0: The total amount of wall time                        = 161.672374
+  0: The maximum resident set size (KB)                   = 888980
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson_extdiag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.391617
-  0: The maximum resident set size (KB)                   = 920628
+  0: The total amount of wall time                        = 176.424195
+  0: The maximum resident set size (KB)                   = 918408
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.595087
-  0: The maximum resident set size (KB)                   = 891800
+  0: The total amount of wall time                        = 167.157298
+  0: The maximum resident set size (KB)                   = 889456
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 235.950271
- 0: The maximum resident set size (KB)                   = 611648
+ 0: The total amount of wall time                        = 235.602404
+ 0: The maximum resident set size (KB)                   = 603952
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 254.488849
-  0: The maximum resident set size (KB)                   = 895644
+  0: The total amount of wall time                        = 261.263701
+  0: The maximum resident set size (KB)                   = 898428
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_unified_drag_suite_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.410158
-  0: The maximum resident set size (KB)                   = 897580
+  0: The total amount of wall time                        = 260.847092
+  0: The maximum resident set size (KB)                   = 898932
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_diag_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.647866
-  0: The maximum resident set size (KB)                   = 983292
+  0: The total amount of wall time                        = 271.992892
+  0: The maximum resident set size (KB)                   = 982404
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.547826
-  0: The maximum resident set size (KB)                   = 897964
+  0: The total amount of wall time                        = 263.710457
+  0: The maximum resident set size (KB)                   = 901084
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_unified_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.130046
-  0: The maximum resident set size (KB)                   = 900628
+  0: The total amount of wall time                        = 267.915839
+  0: The maximum resident set size (KB)                   = 900988
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_noah_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 254.259143
-  0: The maximum resident set size (KB)                   = 895528
+  0: The total amount of wall time                        = 257.102540
+  0: The maximum resident set size (KB)                   = 899636
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 446.752439
-  0: The maximum resident set size (KB)                   = 1006784
+  0: The total amount of wall time                        = 435.753830
+  0: The maximum resident set size (KB)                   = 1003424
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_lndp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.318182
-  0: The maximum resident set size (KB)                   = 900664
+  0: The total amount of wall time                        = 262.578444
+  0: The maximum resident set size (KB)                   = 901676
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.354343
-  0: The maximum resident set size (KB)                   = 900936
+  0: The total amount of wall time                        = 262.318834
+  0: The maximum resident set size (KB)                   = 894512
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_flake_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.972522
-  0: The maximum resident set size (KB)                   = 900144
+  0: The total amount of wall time                        = 258.198827
+  0: The maximum resident set size (KB)                   = 900224
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 431.419140
-  0: The maximum resident set size (KB)                   = 896680
+  0: The total amount of wall time                        = 430.879500
+  0: The maximum resident set size (KB)                   = 899672
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 266.961573
-  0: The maximum resident set size (KB)                   = 894396
+  0: The total amount of wall time                        = 255.038304
+  0: The maximum resident set size (KB)                   = 896268
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.903834
-  0: The maximum resident set size (KB)                   = 896820
+  0: The total amount of wall time                        = 259.053511
+  0: The maximum resident set size (KB)                   = 894320
 
 Test 094 rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wam_debug
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 280.478272
-  0: The maximum resident set size (KB)                   = 263908
+  0: The total amount of wall time                        = 275.127493
+  0: The maximum resident set size (KB)                   = 251760
 
 Test 095 control_wam_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 291.065628
-  0: The maximum resident set size (KB)                   = 703256
+  0: The total amount of wall time                        = 248.297918
+  0: The maximum resident set size (KB)                   = 702736
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 319.136739
-  0: The maximum resident set size (KB)                   = 1061500
+  0: The total amount of wall time                        = 309.252477
+  0: The maximum resident set size (KB)                   = 1054064
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 353.929142
-  0: The maximum resident set size (KB)                   = 720808
+  0: The total amount of wall time                        = 339.908220
+  0: The maximum resident set size (KB)                   = 717972
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 855.414060
-  0: The maximum resident set size (KB)                   = 718252
+  0: The total amount of wall time                        = 821.601600
+  0: The maximum resident set size (KB)                   = 718908
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2889,62 +2889,62 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 950.245423
-  0: The maximum resident set size (KB)                   = 720628
+  0: The total amount of wall time                        = 916.003389
+  0: The maximum resident set size (KB)                   = 713120
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 400.344281
-  0: The maximum resident set size (KB)                   = 297912
+  0: The total amount of wall time                        = 398.287221
+  0: The maximum resident set size (KB)                   = 297488
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 427.505940
-  0: The maximum resident set size (KB)                   = 295936
+  0: The total amount of wall time                        = 423.673695
+  0: The maximum resident set size (KB)                   = 297092
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 199.974663
-  0: The maximum resident set size (KB)                   = 189496
+  0: The total amount of wall time                        = 191.213885
+  0: The maximum resident set size (KB)                   = 193432
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 437.749138
-  0: The maximum resident set size (KB)                   = 237308
+  0: The total amount of wall time                        = 436.608260
+  0: The maximum resident set size (KB)                   = 238540
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_docn
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
@@ -2952,120 +2952,120 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 343.846133
-  0: The maximum resident set size (KB)                   = 714048
+  0: The total amount of wall time                        = 322.364060
+  0: The maximum resident set size (KB)                   = 714564
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 340.571921
-  0: The maximum resident set size (KB)                   = 713360
+  0: The total amount of wall time                        = 326.870710
+  0: The maximum resident set size (KB)                   = 716716
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 947.417951
-  0: The maximum resident set size (KB)                   = 857492
+  0: The total amount of wall time                        = 946.393651
+  0: The maximum resident set size (KB)                   = 851796
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.488845
- 0: The maximum resident set size (KB)                   = 719332
+ 0: The total amount of wall time                        = 139.383191
+ 0: The maximum resident set size (KB)                   = 739212
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 91.814454
- 0: The maximum resident set size (KB)                   = 720724
+ 0: The total amount of wall time                        = 80.024735
+ 0: The maximum resident set size (KB)                   = 719788
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.030515
- 0: The maximum resident set size (KB)                   = 620112
+ 0: The total amount of wall time                        = 137.666544
+ 0: The maximum resident set size (KB)                   = 620180
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.632176
- 0: The maximum resident set size (KB)                   = 620276
+ 0: The total amount of wall time                        = 139.623837
+ 0: The maximum resident set size (KB)                   = 621800
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.218903
- 0: The maximum resident set size (KB)                   = 719320
+ 0: The total amount of wall time                        = 141.393800
+ 0: The maximum resident set size (KB)                   = 718844
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.876808
- 0: The maximum resident set size (KB)                   = 619648
+ 0: The total amount of wall time                        = 136.409498
+ 0: The maximum resident set size (KB)                   = 620480
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3074,14 +3074,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 312.755490
-  0: The maximum resident set size (KB)                   = 561868
+  0: The total amount of wall time                        = 302.254769
+  0: The maximum resident set size (KB)                   = 557820
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3090,51 +3090,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 301.178991
-  0: The maximum resident set size (KB)                   = 535428
+  0: The total amount of wall time                        = 305.101395
+  0: The maximum resident set size (KB)                   = 528356
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_multiple_files_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.632752
- 0: The maximum resident set size (KB)                   = 719248
+ 0: The total amount of wall time                        = 142.499683
+ 0: The maximum resident set size (KB)                   = 719876
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.728509
- 0: The maximum resident set size (KB)                   = 1835468
+ 0: The total amount of wall time                        = 194.027163
+ 0: The maximum resident set size (KB)                   = 1832600
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 443.882130
- 0: The maximum resident set size (KB)                   = 726048
+ 0: The total amount of wall time                        = 430.009093
+ 0: The maximum resident set size (KB)                   = 724072
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_atmwav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3178,14 +3178,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 80.847739
-  0: The maximum resident set size (KB)                   = 494900
+  0: The total amount of wall time                        = 81.751701
+  0: The maximum resident set size (KB)                   = 498928
 
 Test 119 control_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384gdas_wav
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3231,14 +3231,14 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 696.343829
-  0: The maximum resident set size (KB)                   = 1041956
+  0: The total amount of wall time                        = 699.354381
+  0: The maximum resident set size (KB)                   = 1037184
 
 Test 120 control_c384gdas_wav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_atm_aerosols
-working dir  = /scratch1/NCEPDEV/stmp2/emc.nemspara/FV3_RT/rt_10232/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/Raffaele.Montuoro/FV3_RT/rt_212353/control_atm_aerosols
 Checking test 121 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3285,12 +3285,12 @@ Checking test 121 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.789327
-  0: The maximum resident set size (KB)                   = 897612
+  0: The total amount of wall time                        = 282.163985
+  0: The maximum resident set size (KB)                   = 890184
 
 Test 121 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Feb 10 01:39:10 UTC 2022
-Elapsed time: 00h:52m:12s. Have a nice day!
+Mon Feb 14 02:22:04 UTC 2022
+Elapsed time: 01h:03m:13s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,23 +1,23 @@
-Tue Feb 15 23:08:29 GMT 2022
+Fri Feb 18 19:47:02 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1694 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 223 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1550 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 1521 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 828 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 233 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 229 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1568 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1567 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 273 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 013 elapsed time 121 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 1504 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 001 elapsed time 1720 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 222 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1531 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 1526 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1592 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 868 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 248 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 244 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 206 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1705 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1576 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 276 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 013 elapsed time 151 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 1525 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 287.537434
-  0: The maximum resident set size (KB)                   = 599480
+  0: The total amount of wall time                        = 572.770347
+  0: The maximum resident set size (KB)                   = 602848
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_2threads_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 850.182065
-  0: The maximum resident set size (KB)                   = 668516
+  0: The total amount of wall time                        = 955.429729
+  0: The maximum resident set size (KB)                   = 668848
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_mpi_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_mpi_p8
 Checking test 003 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 250.412408
-  0: The maximum resident set size (KB)                   = 595328
+  0: The total amount of wall time                        = 427.496811
+  0: The maximum resident set size (KB)                   = 595108
 
 Test 003 cpld_mpi_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_control_p7_rrtmgp
 Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 332.556963
-  0: The maximum resident set size (KB)                   = 704512
+  0: The total amount of wall time                        = 514.063969
+  0: The maximum resident set size (KB)                   = 699452
 
 Test 004 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_p7
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_bmark_p7
 Checking test 005 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -314,14 +314,14 @@ Checking test 005 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1156.445259
-  0: The maximum resident set size (KB)                   = 1367492
+  0: The total amount of wall time                        = 1380.882602
+  0: The maximum resident set size (KB)                   = 1357704
 
 Test 005 cpld_bmark_p7 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_bmark_p8
 Checking test 006 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -366,14 +366,14 @@ Checking test 006 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1154.424777
-  0: The maximum resident set size (KB)                   = 1368652
+  0: The total amount of wall time                        = 1338.813150
+  0: The maximum resident set size (KB)                   = 1366324
 
 Test 006 cpld_bmark_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_bmark_mpi_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_bmark_mpi_p8
 Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -418,14 +418,14 @@ Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1143.578481
-  0: The maximum resident set size (KB)                   = 1368128
+  0: The total amount of wall time                        = 1254.781665
+  0: The maximum resident set size (KB)                   = 1369520
 
 Test 007 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_control_c96_p8
 Checking test 008 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -487,14 +487,14 @@ Checking test 008 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 281.752821
-  0: The maximum resident set size (KB)                   = 593292
+  0: The total amount of wall time                        = 286.415672
+  0: The maximum resident set size (KB)                   = 588436
 
 Test 008 cpld_control_c96_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c96_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_restart_c96_p8
 Checking test 009 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -544,14 +544,14 @@ Checking test 009 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 156.183674
-  0: The maximum resident set size (KB)                   = 351852
+  0: The total amount of wall time                        = 166.872386
+  0: The maximum resident set size (KB)                   = 354788
 
 Test 009 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c192_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -601,14 +601,14 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1191.642790
-  0: The maximum resident set size (KB)                   = 785936
+  0: The total amount of wall time                        = 1209.908172
+  0: The maximum resident set size (KB)                   = 782096
 
 Test 010 cpld_control_c192_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c192_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -658,14 +658,14 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 745.946772
-  0: The maximum resident set size (KB)                   = 886608
+  0: The total amount of wall time                        = 782.657238
+  0: The maximum resident set size (KB)                   = 894564
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_control_c384_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_control_c384_p8
 Checking test 012 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -708,14 +708,14 @@ Checking test 012 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1322.755919
-  0: The maximum resident set size (KB)                   = 1338152
+  0: The total amount of wall time                        = 1336.654335
+  0: The maximum resident set size (KB)                   = 1328700
 
 Test 012 cpld_control_c384_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_restart_c384_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_restart_c384_p8
 Checking test 013 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -758,14 +758,14 @@ Checking test 013 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 715.778780
-  0: The maximum resident set size (KB)                   = 1293564
+  0: The total amount of wall time                        = 776.389948
+  0: The maximum resident set size (KB)                   = 1295220
 
 Test 013 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/cpld_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -815,14 +815,14 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 799.151252
-  0: The maximum resident set size (KB)                   = 645616
+  0: The total amount of wall time                        = 804.187842
+  0: The maximum resident set size (KB)                   = 645456
 
 Test 014 cpld_debug_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -869,14 +869,14 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.568770
-  0: The maximum resident set size (KB)                   = 483568
+  0: The total amount of wall time                        = 216.898292
+  0: The maximum resident set size (KB)                   = 482516
 
 Test 015 control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_decomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -919,28 +919,28 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.603810
-  0: The maximum resident set size (KB)                   = 484460
+  0: The total amount of wall time                        = 304.891000
+  0: The maximum resident set size (KB)                   = 479360
 
 Test 016 control_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2dwrtdecomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_2dwrtdecomp
 Checking test 017 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 157.579583
-  0: The maximum resident set size (KB)                   = 479888
+  0: The total amount of wall time                        = 295.430979
+  0: The maximum resident set size (KB)                   = 484180
 
 Test 017 control_2dwrtdecomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -983,14 +983,14 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 741.362627
- 0: The maximum resident set size (KB)                   = 529228
+ 0: The total amount of wall time                        = 862.546907
+ 0: The maximum resident set size (KB)                   = 529320
 
 Test 018 control_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1029,14 +1029,14 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 90.526641
-  0: The maximum resident set size (KB)                   = 219504
+  0: The total amount of wall time                        = 100.874121
+  0: The maximum resident set size (KB)                   = 216776
 
 Test 019 control_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_fhzero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1079,14 +1079,14 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.166924
-  0: The maximum resident set size (KB)                   = 478524
+  0: The total amount of wall time                        = 164.127399
+  0: The maximum resident set size (KB)                   = 481572
 
 Test 020 control_fhzero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,14 +1113,14 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 157.717925
-  0: The maximum resident set size (KB)                   = 476668
+  0: The total amount of wall time                        = 214.010981
+  0: The maximum resident set size (KB)                   = 476972
 
 Test 021 control_CubedSphereGrid PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_latlon
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_latlon
 Checking test 022 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1131,14 +1131,14 @@ Checking test 022 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 163.647894
-  0: The maximum resident set size (KB)                   = 478892
+  0: The total amount of wall time                        = 208.490021
+  0: The maximum resident set size (KB)                   = 479292
 
 Test 022 control_latlon PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1149,14 +1149,14 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.769911
-  0: The maximum resident set size (KB)                   = 476268
+  0: The total amount of wall time                        = 207.459093
+  0: The maximum resident set size (KB)                   = 478896
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c48
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1195,14 +1195,14 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 535.037076
-0: The maximum resident set size (KB)                   = 665588
+0: The total amount of wall time                        = 547.944401
+0: The maximum resident set size (KB)                   = 661504
 
 Test 024 control_c48 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1213,14 +1213,14 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 643.971257
-  0: The maximum resident set size (KB)                   = 585596
+  0: The total amount of wall time                        = 713.670577
+  0: The maximum resident set size (KB)                   = 585320
 
 Test 025 control_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c384
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1231,14 +1231,14 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 799.550167
-  0: The maximum resident set size (KB)                   = 752768
+  0: The total amount of wall time                        = 1063.379693
+  0: The maximum resident set size (KB)                   = 751792
 
 Test 026 control_c384 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_c384gdas
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1281,14 +1281,14 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 746.475032
-  0: The maximum resident set size (KB)                   = 842540
+  0: The total amount of wall time                        = 973.609341
+  0: The maximum resident set size (KB)                   = 837424
 
 Test 027 control_c384gdas PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1299,28 +1299,28 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 108.317093
-  0: The maximum resident set size (KB)                   = 482408
+  0: The total amount of wall time                        = 110.050249
+  0: The maximum resident set size (KB)                   = 480296
 
 Test 028 control_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 61.446534
-  0: The maximum resident set size (KB)                   = 241280
+  0: The total amount of wall time                        = 61.985699
+  0: The maximum resident set size (KB)                   = 243236
 
 Test 029 control_stochy_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_lndp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1331,14 +1331,14 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.721761
-  0: The maximum resident set size (KB)                   = 482356
+  0: The total amount of wall time                        = 118.990352
+  0: The maximum resident set size (KB)                   = 486300
 
 Test 030 control_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_iovr4
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_iovr4
 Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 031 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 166.357026
-  0: The maximum resident set size (KB)                   = 480828
+  0: The total amount of wall time                        = 303.881573
+  0: The maximum resident set size (KB)                   = 478364
 
 Test 031 control_iovr4 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_iovr5
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_iovr5
 Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1375,14 +1375,14 @@ Checking test 032 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 166.812480
-  0: The maximum resident set size (KB)                   = 479468
+  0: The total amount of wall time                        = 305.666187
+  0: The maximum resident set size (KB)                   = 475756
 
 Test 032 control_iovr5 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_p8
 Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1429,14 +1429,14 @@ Checking test 033 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.348967
-  0: The maximum resident set size (KB)                   = 506028
+  0: The total amount of wall time                        = 292.926298
+  0: The maximum resident set size (KB)                   = 503924
 
 Test 033 control_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_restart_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_restart_p8
 Checking test 034 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1475,14 +1475,14 @@ Checking test 034 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 102.374673
-  0: The maximum resident set size (KB)                   = 291884
+  0: The total amount of wall time                        = 104.887137
+  0: The maximum resident set size (KB)                   = 291048
 
 Test 034 control_restart_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_decomp_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_decomp_p8
 Checking test 035 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1525,14 +1525,14 @@ Checking test 035 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.866907
-  0: The maximum resident set size (KB)                   = 498832
+  0: The total amount of wall time                        = 294.549265
+  0: The maximum resident set size (KB)                   = 497500
 
 Test 035 control_decomp_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_2threads_p8
 Checking test 036 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1575,14 +1575,14 @@ Checking test 036 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 882.494034
- 0: The maximum resident set size (KB)                   = 573868
+ 0: The total amount of wall time                        = 815.180102
+ 0: The maximum resident set size (KB)                   = 578468
 
 Test 036 control_2threads_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_p7_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_p7_rrtmgp
 Checking test 037 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1629,14 +1629,14 @@ Checking test 037 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.710208
-  0: The maximum resident set size (KB)                   = 604940
+  0: The total amount of wall time                        = 332.991476
+  0: The maximum resident set size (KB)                   = 607428
 
 Test 037 control_p7_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_control
 Checking test 038 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1647,42 +1647,42 @@ Checking test 038 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 413.136845
- 0: The maximum resident set size (KB)                   = 586992
+ 0: The total amount of wall time                        = 672.115645
+ 0: The maximum resident set size (KB)                   = 587856
 
 Test 038 regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_restart
 Checking test 039 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 229.512172
- 0: The maximum resident set size (KB)                   = 586228
+ 0: The total amount of wall time                        = 231.204318
+ 0: The maximum resident set size (KB)                   = 594448
 
 Test 039 regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_control_2dwrtdecomp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_control_2dwrtdecomp
 Checking test 040 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 412.450230
- 0: The maximum resident set size (KB)                   = 583476
+ 0: The total amount of wall time                        = 554.925056
+ 0: The maximum resident set size (KB)                   = 585468
 
 Test 040 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_noquilt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_noquilt
 Checking test 041 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 041 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 438.047574
- 0: The maximum resident set size (KB)                   = 594116
+ 0: The total amount of wall time                        = 448.710350
+ 0: The maximum resident set size (KB)                   = 588744
 
 Test 041 regional_noquilt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_hafs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_hafs
 Checking test 042 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1706,28 +1706,28 @@ Checking test 042 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 410.665038
- 0: The maximum resident set size (KB)                   = 592916
+ 0: The total amount of wall time                        = 591.733327
+ 0: The maximum resident set size (KB)                   = 585628
 
 Test 042 regional_hafs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_netcdf_parallel
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_netcdf_parallel
 Checking test 043 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
- Comparing phyf024.nc ............ALT CHECK......OK
+ Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 411.499997
- 0: The maximum resident set size (KB)                   = 581896
+ 0: The total amount of wall time                        = 411.150861
+ 0: The maximum resident set size (KB)                   = 583908
 
 Test 043 regional_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_RRTMGP
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_RRTMGP
 Checking test 044 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1738,14 +1738,14 @@ Checking test 044 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 518.501952
- 0: The maximum resident set size (KB)                   = 713388
+ 0: The total amount of wall time                        = 525.600759
+ 0: The maximum resident set size (KB)                   = 710244
 
 Test 044 regional_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_control
 Checking test 045 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1792,14 +1792,14 @@ Checking test 045 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.031430
-  0: The maximum resident set size (KB)                   = 844192
+  0: The total amount of wall time                        = 495.204322
+  0: The maximum resident set size (KB)                   = 845436
 
 Test 045 rap_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_restart
 Checking test 046 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1838,14 +1838,14 @@ Checking test 046 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.742098
-  0: The maximum resident set size (KB)                   = 591264
+  0: The total amount of wall time                        = 242.377460
+  0: The maximum resident set size (KB)                   = 590240
 
 Test 046 rap_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_sfcdiff
 Checking test 047 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1892,14 +1892,14 @@ Checking test 047 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.527081
-  0: The maximum resident set size (KB)                   = 849380
+  0: The total amount of wall time                        = 495.099936
+  0: The maximum resident set size (KB)                   = 843216
 
 Test 047 rap_sfcdiff PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff_restart
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_sfcdiff_restart
 Checking test 048 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1938,14 +1938,14 @@ Checking test 048 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.739240
-  0: The maximum resident set size (KB)                   = 593724
+  0: The total amount of wall time                        = 246.688791
+  0: The maximum resident set size (KB)                   = 591272
 
 Test 048 rap_sfcdiff_restart PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hrrr_control
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hrrr_control
 Checking test 049 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1992,14 +1992,14 @@ Checking test 049 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.699345
-  0: The maximum resident set size (KB)                   = 846120
+  0: The total amount of wall time                        = 476.404177
+  0: The maximum resident set size (KB)                   = 838828
 
 Test 049 hrrr_control PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_v1beta
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rrfs_v1beta
 Checking test 050 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2046,14 +2046,14 @@ Checking test 050 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 461.657812
-  0: The maximum resident set size (KB)                   = 843752
+  0: The total amount of wall time                        = 491.463687
+  0: The maximum resident set size (KB)                   = 843624
 
 Test 050 rrfs_v1beta PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rrfs_conus13km_hrrr_warm
 Checking test 051 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2062,14 +2062,14 @@ Checking test 051 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 213.051039
-  0: The maximum resident set size (KB)                   = 692616
+  0: The total amount of wall time                        = 216.798932
+  0: The maximum resident set size (KB)                   = 690936
 
 Test 051 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rrfs_conus13km_radar_tten_warm
 Checking test 052 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2078,14 +2078,14 @@ Checking test 052 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 214.655281
-  0: The maximum resident set size (KB)                   = 693856
+  0: The total amount of wall time                        = 215.742502
+  0: The maximum resident set size (KB)                   = 693196
 
 Test 052 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_rrtmgp
 Checking test 053 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2096,14 +2096,14 @@ Checking test 053 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 250.787878
-  0: The maximum resident set size (KB)                   = 597644
+  0: The total amount of wall time                        = 258.204663
+  0: The maximum resident set size (KB)                   = 593204
 
 Test 053 control_rrtmgp PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp_c192
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_rrtmgp_c192
 Checking test 054 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2114,14 +2114,14 @@ Checking test 054 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 687.422961
-  0: The maximum resident set size (KB)                   = 805624
+  0: The total amount of wall time                        = 689.486133
+  0: The maximum resident set size (KB)                   = 807588
 
 Test 054 control_rrtmgp_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmg
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_csawmg
 Checking test 055 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 055 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 419.219626
-  0: The maximum resident set size (KB)                   = 535724
+  0: The total amount of wall time                        = 432.006877
+  0: The maximum resident set size (KB)                   = 540104
 
 Test 055 control_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmgt
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_csawmgt
 Checking test 056 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2150,14 +2150,14 @@ Checking test 056 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 412.567280
-  0: The maximum resident set size (KB)                   = 537088
+  0: The total amount of wall time                        = 428.130591
+  0: The maximum resident set size (KB)                   = 538208
 
 Test 056 control_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_flake
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_flake
 Checking test 057 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2168,14 +2168,14 @@ Checking test 057 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 276.445136
-  0: The maximum resident set size (KB)                   = 547340
+  0: The total amount of wall time                        = 282.472889
+  0: The maximum resident set size (KB)                   = 548576
 
 Test 057 control_flake PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_ras
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_ras
 Checking test 058 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 058 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 224.931886
-  0: The maximum resident set size (KB)                   = 508824
+  0: The total amount of wall time                        = 232.116525
+  0: The maximum resident set size (KB)                   = 507740
 
 Test 058 control_ras PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson
 Checking test 059 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2204,14 +2204,14 @@ Checking test 059 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 278.052867
-  0: The maximum resident set size (KB)                   = 861924
+  0: The total amount of wall time                        = 285.661177
+  0: The maximum resident set size (KB)                   = 861940
 
 Test 059 control_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_no_aero
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson_no_aero
 Checking test 060 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2222,54 +2222,54 @@ Checking test 060 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 267.232408
-  0: The maximum resident set size (KB)                   = 854868
+  0: The total amount of wall time                        = 271.578448
+  0: The maximum resident set size (KB)                   = 849968
 
 Test 060 control_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wam_repro
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_wam_repro
 Checking test 061 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 148.641721
-  0: The maximum resident set size (KB)                   = 238188
+  0: The total amount of wall time                        = 152.162350
+  0: The maximum resident set size (KB)                   = 238208
 
 Test 061 control_wam PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_debug
 Checking test 062 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.084606
-  0: The maximum resident set size (KB)                   = 539536
+  0: The total amount of wall time                        = 191.464683
+  0: The maximum resident set size (KB)                   = 535888
 
 Test 062 control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_2threads_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_2threads_debug
 Checking test 063 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 358.384775
- 0: The maximum resident set size (KB)                   = 591816
+ 0: The total amount of wall time                        = 370.769432
+ 0: The maximum resident set size (KB)                   = 587096
 
 Test 063 control_2threads_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_CubedSphereGrid_debug
 Checking test 064 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2296,428 +2296,428 @@ Checking test 064 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 204.805348
-  0: The maximum resident set size (KB)                   = 538548
+  0: The total amount of wall time                        = 207.046407
+  0: The maximum resident set size (KB)                   = 540300
 
 Test 064 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_wrtGauss_netcdf_parallel_debug
 Checking test 065 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.213611
-  0: The maximum resident set size (KB)                   = 543400
+  0: The total amount of wall time                        = 199.404484
+  0: The maximum resident set size (KB)                   = 543412
 
 Test 065 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_stochy_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_stochy_debug
 Checking test 066 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 217.253974
-  0: The maximum resident set size (KB)                   = 543216
+  0: The total amount of wall time                        = 225.619491
+  0: The maximum resident set size (KB)                   = 545740
 
 Test 066 control_stochy_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_lndp_debug
 Checking test 067 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.770881
-  0: The maximum resident set size (KB)                   = 546576
+  0: The total amount of wall time                        = 195.774001
+  0: The maximum resident set size (KB)                   = 540340
 
 Test 067 control_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_rrtmgp_debug
 Checking test 068 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 209.945333
-  0: The maximum resident set size (KB)                   = 638336
+  0: The total amount of wall time                        = 209.949878
+  0: The maximum resident set size (KB)                   = 639212
 
 Test 068 control_rrtmgp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmg_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_csawmg_debug
 Checking test 069 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 302.284641
-  0: The maximum resident set size (KB)                   = 576368
+  0: The total amount of wall time                        = 304.510320
+  0: The maximum resident set size (KB)                   = 576320
 
 Test 069 control_csawmg_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_csawmgt_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_csawmgt_debug
 Checking test 070 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.923767
-  0: The maximum resident set size (KB)                   = 575244
+  0: The total amount of wall time                        = 297.898176
+  0: The maximum resident set size (KB)                   = 579132
 
 Test 070 control_csawmgt_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_ras_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_ras_debug
 Checking test 071 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.938391
-  0: The maximum resident set size (KB)                   = 557584
+  0: The total amount of wall time                        = 199.210100
+  0: The maximum resident set size (KB)                   = 556840
 
 Test 071 control_ras_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_diag_debug
 Checking test 072 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.365865
-  0: The maximum resident set size (KB)                   = 597396
+  0: The total amount of wall time                        = 202.610690
+  0: The maximum resident set size (KB)                   = 596228
 
 Test 072 control_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_debug_p8
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_debug_p8
 Checking test 073 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.890511
-  0: The maximum resident set size (KB)                   = 557768
+  0: The total amount of wall time                        = 208.705326
+  0: The maximum resident set size (KB)                   = 555568
 
 Test 073 control_debug_p8 PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson_debug
 Checking test 074 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 222.745665
-  0: The maximum resident set size (KB)                   = 900056
+  0: The total amount of wall time                        = 221.264089
+  0: The maximum resident set size (KB)                   = 900556
 
 Test 074 control_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson_no_aero_debug
 Checking test 075 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.308171
-  0: The maximum resident set size (KB)                   = 900132
+  0: The total amount of wall time                        = 217.047958
+  0: The maximum resident set size (KB)                   = 898736
 
 Test 075 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_extdiag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson_extdiag_debug
 Checking test 076 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.118404
-  0: The maximum resident set size (KB)                   = 932852
+  0: The total amount of wall time                        = 234.916285
+  0: The maximum resident set size (KB)                   = 929012
 
 Test 076 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_thompson_progcld_thompson_debug
 Checking test 077 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.990753
-  0: The maximum resident set size (KB)                   = 899824
+  0: The total amount of wall time                        = 224.815759
+  0: The maximum resident set size (KB)                   = 901316
 
 Test 077 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/regional_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/regional_debug
 Checking test 078 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 320.677425
- 0: The maximum resident set size (KB)                   = 616552
+ 0: The total amount of wall time                        = 320.529765
+ 0: The maximum resident set size (KB)                   = 609892
 
 Test 078 regional_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_control_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_control_debug
 Checking test 079 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.418090
-  0: The maximum resident set size (KB)                   = 908656
+  0: The total amount of wall time                        = 345.870965
+  0: The maximum resident set size (KB)                   = 906836
 
 Test 079 rap_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_unified_drag_suite_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_unified_drag_suite_debug
 Checking test 080 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.639697
-  0: The maximum resident set size (KB)                   = 905864
+  0: The total amount of wall time                        = 342.180447
+  0: The maximum resident set size (KB)                   = 907196
 
 Test 080 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_diag_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_diag_debug
 Checking test 081 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 364.101000
-  0: The maximum resident set size (KB)                   = 991736
+  0: The total amount of wall time                        = 365.449951
+  0: The maximum resident set size (KB)                   = 988852
 
 Test 081 rap_diag_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_cires_ugwp_debug
 Checking test 082 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.317857
-  0: The maximum resident set size (KB)                   = 912212
+  0: The total amount of wall time                        = 351.551618
+  0: The maximum resident set size (KB)                   = 906820
 
 Test 082 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_unified_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_unified_ugwp_debug
 Checking test 083 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.239030
-  0: The maximum resident set size (KB)                   = 911600
+  0: The total amount of wall time                        = 355.837340
+  0: The maximum resident set size (KB)                   = 908620
 
 Test 083 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_noah_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_noah_debug
 Checking test 084 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 338.517879
-  0: The maximum resident set size (KB)                   = 908444
+  0: The total amount of wall time                        = 345.195474
+  0: The maximum resident set size (KB)                   = 905676
 
 Test 084 rap_noah_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_rrtmgp_debug
 Checking test 085 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 583.846268
-  0: The maximum resident set size (KB)                   = 1007140
+  0: The total amount of wall time                        = 587.919788
+  0: The maximum resident set size (KB)                   = 1008900
 
 Test 085 rap_rrtmgp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_lndp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_lndp_debug
 Checking test 086 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.438342
-  0: The maximum resident set size (KB)                   = 909412
+  0: The total amount of wall time                        = 345.892889
+  0: The maximum resident set size (KB)                   = 906608
 
 Test 086 rap_lndp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_sfcdiff_debug
 Checking test 087 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.678667
-  0: The maximum resident set size (KB)                   = 910424
+  0: The total amount of wall time                        = 347.064909
+  0: The maximum resident set size (KB)                   = 910664
 
 Test 087 rap_sfcdiff_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_flake_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_flake_debug
 Checking test 088 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.691838
-  0: The maximum resident set size (KB)                   = 909552
+  0: The total amount of wall time                        = 347.026630
+  0: The maximum resident set size (KB)                   = 905324
 
 Test 088 rap_flake_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 089 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 570.525723
-  0: The maximum resident set size (KB)                   = 905892
+  0: The total amount of wall time                        = 573.909160
+  0: The maximum resident set size (KB)                   = 906920
 
 Test 089 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rap_progcld_thompson_debug
 Checking test 090 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.606229
-  0: The maximum resident set size (KB)                   = 905776
+  0: The total amount of wall time                        = 349.598382
+  0: The maximum resident set size (KB)                   = 911060
 
 Test 090 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/rrfs_v1beta_debug
 Checking test 091 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.462510
-  0: The maximum resident set size (KB)                   = 906852
+  0: The total amount of wall time                        = 343.412854
+  0: The maximum resident set size (KB)                   = 906636
 
 Test 091 rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_wam_debug
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_wam_debug
 Checking test 092 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 365.517252
-  0: The maximum resident set size (KB)                   = 260668
+  0: The total amount of wall time                        = 368.379812
+  0: The maximum resident set size (KB)                   = 260416
 
 Test 092 control_wam_debug PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_atm
 Checking test 093 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1058.151958
-  0: The maximum resident set size (KB)                   = 803096
+  0: The total amount of wall time                        = 1111.707846
+  0: The maximum resident set size (KB)                   = 792524
 
 Test 093 hafs_regional_atm PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_atm_thompson_gfdlsf
 Checking test 094 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 1149.722170
-  0: The maximum resident set size (KB)                   = 1145192
+  0: The total amount of wall time                        = 1196.719039
+  0: The maximum resident set size (KB)                   = 1148784
 
 Test 094 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_atm_ocn
 Checking test 095 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2726,44 +2726,44 @@ Checking test 095 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 453.174536
-  0: The maximum resident set size (KB)                   = 813800
+  0: The total amount of wall time                        = 459.116442
+  0: The maximum resident set size (KB)                   = 812156
 
 Test 095 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_atm_wav
 Checking test 096 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 914.520666
-  0: The maximum resident set size (KB)                   = 819268
+  0: The total amount of wall time                        = 926.881745
+  0: The maximum resident set size (KB)                   = 816196
 
 Test 096 hafs_regional_atm_wav PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_atm_ocn_wav
 Checking test 097 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1031.739883
-  0: The maximum resident set size (KB)                   = 813272
+  0: The total amount of wall time                        = 1039.019964
+  0: The maximum resident set size (KB)                   = 815040
 
 Test 097 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_docn
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_docn
 Checking test 098 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2771,14 +2771,14 @@ Checking test 098 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 440.198005
-  0: The maximum resident set size (KB)                   = 817244
+  0: The total amount of wall time                        = 449.713637
+  0: The maximum resident set size (KB)                   = 816016
 
 Test 098 hafs_regional_docn PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_docn_oisst
 Checking test 099 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2786,105 +2786,105 @@ Checking test 099 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 438.378216
-  0: The maximum resident set size (KB)                   = 818636
+  0: The total amount of wall time                        = 454.902969
+  0: The maximum resident set size (KB)                   = 815064
 
 Test 099 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/hafs_regional_datm_cdeps
 Checking test 100 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1218.944838
-  0: The maximum resident set size (KB)                   = 858084
+  0: The total amount of wall time                        = 1223.747576
+  0: The maximum resident set size (KB)                   = 858980
 
 Test 100 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_control_cfsr
 Checking test 101 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.409926
- 0: The maximum resident set size (KB)                   = 727952
+ 0: The total amount of wall time                        = 194.591131
+ 0: The maximum resident set size (KB)                   = 726708
 
 Test 101 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_restart_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_restart_cfsr
 Checking test 102 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 116.575107
- 0: The maximum resident set size (KB)                   = 725680
+ 0: The total amount of wall time                        = 124.643522
+ 0: The maximum resident set size (KB)                   = 726784
 
 Test 102 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_control_gefs
 Checking test 103 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.162015
- 0: The maximum resident set size (KB)                   = 628464
+ 0: The total amount of wall time                        = 194.518902
+ 0: The maximum resident set size (KB)                   = 627972
 
 Test 103 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_stochy_gefs
 Checking test 104 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.115683
- 0: The maximum resident set size (KB)                   = 627708
+ 0: The total amount of wall time                        = 194.743204
+ 0: The maximum resident set size (KB)                   = 629440
 
 Test 104 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_bulk_cfsr
 Checking test 105 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.530453
- 0: The maximum resident set size (KB)                   = 726392
+ 0: The total amount of wall time                        = 199.100831
+ 0: The maximum resident set size (KB)                   = 728380
 
 Test 105 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_bulk_gefs
 Checking test 106 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.205731
- 0: The maximum resident set size (KB)                   = 625268
+ 0: The total amount of wall time                        = 192.088572
+ 0: The maximum resident set size (KB)                   = 629644
 
 Test 106 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_mx025_cfsr
 Checking test 107 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2893,14 +2893,14 @@ Checking test 107 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 416.154362
-  0: The maximum resident set size (KB)                   = 590856
+  0: The total amount of wall time                        = 433.491785
+  0: The maximum resident set size (KB)                   = 598404
 
 Test 107 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_mx025_gefs
 Checking test 108 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2909,51 +2909,51 @@ Checking test 108 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 402.960870
-  0: The maximum resident set size (KB)                   = 564612
+  0: The total amount of wall time                        = 420.168692
+  0: The maximum resident set size (KB)                   = 565864
 
 Test 108 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_multiple_files_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_multiple_files_cfsr
 Checking test 109 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.205364
- 0: The maximum resident set size (KB)                   = 727760
+ 0: The total amount of wall time                        = 204.135260
+ 0: The maximum resident set size (KB)                   = 726524
 
 Test 109 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_3072x1536_cfsr
 Checking test 110 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 267.315270
- 0: The maximum resident set size (KB)                   = 1839800
+ 0: The total amount of wall time                        = 273.002031
+ 0: The maximum resident set size (KB)                   = 1838224
 
 Test 110 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/datm_cdeps_debug_cfsr
 Checking test 111 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 569.141297
- 0: The maximum resident set size (KB)                   = 732256
+ 0: The total amount of wall time                        = 593.731002
+ 0: The maximum resident set size (KB)                   = 733028
 
 Test 111 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /lfs4/HFIP/h-nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_695/control_atmwav
+working dir  = /lfs4/HFIP/h-nems/emc.nemspara/RT_RUNDIRS/emc.nemspara/FV3_RT/rt_16735/control_atmwav
 Checking test 112 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2997,12 +2997,12 @@ Checking test 112 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 110.766014
-  0: The maximum resident set size (KB)                   = 523360
+  0: The total amount of wall time                        = 114.378404
+  0: The maximum resident set size (KB)                   = 523716
 
 Test 112 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 16 01:47:31 GMT 2022
-Elapsed time: 02h:39m:03s. Have a nice day!
+Fri Feb 18 22:45:46 GMT 2022
+Elapsed time: 02h:58m:45s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,23 +1,23 @@
-Tue Feb 15 16:32:26 CST 2022
+Fri Feb 18 13:47:00 CST 2022
 Start Regression test
 
-Compile 001 elapsed time 497 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 179 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 465 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 386 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 378 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 182 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 176 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 142 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 432 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 434 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 190 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 96 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 394 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 511 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 187 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 388 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 396 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 502 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 362 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 178 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 180 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 148 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 419 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 437 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 187 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 95 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 484 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 212.264174
-  0: The maximum resident set size (KB)                   = 643836
+  0: The total amount of wall time                        = 214.055231
+  0: The maximum resident set size (KB)                   = 644668
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 241.282786
-  0: The maximum resident set size (KB)                   = 691560
+  0: The total amount of wall time                        = 242.237849
+  0: The maximum resident set size (KB)                   = 695216
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 213.688946
-  0: The maximum resident set size (KB)                   = 642800
+  0: The total amount of wall time                        = 215.621307
+  0: The maximum resident set size (KB)                   = 641264
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_mpi_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 185.519115
-  0: The maximum resident set size (KB)                   = 649044
+  0: The total amount of wall time                        = 187.030801
+  0: The maximum resident set size (KB)                   = 652940
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_p7_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 248.012750
-  0: The maximum resident set size (KB)                   = 743184
+  0: The total amount of wall time                        = 249.826706
+  0: The maximum resident set size (KB)                   = 741772
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_p7
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 889.749692
-  0: The maximum resident set size (KB)                   = 1470324
+  0: The total amount of wall time                        = 887.302651
+  0: The maximum resident set size (KB)                   = 1467736
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 883.328460
-  0: The maximum resident set size (KB)                   = 1468240
+  0: The total amount of wall time                        = 882.246021
+  0: The maximum resident set size (KB)                   = 1467924
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_bmark_mpi_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 861.184317
-  0: The maximum resident set size (KB)                   = 1487304
+  0: The total amount of wall time                        = 862.804458
+  0: The maximum resident set size (KB)                   = 1488880
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 204.140277
-  0: The maximum resident set size (KB)                   = 633092
+  0: The total amount of wall time                        = 204.041587
+  0: The maximum resident set size (KB)                   = 632960
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c96_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 114.237328
-  0: The maximum resident set size (KB)                   = 392420
+  0: The total amount of wall time                        = 114.105938
+  0: The maximum resident set size (KB)                   = 391552
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 856.173169
-  0: The maximum resident set size (KB)                   = 847996
+  0: The total amount of wall time                        = 854.377318
+  0: The maximum resident set size (KB)                   = 848556
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c192_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 589.561757
-  0: The maximum resident set size (KB)                   = 914756
+  0: The total amount of wall time                        = 594.148998
+  0: The maximum resident set size (KB)                   = 912676
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1018.116829
-  0: The maximum resident set size (KB)                   = 1435776
+  0: The total amount of wall time                        = 1020.087661
+  0: The maximum resident set size (KB)                   = 1436032
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_restart_c384_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 551.328401
-  0: The maximum resident set size (KB)                   = 1396276
+  0: The total amount of wall time                        = 547.905851
+  0: The maximum resident set size (KB)                   = 1395196
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/cpld_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 632.984667
-  0: The maximum resident set size (KB)                   = 686276
+  0: The total amount of wall time                        = 643.014478
+  0: The maximum resident set size (KB)                   = 687288
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.588474
-  0: The maximum resident set size (KB)                   = 483092
+  0: The total amount of wall time                        = 119.713278
+  0: The maximum resident set size (KB)                   = 483976
 
 Test 016 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_decomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.810705
-  0: The maximum resident set size (KB)                   = 485596
+  0: The total amount of wall time                        = 127.698812
+  0: The maximum resident set size (KB)                   = 482888
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.529986
-  0: The maximum resident set size (KB)                   = 484980
+  0: The total amount of wall time                        = 115.208067
+  0: The maximum resident set size (KB)                   = 485284
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 146.204093
- 0: The maximum resident set size (KB)                   = 534052
+ 0: The total amount of wall time                        = 142.770538
+ 0: The maximum resident set size (KB)                   = 531280
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 65.856529
-  0: The maximum resident set size (KB)                   = 225480
+  0: The total amount of wall time                        = 66.413278
+  0: The maximum resident set size (KB)                   = 226392
 
 Test 020 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_fhzero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.902153
-  0: The maximum resident set size (KB)                   = 484240
+  0: The total amount of wall time                        = 114.257992
+  0: The maximum resident set size (KB)                   = 483880
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.975733
-  0: The maximum resident set size (KB)                   = 484220
+  0: The total amount of wall time                        = 116.876644
+  0: The maximum resident set size (KB)                   = 480892
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_latlon
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 119.713612
-  0: The maximum resident set size (KB)                   = 485952
+  0: The total amount of wall time                        = 120.486142
+  0: The maximum resident set size (KB)                   = 485272
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.837351
-  0: The maximum resident set size (KB)                   = 483588
+  0: The total amount of wall time                        = 122.901514
+  0: The maximum resident set size (KB)                   = 483376
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c48
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 305.045168
-0: The maximum resident set size (KB)                   = 653552
+0: The total amount of wall time                        = 304.858885
+0: The maximum resident set size (KB)                   = 652880
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 459.408769
-  0: The maximum resident set size (KB)                   = 584544
+  0: The total amount of wall time                        = 462.233647
+  0: The maximum resident set size (KB)                   = 584776
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 776.299041
-  0: The maximum resident set size (KB)                   = 883464
+  0: The total amount of wall time                        = 768.205610
+  0: The maximum resident set size (KB)                   = 881048
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384gdas
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 660.451381
-  0: The maximum resident set size (KB)                   = 1001060
+  0: The total amount of wall time                        = 660.135389
+  0: The maximum resident set size (KB)                   = 978008
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 79.113992
-  0: The maximum resident set size (KB)                   = 481768
+  0: The total amount of wall time                        = 78.871003
+  0: The maximum resident set size (KB)                   = 479912
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.478994
-  0: The maximum resident set size (KB)                   = 264360
+  0: The total amount of wall time                        = 45.051541
+  0: The maximum resident set size (KB)                   = 263016
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_lndp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.627672
-  0: The maximum resident set size (KB)                   = 489164
+  0: The total amount of wall time                        = 72.534107
+  0: The maximum resident set size (KB)                   = 486900
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_iovr4
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 120.694138
-  0: The maximum resident set size (KB)                   = 481792
+  0: The total amount of wall time                        = 120.698284
+  0: The maximum resident set size (KB)                   = 483456
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_iovr5
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.040798
-  0: The maximum resident set size (KB)                   = 484260
+  0: The total amount of wall time                        = 120.801545
+  0: The maximum resident set size (KB)                   = 485136
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.838752
-  0: The maximum resident set size (KB)                   = 505784
+  0: The total amount of wall time                        = 136.167380
+  0: The maximum resident set size (KB)                   = 509356
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_restart_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 74.940431
-  0: The maximum resident set size (KB)                   = 295656
+  0: The total amount of wall time                        = 74.930810
+  0: The maximum resident set size (KB)                   = 293544
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_decomp_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.519225
-  0: The maximum resident set size (KB)                   = 505500
+  0: The total amount of wall time                        = 142.555300
+  0: The maximum resident set size (KB)                   = 507216
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 165.821777
- 0: The maximum resident set size (KB)                   = 577292
+ 0: The total amount of wall time                        = 164.364266
+ 0: The maximum resident set size (KB)                   = 580072
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_p7_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.144966
-  0: The maximum resident set size (KB)                   = 609228
+  0: The total amount of wall time                        = 171.775896
+  0: The maximum resident set size (KB)                   = 606660
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 295.827230
- 0: The maximum resident set size (KB)                   = 584848
+ 0: The total amount of wall time                        = 295.401271
+ 0: The maximum resident set size (KB)                   = 589756
 
 Test 039 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 168.041594
- 0: The maximum resident set size (KB)                   = 585712
+ 0: The total amount of wall time                        = 168.778834
+ 0: The maximum resident set size (KB)                   = 588424
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_control_2dwrtdecomp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 293.582344
- 0: The maximum resident set size (KB)                   = 588296
+ 0: The total amount of wall time                        = 293.539760
+ 0: The maximum resident set size (KB)                   = 588016
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_noquilt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 300.092311
- 0: The maximum resident set size (KB)                   = 600816
+ 0: The total amount of wall time                        = 303.794019
+ 0: The maximum resident set size (KB)                   = 614464
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 212.765525
- 0: The maximum resident set size (KB)                   = 596600
+ 0: The total amount of wall time                        = 212.850653
+ 0: The maximum resident set size (KB)                   = 601884
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_hafs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 294.152437
- 0: The maximum resident set size (KB)                   = 589072
+ 0: The total amount of wall time                        = 294.189400
+ 0: The maximum resident set size (KB)                   = 592492
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 295.838616
- 0: The maximum resident set size (KB)                   = 588412
+ 0: The total amount of wall time                        = 294.757975
+ 0: The maximum resident set size (KB)                   = 585308
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_RRTMGP
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 372.666116
- 0: The maximum resident set size (KB)                   = 711412
+ 0: The total amount of wall time                        = 371.683816
+ 0: The maximum resident set size (KB)                   = 709948
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.737976
-  0: The maximum resident set size (KB)                   = 852068
+  0: The total amount of wall time                        = 340.598602
+  0: The maximum resident set size (KB)                   = 848692
 
 Test 047 rap_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_2threads
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 414.899143
- 0: The maximum resident set size (KB)                   = 912884
+ 0: The total amount of wall time                        = 411.230179
+ 0: The maximum resident set size (KB)                   = 915716
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.948777
-  0: The maximum resident set size (KB)                   = 602408
+  0: The total amount of wall time                        = 175.531968
+  0: The maximum resident set size (KB)                   = 605660
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 337.949056
-  0: The maximum resident set size (KB)                   = 851744
+  0: The total amount of wall time                        = 338.077333
+  0: The maximum resident set size (KB)                   = 848684
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff_restart
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.643253
-  0: The maximum resident set size (KB)                   = 604520
+  0: The total amount of wall time                        = 175.154037
+  0: The maximum resident set size (KB)                   = 604596
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hrrr_control
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 327.888047
-  0: The maximum resident set size (KB)                   = 850168
+  0: The total amount of wall time                        = 328.973300
+  0: The maximum resident set size (KB)                   = 849168
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_v1beta
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 334.530115
-  0: The maximum resident set size (KB)                   = 848360
+  0: The total amount of wall time                        = 336.336345
+  0: The maximum resident set size (KB)                   = 846068
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 165.208605
-  0: The maximum resident set size (KB)                   = 716388
+  0: The total amount of wall time                        = 164.509712
+  0: The maximum resident set size (KB)                   = 710820
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 162.555459
-  0: The maximum resident set size (KB)                   = 714200
+  0: The total amount of wall time                        = 164.693920
+  0: The maximum resident set size (KB)                   = 718804
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.869453
-  0: The maximum resident set size (KB)                   = 604292
+  0: The total amount of wall time                        = 185.359483
+  0: The maximum resident set size (KB)                   = 602008
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp_c192
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 503.546430
-  0: The maximum resident set size (KB)                   = 806864
+  0: The total amount of wall time                        = 502.637607
+  0: The maximum resident set size (KB)                   = 804548
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmg
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 304.763176
-  0: The maximum resident set size (KB)                   = 543472
+  0: The total amount of wall time                        = 304.049025
+  0: The maximum resident set size (KB)                   = 543232
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmgt
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 300.924151
-  0: The maximum resident set size (KB)                   = 543164
+  0: The total amount of wall time                        = 301.843002
+  0: The maximum resident set size (KB)                   = 542528
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_flake
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.213298
-  0: The maximum resident set size (KB)                   = 556860
+  0: The total amount of wall time                        = 213.987616
+  0: The maximum resident set size (KB)                   = 555628
 
 Test 060 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_ras
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.183978
-  0: The maximum resident set size (KB)                   = 514240
+  0: The total amount of wall time                        = 164.429567
+  0: The maximum resident set size (KB)                   = 512172
 
 Test 061 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 206.098830
-  0: The maximum resident set size (KB)                   = 865864
+  0: The total amount of wall time                        = 206.089440
+  0: The maximum resident set size (KB)                   = 870596
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_no_aero
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.521702
-  0: The maximum resident set size (KB)                   = 859528
+  0: The total amount of wall time                        = 196.836718
+  0: The maximum resident set size (KB)                   = 833856
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wam_repro
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 111.314381
-  0: The maximum resident set size (KB)                   = 247612
+  0: The total amount of wall time                        = 110.732313
+  0: The maximum resident set size (KB)                   = 247224
 
 Test 064 control_wam PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.032266
-  0: The maximum resident set size (KB)                   = 542852
+  0: The total amount of wall time                        = 152.561521
+  0: The maximum resident set size (KB)                   = 541724
 
 Test 065 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_2threads_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 226.919576
- 0: The maximum resident set size (KB)                   = 587192
+ 0: The total amount of wall time                        = 230.950721
+ 0: The maximum resident set size (KB)                   = 568100
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2428,428 +2428,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.352132
-  0: The maximum resident set size (KB)                   = 542428
+  0: The total amount of wall time                        = 164.528757
+  0: The maximum resident set size (KB)                   = 542392
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.798926
-  0: The maximum resident set size (KB)                   = 540384
+  0: The total amount of wall time                        = 157.497322
+  0: The maximum resident set size (KB)                   = 545720
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_stochy_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.285929
-  0: The maximum resident set size (KB)                   = 545096
+  0: The total amount of wall time                        = 172.133928
+  0: The maximum resident set size (KB)                   = 544620
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.431775
-  0: The maximum resident set size (KB)                   = 554640
+  0: The total amount of wall time                        = 153.056028
+  0: The maximum resident set size (KB)                   = 556900
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.193199
-  0: The maximum resident set size (KB)                   = 638636
+  0: The total amount of wall time                        = 170.800250
+  0: The maximum resident set size (KB)                   = 636292
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmg_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 237.676619
-  0: The maximum resident set size (KB)                   = 576188
+  0: The total amount of wall time                        = 237.667896
+  0: The maximum resident set size (KB)                   = 577828
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_csawmgt_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.426301
-  0: The maximum resident set size (KB)                   = 574144
+  0: The total amount of wall time                        = 236.068539
+  0: The maximum resident set size (KB)                   = 577944
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_ras_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.517146
-  0: The maximum resident set size (KB)                   = 553728
+  0: The total amount of wall time                        = 158.000436
+  0: The maximum resident set size (KB)                   = 557884
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.008977
-  0: The maximum resident set size (KB)                   = 599508
+  0: The total amount of wall time                        = 162.126697
+  0: The maximum resident set size (KB)                   = 602684
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_debug_p8
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.367794
-  0: The maximum resident set size (KB)                   = 567156
+  0: The total amount of wall time                        = 163.723793
+  0: The maximum resident set size (KB)                   = 571372
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 180.977053
-  0: The maximum resident set size (KB)                   = 907160
+  0: The total amount of wall time                        = 176.526502
+  0: The maximum resident set size (KB)                   = 903932
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.291407
-  0: The maximum resident set size (KB)                   = 899352
+  0: The total amount of wall time                        = 176.970525
+  0: The maximum resident set size (KB)                   = 899980
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.051630
-  0: The maximum resident set size (KB)                   = 936928
+  0: The total amount of wall time                        = 187.290345
+  0: The maximum resident set size (KB)                   = 935592
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 177.460747
-  0: The maximum resident set size (KB)                   = 906540
+  0: The total amount of wall time                        = 181.569820
+  0: The maximum resident set size (KB)                   = 903208
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/regional_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 250.671408
- 0: The maximum resident set size (KB)                   = 616508
+ 0: The total amount of wall time                        = 249.198107
+ 0: The maximum resident set size (KB)                   = 617384
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_control_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.523298
-  0: The maximum resident set size (KB)                   = 909940
+  0: The total amount of wall time                        = 269.314784
+  0: The maximum resident set size (KB)                   = 910008
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_unified_drag_suite_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.819758
-  0: The maximum resident set size (KB)                   = 908784
+  0: The total amount of wall time                        = 275.018056
+  0: The maximum resident set size (KB)                   = 910860
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_diag_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.469690
-  0: The maximum resident set size (KB)                   = 1005772
+  0: The total amount of wall time                        = 289.475087
+  0: The maximum resident set size (KB)                   = 1008600
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.375296
-  0: The maximum resident set size (KB)                   = 915404
+  0: The total amount of wall time                        = 275.953293
+  0: The maximum resident set size (KB)                   = 918028
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_unified_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.582644
-  0: The maximum resident set size (KB)                   = 913020
+  0: The total amount of wall time                        = 275.561331
+  0: The maximum resident set size (KB)                   = 908700
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_noah_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.940835
-  0: The maximum resident set size (KB)                   = 912144
+  0: The total amount of wall time                        = 275.635994
+  0: The maximum resident set size (KB)                   = 909764
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 462.431713
-  0: The maximum resident set size (KB)                   = 1011368
+  0: The total amount of wall time                        = 460.846305
+  0: The maximum resident set size (KB)                   = 1011112
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_lndp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.029144
-  0: The maximum resident set size (KB)                   = 910320
+  0: The total amount of wall time                        = 273.752836
+  0: The maximum resident set size (KB)                   = 908608
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.919260
-  0: The maximum resident set size (KB)                   = 908780
+  0: The total amount of wall time                        = 279.773574
+  0: The maximum resident set size (KB)                   = 909024
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_flake_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.865092
-  0: The maximum resident set size (KB)                   = 908400
+  0: The total amount of wall time                        = 271.271163
+  0: The maximum resident set size (KB)                   = 909096
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 457.893596
-  0: The maximum resident set size (KB)                   = 908316
+  0: The total amount of wall time                        = 458.603522
+  0: The maximum resident set size (KB)                   = 910072
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.580671
-  0: The maximum resident set size (KB)                   = 913300
+  0: The total amount of wall time                        = 274.397191
+  0: The maximum resident set size (KB)                   = 907328
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.407976
-  0: The maximum resident set size (KB)                   = 907160
+  0: The total amount of wall time                        = 271.618972
+  0: The maximum resident set size (KB)                   = 905132
 
 Test 094 rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_wam_debug
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 289.820278
-  0: The maximum resident set size (KB)                   = 272164
+  0: The total amount of wall time                        = 297.960505
+  0: The maximum resident set size (KB)                   = 272856
 
 Test 095 control_wam_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 245.595453
-  0: The maximum resident set size (KB)                   = 848056
+  0: The total amount of wall time                        = 251.720165
+  0: The maximum resident set size (KB)                   = 851668
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 301.718889
-  0: The maximum resident set size (KB)                   = 1204896
+  0: The total amount of wall time                        = 300.441300
+  0: The maximum resident set size (KB)                   = 1200788
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2858,28 +2858,28 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 353.582163
-  0: The maximum resident set size (KB)                   = 887228
+  0: The total amount of wall time                        = 354.122258
+  0: The maximum resident set size (KB)                   = 889256
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 759.818307
-  0: The maximum resident set size (KB)                   = 885204
+  0: The total amount of wall time                        = 763.265296
+  0: The maximum resident set size (KB)                   = 864868
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2888,28 +2888,28 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 859.827896
-  0: The maximum resident set size (KB)                   = 888988
+  0: The total amount of wall time                        = 852.434393
+  0: The maximum resident set size (KB)                   = 862952
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 1256.953938
-  0: The maximum resident set size (KB)                   = 387436
+  0: The total amount of wall time                        = 1263.602224
+  0: The maximum resident set size (KB)                   = 387188
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2918,28 +2918,28 @@ Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 411.686998
-  0: The maximum resident set size (KB)                   = 428076
+  0: The total amount of wall time                        = 410.691663
+  0: The maximum resident set size (KB)                   = 433124
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 185.255104
-  0: The maximum resident set size (KB)                   = 273352
+  0: The total amount of wall time                        = 184.447765
+  0: The maximum resident set size (KB)                   = 273236
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2952,14 +2952,14 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 521.599350
-  0: The maximum resident set size (KB)                   = 458652
+  0: The total amount of wall time                        = 519.232216
+  0: The maximum resident set size (KB)                   = 458484
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_docn
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2967,14 +2967,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 331.057996
-  0: The maximum resident set size (KB)                   = 886496
+  0: The total amount of wall time                        = 334.634598
+  0: The maximum resident set size (KB)                   = 888892
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2982,105 +2982,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 334.912796
-  0: The maximum resident set size (KB)                   = 889916
+  0: The total amount of wall time                        = 335.016386
+  0: The maximum resident set size (KB)                   = 889288
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 918.198700
-  0: The maximum resident set size (KB)                   = 870028
+  0: The total amount of wall time                        = 920.559212
+  0: The maximum resident set size (KB)                   = 866300
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.516470
- 0: The maximum resident set size (KB)                   = 720788
+ 0: The total amount of wall time                        = 144.117291
+ 0: The maximum resident set size (KB)                   = 720772
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 96.632069
- 0: The maximum resident set size (KB)                   = 718324
+ 0: The total amount of wall time                        = 100.094114
+ 0: The maximum resident set size (KB)                   = 724540
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.722042
- 0: The maximum resident set size (KB)                   = 621300
+ 0: The total amount of wall time                        = 141.548594
+ 0: The maximum resident set size (KB)                   = 622052
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.435816
- 0: The maximum resident set size (KB)                   = 621608
+ 0: The total amount of wall time                        = 144.317288
+ 0: The maximum resident set size (KB)                   = 622496
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.020927
- 0: The maximum resident set size (KB)                   = 720656
+ 0: The total amount of wall time                        = 145.018430
+ 0: The maximum resident set size (KB)                   = 718104
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.961868
- 0: The maximum resident set size (KB)                   = 623804
+ 0: The total amount of wall time                        = 142.297100
+ 0: The maximum resident set size (KB)                   = 623268
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3089,14 +3089,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 297.323710
-  0: The maximum resident set size (KB)                   = 638900
+  0: The total amount of wall time                        = 299.845520
+  0: The maximum resident set size (KB)                   = 634032
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3105,51 +3105,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 294.142747
-  0: The maximum resident set size (KB)                   = 594440
+  0: The total amount of wall time                        = 299.395191
+  0: The maximum resident set size (KB)                   = 596532
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.982771
- 0: The maximum resident set size (KB)                   = 720980
+ 0: The total amount of wall time                        = 142.817306
+ 0: The maximum resident set size (KB)                   = 724060
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 185.144586
- 0: The maximum resident set size (KB)                   = 1831440
+ 0: The total amount of wall time                        = 186.394859
+ 0: The maximum resident set size (KB)                   = 1833476
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 434.471459
- 0: The maximum resident set size (KB)                   = 723444
+ 0: The total amount of wall time                        = 441.445709
+ 0: The maximum resident set size (KB)                   = 722896
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_atmwav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3193,14 +3193,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 80.329841
-  0: The maximum resident set size (KB)                   = 568300
+  0: The total amount of wall time                        = 81.609428
+  0: The maximum resident set size (KB)                   = 565736
 
 Test 119 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_101450/control_c384gdas_wav
+working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_308557/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3246,12 +3246,12 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 663.983848
-  0: The maximum resident set size (KB)                   = 1209932
+  0: The total amount of wall time                        = 667.592167
+  0: The maximum resident set size (KB)                   = 1209332
 
 Test 120 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Feb 15 17:48:03 CST 2022
-Elapsed time: 01h:15m:38s. Have a nice day!
+Fri Feb 18 14:55:56 CST 2022
+Elapsed time: 01h:08m:57s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,23 +1,23 @@
-Wed Feb  9 18:46:36 CST 2022
+Sun Feb 13 20:53:37 CST 2022
 Start Regression test
 
-Compile 001 elapsed time 474 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 194 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 396 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 382 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 462 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 358 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 188 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 175 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 166 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 446 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 411 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 189 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 122 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 409 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 614 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 206 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 466 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 462 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 593 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 220 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 219 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 492 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 511 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 252 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 141 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 465 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_control_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 223.053048
-  0: The maximum resident set size (KB)                   = 645536
+  0: The total amount of wall time                        = 216.193402
+  0: The maximum resident set size (KB)                   = 644164
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_2threads_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 278.009135
-  0: The maximum resident set size (KB)                   = 691416
+  0: The total amount of wall time                        = 301.944807
+  0: The maximum resident set size (KB)                   = 692664
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_decomp_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 247.871680
-  0: The maximum resident set size (KB)                   = 640784
+  0: The total amount of wall time                        = 215.832600
+  0: The maximum resident set size (KB)                   = 639008
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_mpi_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 208.892283
-  0: The maximum resident set size (KB)                   = 655168
+  0: The total amount of wall time                        = 186.574180
+  0: The maximum resident set size (KB)                   = 652808
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_control_p7_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 276.435437
-  0: The maximum resident set size (KB)                   = 740212
+  0: The total amount of wall time                        = 247.684815
+  0: The maximum resident set size (KB)                   = 742060
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_bmark_p7
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 889.301406
-  0: The maximum resident set size (KB)                   = 1473464
+  0: The total amount of wall time                        = 913.649880
+  0: The maximum resident set size (KB)                   = 1494280
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_bmark_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 890.434624
-  0: The maximum resident set size (KB)                   = 1470452
+  0: The total amount of wall time                        = 928.977263
+  0: The maximum resident set size (KB)                   = 1471508
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_bmark_mpi_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 865.131694
-  0: The maximum resident set size (KB)                   = 1506980
+  0: The total amount of wall time                        = 882.104623
+  0: The maximum resident set size (KB)                   = 1487004
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 237.235565
-  0: The maximum resident set size (KB)                   = 630672
+  0: The total amount of wall time                        = 205.444606
+  0: The maximum resident set size (KB)                   = 629576
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_restart_c96_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 113.926478
-  0: The maximum resident set size (KB)                   = 392688
+  0: The total amount of wall time                        = 137.832971
+  0: The maximum resident set size (KB)                   = 391076
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 884.675423
-  0: The maximum resident set size (KB)                   = 845532
+  0: The total amount of wall time                        = 878.487928
+  0: The maximum resident set size (KB)                   = 843728
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_restart_c192_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 610.057280
-  0: The maximum resident set size (KB)                   = 913080
+  0: The total amount of wall time                        = 594.648261
+  0: The maximum resident set size (KB)                   = 915200
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1047.277856
-  0: The maximum resident set size (KB)                   = 1444360
+  0: The total amount of wall time                        = 1025.793054
+  0: The maximum resident set size (KB)                   = 1435696
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_restart_c384_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 560.696710
-  0: The maximum resident set size (KB)                   = 1398812
+  0: The total amount of wall time                        = 550.226038
+  0: The maximum resident set size (KB)                   = 1398984
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/cpld_debug_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 637.748379
-  0: The maximum resident set size (KB)                   = 685040
+  0: The total amount of wall time                        = 624.892826
+  0: The maximum resident set size (KB)                   = 689644
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.828299
-  0: The maximum resident set size (KB)                   = 488208
+  0: The total amount of wall time                        = 120.216003
+  0: The maximum resident set size (KB)                   = 484224
 
 Test 016 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_decomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.276571
-  0: The maximum resident set size (KB)                   = 484256
+  0: The total amount of wall time                        = 127.307003
+  0: The maximum resident set size (KB)                   = 488540
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_2dwrtdecomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.345028
-  0: The maximum resident set size (KB)                   = 486312
+  0: The total amount of wall time                        = 114.709920
+  0: The maximum resident set size (KB)                   = 488476
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 145.636193
- 0: The maximum resident set size (KB)                   = 531468
+ 0: The total amount of wall time                        = 183.595308
+ 0: The maximum resident set size (KB)                   = 536604
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 66.550875
-  0: The maximum resident set size (KB)                   = 227596
+  0: The total amount of wall time                        = 65.765257
+  0: The maximum resident set size (KB)                   = 224784
 
 Test 020 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_fhzero
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.276665
-  0: The maximum resident set size (KB)                   = 487444
+  0: The total amount of wall time                        = 113.142237
+  0: The maximum resident set size (KB)                   = 484488
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.654283
-  0: The maximum resident set size (KB)                   = 487176
+  0: The total amount of wall time                        = 116.457411
+  0: The maximum resident set size (KB)                   = 484196
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_latlon
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 149.618101
-  0: The maximum resident set size (KB)                   = 487368
+  0: The total amount of wall time                        = 118.079110
+  0: The maximum resident set size (KB)                   = 487696
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 153.009495
-  0: The maximum resident set size (KB)                   = 487148
+  0: The total amount of wall time                        = 120.816194
+  0: The maximum resident set size (KB)                   = 485732
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_c48
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 305.071086
-0: The maximum resident set size (KB)                   = 654508
+0: The total amount of wall time                        = 351.006205
+0: The maximum resident set size (KB)                   = 653208
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_c192
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 484.522227
-  0: The maximum resident set size (KB)                   = 588292
+  0: The total amount of wall time                        = 485.828657
+  0: The maximum resident set size (KB)                   = 587948
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_c384
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 797.197960
-  0: The maximum resident set size (KB)                   = 876836
+  0: The total amount of wall time                        = 932.107903
+  0: The maximum resident set size (KB)                   = 881516
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_c384gdas
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 688.566435
-  0: The maximum resident set size (KB)                   = 1000120
+  0: The total amount of wall time                        = 795.349561
+  0: The maximum resident set size (KB)                   = 997960
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_stochy
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 78.593703
-  0: The maximum resident set size (KB)                   = 486308
+  0: The total amount of wall time                        = 79.156864
+  0: The maximum resident set size (KB)                   = 486008
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_stochy_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 46.634899
-  0: The maximum resident set size (KB)                   = 264668
+  0: The total amount of wall time                        = 44.910393
+  0: The maximum resident set size (KB)                   = 267700
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_lndp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.595574
-  0: The maximum resident set size (KB)                   = 488432
+  0: The total amount of wall time                        = 73.069541
+  0: The maximum resident set size (KB)                   = 490344
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_iovr4
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 122.819309
-  0: The maximum resident set size (KB)                   = 487932
+  0: The total amount of wall time                        = 122.011542
+  0: The maximum resident set size (KB)                   = 486100
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_iovr5
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 122.029018
-  0: The maximum resident set size (KB)                   = 484136
+  0: The total amount of wall time                        = 119.994300
+  0: The maximum resident set size (KB)                   = 486036
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 135.809928
-  0: The maximum resident set size (KB)                   = 507584
+  0: The total amount of wall time                        = 167.518386
+  0: The maximum resident set size (KB)                   = 509216
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_restart_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 75.286323
-  0: The maximum resident set size (KB)                   = 290532
+  0: The total amount of wall time                        = 77.125549
+  0: The maximum resident set size (KB)                   = 295280
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_decomp_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.514007
-  0: The maximum resident set size (KB)                   = 506092
+  0: The total amount of wall time                        = 161.199660
+  0: The maximum resident set size (KB)                   = 507852
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_2threads_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 163.212629
- 0: The maximum resident set size (KB)                   = 575608
+ 0: The total amount of wall time                        = 244.524234
+ 0: The maximum resident set size (KB)                   = 580272
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_p7_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.934449
-  0: The maximum resident set size (KB)                   = 610740
+  0: The total amount of wall time                        = 195.753779
+  0: The maximum resident set size (KB)                   = 610964
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 296.859347
- 0: The maximum resident set size (KB)                   = 591380
+ 0: The total amount of wall time                        = 316.435167
+ 0: The maximum resident set size (KB)                   = 592092
 
 Test 039 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 170.092329
- 0: The maximum resident set size (KB)                   = 590516
+ 0: The total amount of wall time                        = 163.246730
+ 0: The maximum resident set size (KB)                   = 590328
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_control_2dwrtdecomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 294.095548
- 0: The maximum resident set size (KB)                   = 587552
+ 0: The total amount of wall time                        = 322.831053
+ 0: The maximum resident set size (KB)                   = 589164
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_noquilt
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 298.687076
- 0: The maximum resident set size (KB)                   = 599856
+ 0: The total amount of wall time                        = 312.198143
+ 0: The maximum resident set size (KB)                   = 601108
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 211.950721
- 0: The maximum resident set size (KB)                   = 595308
+ 0: The total amount of wall time                        = 298.093366
+ 0: The maximum resident set size (KB)                   = 605080
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_hafs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 295.058457
- 0: The maximum resident set size (KB)                   = 591776
+ 0: The total amount of wall time                        = 317.634914
+ 0: The maximum resident set size (KB)                   = 589696
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 294.984258
- 0: The maximum resident set size (KB)                   = 585384
+ 0: The total amount of wall time                        = 303.358879
+ 0: The maximum resident set size (KB)                   = 585224
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_RRTMGP
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 372.144460
- 0: The maximum resident set size (KB)                   = 715068
+ 0: The total amount of wall time                        = 374.269252
+ 0: The maximum resident set size (KB)                   = 711572
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.583138
-  0: The maximum resident set size (KB)                   = 851420
+  0: The total amount of wall time                        = 339.483841
+  0: The maximum resident set size (KB)                   = 850968
 
 Test 047 rap_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 422.446028
- 0: The maximum resident set size (KB)                   = 915072
+ 0: The total amount of wall time                        = 514.662306
+ 0: The maximum resident set size (KB)                   = 908604
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1970,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.342478
-  0: The maximum resident set size (KB)                   = 605900
+  0: The total amount of wall time                        = 174.918171
+  0: The maximum resident set size (KB)                   = 606636
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_sfcdiff
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 339.005957
-  0: The maximum resident set size (KB)                   = 854536
+  0: The total amount of wall time                        = 339.614673
+  0: The maximum resident set size (KB)                   = 854912
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_sfcdiff_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2070,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.977718
-  0: The maximum resident set size (KB)                   = 606464
+  0: The total amount of wall time                        = 176.601885
+  0: The maximum resident set size (KB)                   = 609060
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hrrr_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 328.443479
-  0: The maximum resident set size (KB)                   = 851312
+  0: The total amount of wall time                        = 327.397345
+  0: The maximum resident set size (KB)                   = 853816
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rrfs_v1beta
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2178,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 335.060765
-  0: The maximum resident set size (KB)                   = 849752
+  0: The total amount of wall time                        = 336.816503
+  0: The maximum resident set size (KB)                   = 848328
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2194,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 163.297347
-  0: The maximum resident set size (KB)                   = 714296
+  0: The total amount of wall time                        = 149.030307
+  0: The maximum resident set size (KB)                   = 712288
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2210,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 161.993236
-  0: The maximum resident set size (KB)                   = 717024
+  0: The total amount of wall time                        = 150.505040
+  0: The maximum resident set size (KB)                   = 715832
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.092905
-  0: The maximum resident set size (KB)                   = 604216
+  0: The total amount of wall time                        = 184.313218
+  0: The maximum resident set size (KB)                   = 605032
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_rrtmgp_c192
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 531.859113
-  0: The maximum resident set size (KB)                   = 806924
+  0: The total amount of wall time                        = 502.645274
+  0: The maximum resident set size (KB)                   = 806452
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_csawmg
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 305.594203
-  0: The maximum resident set size (KB)                   = 545116
+  0: The total amount of wall time                        = 305.705741
+  0: The maximum resident set size (KB)                   = 545300
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_csawmgt
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 318.747433
-  0: The maximum resident set size (KB)                   = 541388
+  0: The total amount of wall time                        = 303.506389
+  0: The maximum resident set size (KB)                   = 543144
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_flake
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.887396
-  0: The maximum resident set size (KB)                   = 558420
+  0: The total amount of wall time                        = 216.398335
+  0: The maximum resident set size (KB)                   = 557772
 
 Test 060 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_ras
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.294088
-  0: The maximum resident set size (KB)                   = 513908
+  0: The total amount of wall time                        = 164.694793
+  0: The maximum resident set size (KB)                   = 515508
 
 Test 061 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 226.882878
-  0: The maximum resident set size (KB)                   = 871088
+  0: The total amount of wall time                        = 208.286907
+  0: The maximum resident set size (KB)                   = 871440
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson_no_aero
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.886101
-  0: The maximum resident set size (KB)                   = 863944
+  0: The total amount of wall time                        = 197.394736
+  0: The maximum resident set size (KB)                   = 868288
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wam_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_wam_repro
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 111.137634
-  0: The maximum resident set size (KB)                   = 249764
+  0: The total amount of wall time                        = 112.396473
+  0: The maximum resident set size (KB)                   = 248976
 
 Test 064 control_wam PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.069423
-  0: The maximum resident set size (KB)                   = 543704
+  0: The total amount of wall time                        = 152.638420
+  0: The maximum resident set size (KB)                   = 546588
 
 Test 065 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_2threads_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 230.975604
- 0: The maximum resident set size (KB)                   = 589088
+ 0: The total amount of wall time                        = 274.102130
+ 0: The maximum resident set size (KB)                   = 594864
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2428,428 +2428,428 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 165.545095
-  0: The maximum resident set size (KB)                   = 549368
+  0: The total amount of wall time                        = 163.045151
+  0: The maximum resident set size (KB)                   = 543676
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.966476
-  0: The maximum resident set size (KB)                   = 547472
+  0: The total amount of wall time                        = 152.494896
+  0: The maximum resident set size (KB)                   = 547820
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_stochy_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.355298
-  0: The maximum resident set size (KB)                   = 551540
+  0: The total amount of wall time                        = 172.135286
+  0: The maximum resident set size (KB)                   = 548912
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_lndp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.745111
-  0: The maximum resident set size (KB)                   = 557244
+  0: The total amount of wall time                        = 156.219563
+  0: The maximum resident set size (KB)                   = 558996
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.120928
-  0: The maximum resident set size (KB)                   = 644224
+  0: The total amount of wall time                        = 165.130155
+  0: The maximum resident set size (KB)                   = 640720
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_csawmg_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 255.571095
-  0: The maximum resident set size (KB)                   = 582264
+  0: The total amount of wall time                        = 238.257564
+  0: The maximum resident set size (KB)                   = 581720
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_csawmgt_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 244.204382
-  0: The maximum resident set size (KB)                   = 580808
+  0: The total amount of wall time                        = 232.539784
+  0: The maximum resident set size (KB)                   = 578448
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_ras_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.013019
-  0: The maximum resident set size (KB)                   = 558680
+  0: The total amount of wall time                        = 157.294120
+  0: The maximum resident set size (KB)                   = 556924
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_diag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.933394
-  0: The maximum resident set size (KB)                   = 605032
+  0: The total amount of wall time                        = 161.211745
+  0: The maximum resident set size (KB)                   = 597908
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_debug_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.399665
-  0: The maximum resident set size (KB)                   = 576076
+  0: The total amount of wall time                        = 163.959797
+  0: The maximum resident set size (KB)                   = 573700
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 185.111240
-  0: The maximum resident set size (KB)                   = 912244
+  0: The total amount of wall time                        = 179.621011
+  0: The maximum resident set size (KB)                   = 904120
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.380240
-  0: The maximum resident set size (KB)                   = 901864
+  0: The total amount of wall time                        = 172.909478
+  0: The maximum resident set size (KB)                   = 904424
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.470547
-  0: The maximum resident set size (KB)                   = 950372
+  0: The total amount of wall time                        = 184.132391
+  0: The maximum resident set size (KB)                   = 945956
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 183.419450
-  0: The maximum resident set size (KB)                   = 907372
+  0: The total amount of wall time                        = 179.041738
+  0: The maximum resident set size (KB)                   = 903804
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/regional_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 320.501524
- 0: The maximum resident set size (KB)                   = 614408
+ 0: The total amount of wall time                        = 248.666270
+ 0: The maximum resident set size (KB)                   = 613740
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_control_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.944487
-  0: The maximum resident set size (KB)                   = 912228
+  0: The total amount of wall time                        = 273.433216
+  0: The maximum resident set size (KB)                   = 913876
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_unified_drag_suite_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 333.845654
-  0: The maximum resident set size (KB)                   = 912440
+  0: The total amount of wall time                        = 270.389446
+  0: The maximum resident set size (KB)                   = 912232
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_diag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.622183
-  0: The maximum resident set size (KB)                   = 1010864
+  0: The total amount of wall time                        = 287.445031
+  0: The maximum resident set size (KB)                   = 1008912
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.252267
-  0: The maximum resident set size (KB)                   = 918552
+  0: The total amount of wall time                        = 283.964565
+  0: The maximum resident set size (KB)                   = 918176
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_unified_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.453151
-  0: The maximum resident set size (KB)                   = 911308
+  0: The total amount of wall time                        = 276.307036
+  0: The maximum resident set size (KB)                   = 910092
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_noah_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.519752
-  0: The maximum resident set size (KB)                   = 910376
+  0: The total amount of wall time                        = 269.809125
+  0: The maximum resident set size (KB)                   = 912592
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 465.819981
-  0: The maximum resident set size (KB)                   = 1011576
+  0: The total amount of wall time                        = 456.104609
+  0: The maximum resident set size (KB)                   = 1011800
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_lndp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.679933
-  0: The maximum resident set size (KB)                   = 913280
+  0: The total amount of wall time                        = 272.086173
+  0: The maximum resident set size (KB)                   = 915124
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.251396
-  0: The maximum resident set size (KB)                   = 912260
+  0: The total amount of wall time                        = 274.172653
+  0: The maximum resident set size (KB)                   = 914708
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_flake_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.784947
-  0: The maximum resident set size (KB)                   = 912228
+  0: The total amount of wall time                        = 272.166009
+  0: The maximum resident set size (KB)                   = 912884
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 469.049754
-  0: The maximum resident set size (KB)                   = 913900
+  0: The total amount of wall time                        = 447.277619
+  0: The maximum resident set size (KB)                   = 911364
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.273170
-  0: The maximum resident set size (KB)                   = 912132
+  0: The total amount of wall time                        = 277.195478
+  0: The maximum resident set size (KB)                   = 911392
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.850692
-  0: The maximum resident set size (KB)                   = 909832
+  0: The total amount of wall time                        = 268.991387
+  0: The maximum resident set size (KB)                   = 908160
 
 Test 094 rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_wam_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_wam_debug
 Checking test 095 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 292.814085
-  0: The maximum resident set size (KB)                   = 276084
+  0: The total amount of wall time                        = 290.200129
+  0: The maximum resident set size (KB)                   = 275604
 
 Test 095 control_wam_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 252.486421
-  0: The maximum resident set size (KB)                   = 845536
+  0: The total amount of wall time                        = 278.930043
+  0: The maximum resident set size (KB)                   = 842684
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 301.286358
-  0: The maximum resident set size (KB)                   = 1209900
+  0: The total amount of wall time                        = 341.370040
+  0: The maximum resident set size (KB)                   = 1203352
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2858,28 +2858,28 @@ Checking test 098 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 368.006857
-  0: The maximum resident set size (KB)                   = 890736
+  0: The total amount of wall time                        = 334.801832
+  0: The maximum resident set size (KB)                   = 889884
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 767.150444
-  0: The maximum resident set size (KB)                   = 884456
+  0: The total amount of wall time                        = 737.526157
+  0: The maximum resident set size (KB)                   = 888808
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2888,62 +2888,62 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 906.756755
-  0: The maximum resident set size (KB)                   = 885248
+  0: The total amount of wall time                        = 830.826179
+  0: The maximum resident set size (KB)                   = 889656
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 424.112364
-  0: The maximum resident set size (KB)                   = 372932
+  0: The total amount of wall time                        = 530.958042
+  0: The maximum resident set size (KB)                   = 374820
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 411.383236
-  0: The maximum resident set size (KB)                   = 389588
+  0: The total amount of wall time                        = 510.534274
+  0: The maximum resident set size (KB)                   = 391876
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 213.092516
-  0: The maximum resident set size (KB)                   = 259968
+  0: The total amount of wall time                        = 233.155551
+  0: The maximum resident set size (KB)                   = 247604
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 438.805256
-  0: The maximum resident set size (KB)                   = 355428
+  0: The total amount of wall time                        = 531.806559
+  0: The maximum resident set size (KB)                   = 360456
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_docn
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2951,14 +2951,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 339.726878
-  0: The maximum resident set size (KB)                   = 884728
+  0: The total amount of wall time                        = 315.357287
+  0: The maximum resident set size (KB)                   = 886716
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2966,105 +2966,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 352.785580
-  0: The maximum resident set size (KB)                   = 888580
+  0: The total amount of wall time                        = 315.045394
+  0: The maximum resident set size (KB)                   = 886104
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 928.836170
-  0: The maximum resident set size (KB)                   = 868612
+  0: The total amount of wall time                        = 924.578521
+  0: The maximum resident set size (KB)                   = 865464
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.876786
- 0: The maximum resident set size (KB)                   = 718728
+ 0: The total amount of wall time                        = 141.504413
+ 0: The maximum resident set size (KB)                   = 744112
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 106.614780
- 0: The maximum resident set size (KB)                   = 723412
+ 0: The total amount of wall time                        = 81.980503
+ 0: The maximum resident set size (KB)                   = 720348
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.677578
- 0: The maximum resident set size (KB)                   = 621612
+ 0: The total amount of wall time                        = 140.200602
+ 0: The maximum resident set size (KB)                   = 621452
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.617312
- 0: The maximum resident set size (KB)                   = 621668
+ 0: The total amount of wall time                        = 138.821413
+ 0: The maximum resident set size (KB)                   = 621672
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.781332
- 0: The maximum resident set size (KB)                   = 718620
+ 0: The total amount of wall time                        = 143.410082
+ 0: The maximum resident set size (KB)                   = 737756
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.996956
- 0: The maximum resident set size (KB)                   = 619796
+ 0: The total amount of wall time                        = 138.902281
+ 0: The maximum resident set size (KB)                   = 621516
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3073,14 +3073,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 301.085377
-  0: The maximum resident set size (KB)                   = 633880
+  0: The total amount of wall time                        = 299.379622
+  0: The maximum resident set size (KB)                   = 632268
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3089,51 +3089,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 299.892281
-  0: The maximum resident set size (KB)                   = 596676
+  0: The total amount of wall time                        = 328.713270
+  0: The maximum resident set size (KB)                   = 595084
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.147056
+ 0: The total amount of wall time                        = 142.290451
  0: The maximum resident set size (KB)                   = 722860
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 193.017060
- 0: The maximum resident set size (KB)                   = 1833832
+ 0: The total amount of wall time                        = 188.994268
+ 0: The maximum resident set size (KB)                   = 1834336
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 446.824725
- 0: The maximum resident set size (KB)                   = 726632
+ 0: The total amount of wall time                        = 429.876471
+ 0: The maximum resident set size (KB)                   = 727280
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_atmwav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3177,14 +3177,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 80.222459
-  0: The maximum resident set size (KB)                   = 570972
+  0: The total amount of wall time                        = 81.067934
+  0: The maximum resident set size (KB)                   = 566808
 
 Test 119 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220207/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_225269/control_c384gdas_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_106299/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3230,12 +3230,12 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 673.768659
-  0: The maximum resident set size (KB)                   = 1205284
+  0: The total amount of wall time                        = 801.063679
+  0: The maximum resident set size (KB)                   = 1192740
 
 Test 120 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  9 19:38:01 CST 2022
-Elapsed time: 00h:51m:26s. Have a nice day!
+Sun Feb 13 22:03:46 CST 2022
+Elapsed time: 01h:10m:10s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,17 +1,17 @@
-Wed Feb 16 04:13:07 UTC 2022
+Sat Feb 19 00:57:32 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 755 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 769 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 807 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 754 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 005 elapsed time 508 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 500 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 007 elapsed time 458 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 828 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 813 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 810 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 901 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 769 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 005 elapsed time 546 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 535 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 007 elapsed time 499 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 876 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,14 +58,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 140.963002
-The maximum resident set size (KB)                   = 422816
+The total amount of wall time                        = 142.639661
+The maximum resident set size (KB)                   = 422644
 
 Test 001 control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_decomp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_decomp
 Checking test 002 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -108,28 +108,28 @@ Checking test 002 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 144.171561
-The maximum resident set size (KB)                   = 421784
+The total amount of wall time                        = 146.456767
+The maximum resident set size (KB)                   = 421580
 
 Test 002 control_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_2dwrtdecomp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_2dwrtdecomp
 Checking test 003 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 130.717840
-The maximum resident set size (KB)                   = 422856
+The total amount of wall time                        = 136.495434
+The maximum resident set size (KB)                   = 422584
 
 Test 003 control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_restart
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_restart
 Checking test 004 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -168,14 +168,14 @@ Checking test 004 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 77.203543
-The maximum resident set size (KB)                   = 155972
+The total amount of wall time                        = 90.560124
+The maximum resident set size (KB)                   = 156552
 
 Test 004 control_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_fhzero
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_fhzero
 Checking test 005 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -218,14 +218,14 @@ Checking test 005 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 132.591842
-The maximum resident set size (KB)                   = 422752
+The total amount of wall time                        = 131.653125
+The maximum resident set size (KB)                   = 422608
 
 Test 005 control_fhzero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_CubedSphereGrid
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_CubedSphereGrid
 Checking test 006 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -252,14 +252,14 @@ Checking test 006 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 134.052832
-The maximum resident set size (KB)                   = 422808
+The total amount of wall time                        = 134.003547
+The maximum resident set size (KB)                   = 422740
 
 Test 006 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_latlon
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_latlon
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_latlon
 Checking test 007 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -270,14 +270,14 @@ Checking test 007 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.697683
-The maximum resident set size (KB)                   = 422980
+The total amount of wall time                        = 135.567598
+The maximum resident set size (KB)                   = 422936
 
 Test 007 control_latlon PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_wrtGauss_netcdf_parallel
 Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -288,14 +288,14 @@ Checking test 008 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 138.457561
-The maximum resident set size (KB)                   = 422616
+The total amount of wall time                        = 138.644033
+The maximum resident set size (KB)                   = 422900
 
 Test 008 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c48
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_c48
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_c48
 Checking test 009 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -334,14 +334,14 @@ Checking test 009 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 429.924454
-The maximum resident set size (KB)                   = 630300
+The total amount of wall time                        = 430.679554
+The maximum resident set size (KB)                   = 623232
 
 Test 009 control_c48 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c192
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_c192
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_c192
 Checking test 010 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -352,14 +352,14 @@ Checking test 010 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 536.803974
-The maximum resident set size (KB)                   = 523004
+The total amount of wall time                        = 533.445433
+The maximum resident set size (KB)                   = 523272
 
 Test 010 control_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_stochy
 Checking test 011 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -370,28 +370,28 @@ Checking test 011 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 95.001371
-The maximum resident set size (KB)                   = 426504
+The total amount of wall time                        = 93.373286
+The maximum resident set size (KB)                   = 426552
 
 Test 011 control_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy_restart
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_stochy_restart
 Checking test 012 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 52.759183
-The maximum resident set size (KB)                   = 172396
+The total amount of wall time                        = 56.354367
+The maximum resident set size (KB)                   = 173804
 
 Test 012 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_lndp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_lndp
 Checking test 013 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -402,14 +402,14 @@ Checking test 013 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 85.728256
-The maximum resident set size (KB)                   = 427216
+The total amount of wall time                        = 88.230608
+The maximum resident set size (KB)                   = 427156
 
 Test 013 control_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr4
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_iovr4
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_iovr4
 Checking test 014 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -424,14 +424,14 @@ Checking test 014 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 140.138415
-The maximum resident set size (KB)                   = 422800
+The total amount of wall time                        = 139.219438
+The maximum resident set size (KB)                   = 422836
 
 Test 014 control_iovr4 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr5
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_iovr5
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_iovr5
 Checking test 015 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -446,14 +446,14 @@ Checking test 015 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 140.007979
-The maximum resident set size (KB)                   = 422584
+The total amount of wall time                        = 139.796665
+The maximum resident set size (KB)                   = 422572
 
 Test 015 control_iovr5 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_p8
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_p8
 Checking test 016 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -500,14 +500,14 @@ Checking test 016 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.907674
-The maximum resident set size (KB)                   = 455532
+The total amount of wall time                        = 175.721416
+The maximum resident set size (KB)                   = 455564
 
 Test 016 control_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_restart_p8
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_restart_p8
 Checking test 017 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -546,14 +546,14 @@ Checking test 017 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 89.951239
-The maximum resident set size (KB)                   = 264364
+The total amount of wall time                        = 102.293090
+The maximum resident set size (KB)                   = 264392
 
 Test 017 control_restart_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_decomp_p8
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_decomp_p8
 Checking test 018 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -596,14 +596,14 @@ Checking test 018 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 167.064946
-The maximum resident set size (KB)                   = 448944
+The total amount of wall time                        = 162.288864
+The maximum resident set size (KB)                   = 448852
 
 Test 018 control_decomp_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p7_rrtmgp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_p7_rrtmgp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_p7_rrtmgp
 Checking test 019 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -650,14 +650,14 @@ Checking test 019 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 204.532712
-The maximum resident set size (KB)                   = 551916
+The total amount of wall time                        = 206.135629
+The maximum resident set size (KB)                   = 553464
 
 Test 019 control_p7_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_control
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_control
 Checking test 020 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -668,42 +668,42 @@ Checking test 020 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 341.461452
-The maximum resident set size (KB)                   = 532800
+The total amount of wall time                        = 341.967519
+The maximum resident set size (KB)                   = 532280
 
 Test 020 regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_restart
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_restart
 Checking test 021 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 206.655364
-The maximum resident set size (KB)                   = 527232
+The total amount of wall time                        = 207.653059
+The maximum resident set size (KB)                   = 526992
 
 Test 021 regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_control_2dwrtdecomp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_control_2dwrtdecomp
 Checking test 022 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 342.416099
-The maximum resident set size (KB)                   = 532752
+The total amount of wall time                        = 347.207474
+The maximum resident set size (KB)                   = 532264
 
 Test 022 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_noquilt
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_noquilt
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_noquilt
 Checking test 023 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -711,14 +711,14 @@ Checking test 023 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 372.742520
-The maximum resident set size (KB)                   = 534752
+The total amount of wall time                        = 382.373908
+The maximum resident set size (KB)                   = 536572
 
 Test 023 regional_noquilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_hafs
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_hafs
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_hafs
 Checking test 024 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -727,28 +727,28 @@ Checking test 024 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 338.305705
-The maximum resident set size (KB)                   = 527336
+The total amount of wall time                        = 341.265002
+The maximum resident set size (KB)                   = 527536
 
 Test 024 regional_hafs PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_netcdf_parallel
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_netcdf_parallel
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_netcdf_parallel
 Checking test 025 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-The total amount of wall time                        = 335.269752
-The maximum resident set size (KB)                   = 528460
+The total amount of wall time                        = 350.276503
+The maximum resident set size (KB)                   = 527120
 
 Test 025 regional_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_RRTMGP
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_RRTMGP
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_RRTMGP
 Checking test 026 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -759,14 +759,14 @@ Checking test 026 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-The total amount of wall time                        = 430.228733
-The maximum resident set size (KB)                   = 654096
+The total amount of wall time                        = 428.499939
+The maximum resident set size (KB)                   = 651572
 
 Test 026 regional_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_control
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_control
 Checking test 027 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -813,14 +813,14 @@ Checking test 027 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 382.770623
-The maximum resident set size (KB)                   = 789616
+The total amount of wall time                        = 387.844062
+The maximum resident set size (KB)                   = 789776
 
 Test 027 rap_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_restart
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_restart
 Checking test 028 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -859,14 +859,14 @@ Checking test 028 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.900685
-The maximum resident set size (KB)                   = 529236
+The total amount of wall time                        = 206.998167
+The maximum resident set size (KB)                   = 529420
 
 Test 028 rap_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_sfcdiff
 Checking test 029 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -913,14 +913,14 @@ Checking test 029 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 383.082145
-The maximum resident set size (KB)                   = 789548
+The total amount of wall time                        = 395.335969
+The maximum resident set size (KB)                   = 789516
 
 Test 029 rap_sfcdiff PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff_restart
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_sfcdiff_restart
 Checking test 030 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -959,14 +959,14 @@ Checking test 030 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 198.907234
-The maximum resident set size (KB)                   = 528780
+The total amount of wall time                        = 207.114729
+The maximum resident set size (KB)                   = 528888
 
 Test 030 rap_sfcdiff_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hrrr_control
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hrrr_control
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hrrr_control
 Checking test 031 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1013,14 +1013,14 @@ Checking test 031 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 368.371023
-The maximum resident set size (KB)                   = 787292
+The total amount of wall time                        = 381.966506
+The maximum resident set size (KB)                   = 787472
 
 Test 031 hrrr_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_v1beta
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rrfs_v1beta
 Checking test 032 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1067,14 +1067,14 @@ Checking test 032 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 374.512100
-The maximum resident set size (KB)                   = 787288
+The total amount of wall time                        = 375.502008
+The maximum resident set size (KB)                   = 787532
 
 Test 032 rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rrfs_conus13km_hrrr_warm
 Checking test 033 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1083,14 +1083,14 @@ Checking test 033 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 244.062864
-The maximum resident set size (KB)                   = 596108
+The total amount of wall time                        = 267.132741
+The maximum resident set size (KB)                   = 598524
 
 Test 033 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rrfs_conus13km_radar_tten_warm
 Checking test 034 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1099,14 +1099,14 @@ Checking test 034 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 252.982695
-The maximum resident set size (KB)                   = 601916
+The total amount of wall time                        = 266.511826
+The maximum resident set size (KB)                   = 600256
 
 Test 034 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_rrtmgp
 Checking test 035 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1117,14 +1117,14 @@ Checking test 035 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 214.731299
-The maximum resident set size (KB)                   = 549484
+The total amount of wall time                        = 216.395916
+The maximum resident set size (KB)                   = 549512
 
 Test 035 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_c192
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp_c192
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_rrtmgp_c192
 Checking test 036 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1135,14 +1135,14 @@ Checking test 036 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 587.230894
-The maximum resident set size (KB)                   = 760460
+The total amount of wall time                        = 598.693698
+The maximum resident set size (KB)                   = 760652
 
 Test 036 control_rrtmgp_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmg
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_csawmg
 Checking test 037 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1153,14 +1153,14 @@ Checking test 037 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 356.033772
-The maximum resident set size (KB)                   = 490688
+The total amount of wall time                        = 351.945319
+The maximum resident set size (KB)                   = 491056
 
 Test 037 control_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmgt
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_csawmgt
 Checking test 038 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1171,14 +1171,14 @@ Checking test 038 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 349.403539
-The maximum resident set size (KB)                   = 490540
+The total amount of wall time                        = 357.302758
+The maximum resident set size (KB)                   = 490376
 
 Test 038 control_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_flake
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_flake
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_flake
 Checking test 039 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1189,14 +1189,14 @@ Checking test 039 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 229.614982
-The maximum resident set size (KB)                   = 491780
+The total amount of wall time                        = 232.686240
+The maximum resident set size (KB)                   = 491964
 
 Test 039 control_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_ras
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_ras
 Checking test 040 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1207,40 +1207,40 @@ Checking test 040 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 191.267527
-The maximum resident set size (KB)                   = 457248
+The total amount of wall time                        = 188.272160
+The maximum resident set size (KB)                   = 457336
 
 Test 040 control_ras PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_repro
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wam_repro
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_wam_repro
 Checking test 041 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.702270
-The maximum resident set size (KB)                   = 167840
+The total amount of wall time                        = 127.497514
+The maximum resident set size (KB)                   = 167768
 
 Test 041 control_wam PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_debug
 Checking test 042 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 141.253889
-The maximum resident set size (KB)                   = 488948
+The total amount of wall time                        = 144.267277
+The maximum resident set size (KB)                   = 488864
 
 Test 042 control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_CubedSphereGrid_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_CubedSphereGrid_debug
 Checking test 043 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1267,428 +1267,428 @@ Checking test 043 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 150.633314
-The maximum resident set size (KB)                   = 489104
+The total amount of wall time                        = 152.145290
+The maximum resident set size (KB)                   = 489208
 
 Test 043 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_wrtGauss_netcdf_parallel_debug
 Checking test 044 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 144.266689
-The maximum resident set size (KB)                   = 488980
+The total amount of wall time                        = 143.941064
+The maximum resident set size (KB)                   = 489004
 
 Test 044 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_stochy_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_stochy_debug
 Checking test 045 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.877999
-The maximum resident set size (KB)                   = 493828
+The total amount of wall time                        = 161.254536
+The maximum resident set size (KB)                   = 494180
 
 Test 045 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_lndp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_lndp_debug
 Checking test 046 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 145.323902
-The maximum resident set size (KB)                   = 493876
+The total amount of wall time                        = 147.722564
+The maximum resident set size (KB)                   = 493928
 
 Test 046 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_rrtmgp_debug
 Checking test 047 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.806495
-The maximum resident set size (KB)                   = 594776
+The total amount of wall time                        = 155.665066
+The maximum resident set size (KB)                   = 594720
 
 Test 047 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmg_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_csawmg_debug
 Checking test 048 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 232.145498
-The maximum resident set size (KB)                   = 532304
+The total amount of wall time                        = 236.830820
+The maximum resident set size (KB)                   = 531236
 
 Test 048 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_csawmgt_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_csawmgt_debug
 Checking test 049 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 226.772665
-The maximum resident set size (KB)                   = 531176
+The total amount of wall time                        = 227.839679
+The maximum resident set size (KB)                   = 531220
 
 Test 049 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_ras_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_ras_debug
 Checking test 050 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 146.822706
-The maximum resident set size (KB)                   = 501684
+The total amount of wall time                        = 147.745449
+The maximum resident set size (KB)                   = 501644
 
 Test 050 control_ras_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_diag_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_diag_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_diag_debug
 Checking test 051 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 150.066414
-The maximum resident set size (KB)                   = 546828
+The total amount of wall time                        = 149.290674
+The maximum resident set size (KB)                   = 546532
 
 Test 051 control_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug_p8
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_debug_p8
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_debug_p8
 Checking test 052 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 157.551228
-The maximum resident set size (KB)                   = 515056
+The total amount of wall time                        = 165.702729
+The maximum resident set size (KB)                   = 515104
 
 Test 052 control_debug_p8 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_thompson_debug
 Checking test 053 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.928448
-The maximum resident set size (KB)                   = 850632
+The total amount of wall time                        = 177.593931
+The maximum resident set size (KB)                   = 850500
 
 Test 053 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_no_aero_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_thompson_no_aero_debug
 Checking test 054 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.926273
-The maximum resident set size (KB)                   = 844592
+The total amount of wall time                        = 159.918002
+The maximum resident set size (KB)                   = 844680
 
 Test 054 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug_extdiag
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_extdiag_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_thompson_extdiag_debug
 Checking test 055 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.878733
-The maximum resident set size (KB)                   = 878520
+The total amount of wall time                        = 182.390973
+The maximum resident set size (KB)                   = 878448
 
 Test 055 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_thompson_progcld_thompson_debug
 Checking test 056 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 172.087889
-The maximum resident set size (KB)                   = 850616
+The total amount of wall time                        = 179.870020
+The maximum resident set size (KB)                   = 850548
 
 Test 056 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/regional_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/regional_debug
 Checking test 057 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 249.498301
-The maximum resident set size (KB)                   = 553480
+The total amount of wall time                        = 275.942270
+The maximum resident set size (KB)                   = 553504
 
 Test 057 regional_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_control_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_control_debug
 Checking test 058 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 265.239789
-The maximum resident set size (KB)                   = 857296
+The total amount of wall time                        = 274.977591
+The maximum resident set size (KB)                   = 857304
 
 Test 058 rap_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_unified_drag_suite_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_unified_drag_suite_debug
 Checking test 059 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.930092
-The maximum resident set size (KB)                   = 856752
+The total amount of wall time                        = 272.693935
+The maximum resident set size (KB)                   = 856864
 
 Test 059 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_diag_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_diag_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_diag_debug
 Checking test 060 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 283.392043
-The maximum resident set size (KB)                   = 939252
+The total amount of wall time                        = 292.099568
+The maximum resident set size (KB)                   = 939756
 
 Test 060 rap_diag_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_cires_ugwp_debug
 Checking test 061 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 271.577796
-The maximum resident set size (KB)                   = 857792
+The total amount of wall time                        = 282.396789
+The maximum resident set size (KB)                   = 858412
 
 Test 061 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_unified_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_unified_ugwp_debug
 Checking test 062 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 272.281313
-The maximum resident set size (KB)                   = 856724
+The total amount of wall time                        = 280.374536
+The maximum resident set size (KB)                   = 856884
 
 Test 062 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_noah_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_noah_debug
 Checking test 063 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 260.875220
-The maximum resident set size (KB)                   = 855580
+The total amount of wall time                        = 268.260423
+The maximum resident set size (KB)                   = 855624
 
 Test 063 rap_noah_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_rrtmgp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_rrtmgp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_rrtmgp_debug
 Checking test 064 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 445.668639
-The maximum resident set size (KB)                   = 963296
+The total amount of wall time                        = 445.246026
+The maximum resident set size (KB)                   = 962812
 
 Test 064 rap_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_lndp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_lndp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_lndp_debug
 Checking test 065 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 269.504618
-The maximum resident set size (KB)                   = 858336
+The total amount of wall time                        = 272.043541
+The maximum resident set size (KB)                   = 857820
 
 Test 065 rap_lndp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_sfcdiff_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_sfcdiff_debug
 Checking test 066 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 266.290773
-The maximum resident set size (KB)                   = 857012
+The total amount of wall time                        = 270.637072
+The maximum resident set size (KB)                   = 857128
 
 Test 066 rap_sfcdiff_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_flake_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_flake_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_flake_debug
 Checking test 067 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 263.396048
-The maximum resident set size (KB)                   = 857228
+The total amount of wall time                        = 268.559451
+The maximum resident set size (KB)                   = 857300
 
 Test 067 rap_flake_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 068 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 439.249639
-The maximum resident set size (KB)                   = 855332
+The total amount of wall time                        = 452.631214
+The maximum resident set size (KB)                   = 855572
 
 Test 068 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_progcld_thompson_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rap_progcld_thompson_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rap_progcld_thompson_debug
 Checking test 069 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.874770
-The maximum resident set size (KB)                   = 857260
+The total amount of wall time                        = 272.168771
+The maximum resident set size (KB)                   = 857356
 
 Test 069 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/rrfs_v1beta_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/rrfs_v1beta_debug
 Checking test 070 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 264.021967
-The maximum resident set size (KB)                   = 854056
+The total amount of wall time                        = 265.755051
+The maximum resident set size (KB)                   = 854200
 
 Test 070 rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_debug
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/control_wam_debug
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/control_wam_debug
 Checking test 071 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 271.170001
-The maximum resident set size (KB)                   = 197384
+The total amount of wall time                        = 274.508792
+The maximum resident set size (KB)                   = 197784
 
 Test 071 control_wam_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_atm
 Checking test 072 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 333.521750
-The maximum resident set size (KB)                   = 641720
+The total amount of wall time                        = 350.408121
+The maximum resident set size (KB)                   = 641860
 
 Test 072 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_atm_thompson_gfdlsf
 Checking test 073 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 370.991926
-The maximum resident set size (KB)                   = 998016
+The total amount of wall time                        = 376.720765
+The maximum resident set size (KB)                   = 1000796
 
 Test 073 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_ocn
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_atm_ocn
 Checking test 074 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1697,28 +1697,28 @@ Checking test 074 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 509.651724
-The maximum resident set size (KB)                   = 639568
+The total amount of wall time                        = 505.229239
+The maximum resident set size (KB)                   = 641824
 
 Test 074 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_wav
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_wav
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_atm_wav
 Checking test 075 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 898.438599
-The maximum resident set size (KB)                   = 643280
+The total amount of wall time                        = 910.876368
+The maximum resident set size (KB)                   = 642028
 
 Test 075 hafs_regional_atm_wav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_atm_ocn_wav
 Checking test 076 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1727,28 +1727,28 @@ Checking test 076 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 982.686760
-The maximum resident set size (KB)                   = 644304
+The total amount of wall time                        = 1025.986055
+The maximum resident set size (KB)                   = 645504
 
 Test 076 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_1nest_atm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_1nest_atm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_1nest_atm
 Checking test 077 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 358.580142
-The maximum resident set size (KB)                   = 244808
+The total amount of wall time                        = 361.463262
+The maximum resident set size (KB)                   = 243036
 
 Test 077 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_regional_telescopic_2nests_atm
 Checking test 078 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1757,26 +1757,26 @@ Checking test 078 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 374.833921
-The maximum resident set size (KB)                   = 245872
+The total amount of wall time                        = 376.622865
+The maximum resident set size (KB)                   = 246532
 
 Test 078 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_1nest_atm
-working dir  = /gpfs/hps3/stmp/Dom.Heinzeller/FV3_RT/rt_43266/hafs_global_1nest_atm
+working dir  = /gpfs/hps3/stmp/Raffaele.Montuoro/FV3_RT/rt_16849/hafs_global_1nest_atm
 Checking test 079 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 161.172515
-The maximum resident set size (KB)                   = 149968
+The total amount of wall time                        = 161.981537
+The maximum resident set size (KB)                   = 148084
 
 Test 079 hafs_global_1nest_atm PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 16 04:50:19 UTC 2022
-Elapsed time: 00h:37m:12s. Have a nice day!
+Sat Feb 19 01:43:23 UTC 2022
+Elapsed time: 00h:45m:52s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,24 +1,23 @@
-Wed Feb 16 04:12:38 UTC 2022
+Mon Feb 21 21:00:42 UTC 2022
 Start Regression test
 
-Test 009 compile FAIL
-
-Compile 001 elapsed time 1710 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 516 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1153 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 1113 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 1306 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 891 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 446 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 445 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1244 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 1228 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 776 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 434 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 963 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 2004 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 521 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 1112 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1322 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 912 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 456 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 424 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 293 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1231 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 1239 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 779 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 315 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 951 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 244.461606
-[0] The maximum resident set size (KB)                   = 553928
+[0] The total amount of wall time                        = 243.832216
+[0] The maximum resident set size (KB)                   = 552544
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_2threads_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -143,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 231.060779
-[0] The maximum resident set size (KB)                   = 639300
+[0] The total amount of wall time                        = 230.666376
+[0] The maximum resident set size (KB)                   = 641076
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_decomp_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -203,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 246.371875
-[0] The maximum resident set size (KB)                   = 554512
+[0] The total amount of wall time                        = 246.405647
+[0] The maximum resident set size (KB)                   = 554168
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_mpi_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -263,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 208.046266
-[0] The maximum resident set size (KB)                   = 536276
+[0] The total amount of wall time                        = 208.812604
+[0] The maximum resident set size (KB)                   = 534852
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -323,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 289.412041
-[0] The maximum resident set size (KB)                   = 653480
+[0] The total amount of wall time                        = 288.335730
+[0] The maximum resident set size (KB)                   = 656644
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p7
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_p7
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -375,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1008.765261
-[0] The maximum resident set size (KB)                   = 1268340
+[0] The total amount of wall time                        = 1015.992018
+[0] The maximum resident set size (KB)                   = 1269412
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -427,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1009.114691
-[0] The maximum resident set size (KB)                   = 1271004
+[0] The total amount of wall time                        = 1018.815352
+[0] The maximum resident set size (KB)                   = 1273340
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_bmark_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_bmark_mpi_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -479,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 1008.999599
-[0] The maximum resident set size (KB)                   = 1273312
+[0] The total amount of wall time                        = 995.751357
+[0] The maximum resident set size (KB)                   = 1275688
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c96_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c96_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -548,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 233.911751
-[0] The maximum resident set size (KB)                   = 549820
+[0] The total amount of wall time                        = 233.649036
+[0] The maximum resident set size (KB)                   = 556848
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c96_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c96_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -605,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-[0] The total amount of wall time                        = 126.770620
-[0] The maximum resident set size (KB)                   = 340652
+[0] The total amount of wall time                        = 125.096237
+[0] The maximum resident set size (KB)                   = 340604
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c192_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -662,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 988.866429
-[0] The maximum resident set size (KB)                   = 739052
+[0] The total amount of wall time                        = 988.290868
+[0] The maximum resident set size (KB)                   = 738280
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c192_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c192_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -719,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-[0] The total amount of wall time                        = 620.361939
-[0] The maximum resident set size (KB)                   = 828324
+[0] The total amount of wall time                        = 619.984532
+[0] The maximum resident set size (KB)                   = 831532
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c384_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_control_c384_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -769,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 1107.840100
-[0] The maximum resident set size (KB)                   = 1275520
+[0] The total amount of wall time                        = 1113.882872
+[0] The maximum resident set size (KB)                   = 1274640
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_control_c384_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_restart_c384_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -819,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 601.317393
-[0] The maximum resident set size (KB)                   = 1233840
+[0] The total amount of wall time                        = 602.994401
+[0] The maximum resident set size (KB)                   = 1234120
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/cpld_debug_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/cpld_debug_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -876,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-[0] The total amount of wall time                        = 704.938739
-[0] The maximum resident set size (KB)                   = 607624
+[0] The total amount of wall time                        = 707.040151
+[0] The maximum resident set size (KB)                   = 610180
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -930,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 141.718615
-[0] The maximum resident set size (KB)                   = 468332
+[0] The total amount of wall time                        = 141.072614
+[0] The maximum resident set size (KB)                   = 470544
 
 Test 016 control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_decomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -980,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 145.591709
-[0] The maximum resident set size (KB)                   = 473152
+[0] The total amount of wall time                        = 147.168203
+[0] The maximum resident set size (KB)                   = 468132
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2dwrtdecomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 134.506593
-[0] The maximum resident set size (KB)                   = 470852
+[0] The total amount of wall time                        = 133.666501
+[0] The maximum resident set size (KB)                   = 473788
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 129.593650
-[0] The maximum resident set size (KB)                   = 512200
+[0] The total amount of wall time                        = 130.552490
+[0] The maximum resident set size (KB)                   = 512496
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1090,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 73.852335
-[0] The maximum resident set size (KB)                   = 212988
+[0] The total amount of wall time                        = 74.492808
+[0] The maximum resident set size (KB)                   = 214212
 
 Test 020 control_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_fhzero
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1140,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 133.120062
-[0] The maximum resident set size (KB)                   = 472468
+[0] The total amount of wall time                        = 131.466994
+[0] The maximum resident set size (KB)                   = 468244
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_CubedSphereGrid
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 135.744734
-[0] The maximum resident set size (KB)                   = 472132
+[0] The total amount of wall time                        = 135.289738
+[0] The maximum resident set size (KB)                   = 469216
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_latlon
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_latlon
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1192,32 +1191,32 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 137.577266
-[0] The maximum resident set size (KB)                   = 467556
+[0] The total amount of wall time                        = 138.289577
+[0] The maximum resident set size (KB)                   = 468612
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wrtGauss_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 141.784249
-[0] The maximum resident set size (KB)                   = 468704
+[0] The total amount of wall time                        = 141.608758
+[0] The maximum resident set size (KB)                   = 472216
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c48
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c48
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 437.840977
-[0] The maximum resident set size (KB)                   = 658520
+[0] The total amount of wall time                        = 436.706896
+[0] The maximum resident set size (KB)                   = 663120
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c192
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c192
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1274,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 551.450918
-[0] The maximum resident set size (KB)                   = 574424
+[0] The total amount of wall time                        = 559.428903
+[0] The maximum resident set size (KB)                   = 576664
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1292,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 1032.443555
-[0] The maximum resident set size (KB)                   = 856176
+[0] The total amount of wall time                        = 1033.870817
+[0] The maximum resident set size (KB)                   = 860624
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384gdas
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384gdas
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1342,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 891.174537
-[0] The maximum resident set size (KB)                   = 991332
+[0] The total amount of wall time                        = 895.171818
+[0] The maximum resident set size (KB)                   = 997216
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 92.055453
-[0] The maximum resident set size (KB)                   = 470264
+[0] The total amount of wall time                        = 92.533772
+[0] The maximum resident set size (KB)                   = 471176
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 50.563766
-[0] The maximum resident set size (KB)                   = 271980
+[0] The total amount of wall time                        = 50.548521
+[0] The maximum resident set size (KB)                   = 267632
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_lndp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1392,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 84.392980
-[0] The maximum resident set size (KB)                   = 473372
+[0] The total amount of wall time                        = 84.836714
+[0] The maximum resident set size (KB)                   = 476920
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr4
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_iovr4
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1414,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 141.296118
-[0] The maximum resident set size (KB)                   = 468684
+[0] The total amount of wall time                        = 140.045998
+[0] The maximum resident set size (KB)                   = 471252
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_iovr5
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_iovr5
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1436,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 138.726884
-[0] The maximum resident set size (KB)                   = 470548
+[0] The total amount of wall time                        = 139.362281
+[0] The maximum resident set size (KB)                   = 474908
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1490,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 152.421897
-[0] The maximum resident set size (KB)                   = 495708
+[0] The total amount of wall time                        = 154.284144
+[0] The maximum resident set size (KB)                   = 493080
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_restart_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1536,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 83.130962
-[0] The maximum resident set size (KB)                   = 310200
+[0] The total amount of wall time                        = 83.557085
+[0] The maximum resident set size (KB)                   = 310372
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_decomp_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 158.879156
-[0] The maximum resident set size (KB)                   = 487444
+[0] The total amount of wall time                        = 159.401866
+[0] The maximum resident set size (KB)                   = 489112
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1636,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 142.495847
-[0] The maximum resident set size (KB)                   = 566572
+[0] The total amount of wall time                        = 143.574231
+[0] The maximum resident set size (KB)                   = 562704
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_p7_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_p7_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1690,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 201.967502
-[0] The maximum resident set size (KB)                   = 592152
+[0] The total amount of wall time                        = 203.512299
+[0] The maximum resident set size (KB)                   = 591428
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1708,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 346.932710
-[0] The maximum resident set size (KB)                   = 575544
+[0] The total amount of wall time                        = 345.949272
+[0] The maximum resident set size (KB)                   = 574276
 
 Test 039 regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 191.629768
-[0] The maximum resident set size (KB)                   = 572668
+[0] The total amount of wall time                        = 190.789183
+[0] The maximum resident set size (KB)                   = 575388
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_control_2dwrtdecomp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
-[0] The total amount of wall time                        = 343.177414
-[0] The maximum resident set size (KB)                   = 569584
+[0] The total amount of wall time                        = 342.616998
+[0] The maximum resident set size (KB)                   = 574436
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_noquilt
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_noquilt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1751,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-[0] The total amount of wall time                        = 371.119616
-[0] The maximum resident set size (KB)                   = 611032
+[0] The total amount of wall time                        = 368.632081
+[0] The maximum resident set size (KB)                   = 612280
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1769,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 194.935147
-[0] The maximum resident set size (KB)                   = 578684
+[0] The total amount of wall time                        = 195.236225
+[0] The maximum resident set size (KB)                   = 576152
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_hafs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_hafs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1785,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 345.807094
-[0] The maximum resident set size (KB)                   = 569296
+[0] The total amount of wall time                        = 345.453243
+[0] The maximum resident set size (KB)                   = 570904
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_netcdf_parallel
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_netcdf_parallel
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc .........OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 344.453609
-[0] The maximum resident set size (KB)                   = 572288
+[0] The total amount of wall time                        = 344.624296
+[0] The maximum resident set size (KB)                   = 568308
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_RRTMGP
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_RRTMGP
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1817,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 452.938495
-[0] The maximum resident set size (KB)                   = 695232
+[0] The total amount of wall time                        = 450.154561
+[0] The maximum resident set size (KB)                   = 697264
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1871,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 394.968712
-[0] The maximum resident set size (KB)                   = 838716
+[0] The total amount of wall time                        = 396.786571
+[0] The maximum resident set size (KB)                   = 843016
 
 Test 047 rap_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_2threads
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_2threads
 Checking test 048 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1925,14 +1924,14 @@ Checking test 048 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 372.200559
-[0] The maximum resident set size (KB)                   = 897280
+[0] The total amount of wall time                        = 371.799246
+[0] The maximum resident set size (KB)                   = 900828
 
 Test 048 rap_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_restart
 Checking test 049 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1971,14 +1970,14 @@ Checking test 049 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 202.731629
-[0] The maximum resident set size (KB)                   = 589568
+[0] The total amount of wall time                        = 202.849553
+[0] The maximum resident set size (KB)                   = 588116
 
 Test 049 rap_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_sfcdiff
 Checking test 050 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2025,14 +2024,14 @@ Checking test 050 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 392.697571
-[0] The maximum resident set size (KB)                   = 839760
+[0] The total amount of wall time                        = 392.991813
+[0] The maximum resident set size (KB)                   = 842428
 
 Test 050 rap_sfcdiff PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff_restart
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_sfcdiff_restart
 Checking test 051 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2071,14 +2070,14 @@ Checking test 051 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 201.515308
-[0] The maximum resident set size (KB)                   = 587252
+[0] The total amount of wall time                        = 200.869981
+[0] The maximum resident set size (KB)                   = 588068
 
 Test 051 rap_sfcdiff_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hrrr_control
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hrrr_control
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hrrr_control
 Checking test 052 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2124,14 @@ Checking test 052 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 380.441442
-[0] The maximum resident set size (KB)                   = 835952
+[0] The total amount of wall time                        = 379.739843
+[0] The maximum resident set size (KB)                   = 836580
 
 Test 052 hrrr_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_v1beta
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rrfs_v1beta
 Checking test 053 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2178,14 @@ Checking test 053 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 392.015925
-[0] The maximum resident set size (KB)                   = 835540
+[0] The total amount of wall time                        = 391.938090
+[0] The maximum resident set size (KB)                   = 836928
 
 Test 053 rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_hrrr_warm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_conus13km_hrrr_warm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rrfs_conus13km_hrrr_warm
 Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2195,14 +2194,14 @@ Checking test 054 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 180.363937
-[0] The maximum resident set size (KB)                   = 662136
+[0] The total amount of wall time                        = 180.973642
+[0] The maximum resident set size (KB)                   = 663632
 
 Test 054 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_conus13km_radar_tten_warm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_conus13km_radar_tten_warm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rrfs_conus13km_radar_tten_warm
 Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2211,14 +2210,14 @@ Checking test 055 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-[0] The total amount of wall time                        = 183.113977
-[0] The maximum resident set size (KB)                   = 665684
+[0] The total amount of wall time                        = 183.094557
+[0] The maximum resident set size (KB)                   = 664632
 
 Test 055 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_rrtmgp
 Checking test 056 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2229,14 +2228,14 @@ Checking test 056 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 222.897153
-[0] The maximum resident set size (KB)                   = 592084
+[0] The total amount of wall time                        = 224.108725
+[0] The maximum resident set size (KB)                   = 586832
 
 Test 056 control_rrtmgp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_c192
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp_c192
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_rrtmgp_c192
 Checking test 057 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2247,14 +2246,14 @@ Checking test 057 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-[0] The total amount of wall time                        = 606.989592
-[0] The maximum resident set size (KB)                   = 802264
+[0] The total amount of wall time                        = 608.530949
+[0] The maximum resident set size (KB)                   = 803308
 
 Test 057 control_rrtmgp_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmg
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_csawmg
 Checking test 058 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2265,14 +2264,14 @@ Checking test 058 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 362.312140
-[0] The maximum resident set size (KB)                   = 530132
+[0] The total amount of wall time                        = 363.882774
+[0] The maximum resident set size (KB)                   = 532040
 
 Test 058 control_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmgt
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_csawmgt
 Checking test 059 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2283,14 +2282,14 @@ Checking test 059 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 360.357171
-[0] The maximum resident set size (KB)                   = 530480
+[0] The total amount of wall time                        = 358.415874
+[0] The maximum resident set size (KB)                   = 529672
 
 Test 059 control_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_flake
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_flake
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_flake
 Checking test 060 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2300,14 @@ Checking test 060 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 244.601435
-[0] The maximum resident set size (KB)                   = 542644
+[0] The total amount of wall time                        = 244.213209
+[0] The maximum resident set size (KB)                   = 541568
 
 Test 060 control_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_ras
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_ras
 Checking test 061 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2319,14 +2318,14 @@ Checking test 061 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 190.470602
-[0] The maximum resident set size (KB)                   = 500636
+[0] The total amount of wall time                        = 190.821364
+[0] The maximum resident set size (KB)                   = 502308
 
 Test 061 control_ras PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson
 Checking test 062 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2337,14 +2336,14 @@ Checking test 062 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 239.780677
-[0] The maximum resident set size (KB)                   = 855036
+[0] The total amount of wall time                        = 241.331379
+[0] The maximum resident set size (KB)                   = 856308
 
 Test 062 control_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_no_aero
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson_no_aero
 Checking test 063 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2355,54 +2354,54 @@ Checking test 063 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-[0] The total amount of wall time                        = 228.792013
-[0] The maximum resident set size (KB)                   = 853872
+[0] The total amount of wall time                        = 230.747037
+[0] The maximum resident set size (KB)                   = 845256
 
 Test 063 control_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_repro
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wam_repro
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_wam_repro
 Checking test 064 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-[0] The total amount of wall time                        = 126.589439
-[0] The maximum resident set size (KB)                   = 230616
+[0] The total amount of wall time                        = 127.065635
+[0] The maximum resident set size (KB)                   = 232660
 
 Test 064 control_wam PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_debug
 Checking test 065 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 167.927801
-[0] The maximum resident set size (KB)                   = 538104
+[0] The total amount of wall time                        = 168.262481
+[0] The maximum resident set size (KB)                   = 538200
 
 Test 065 control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_2threads_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_2threads_debug
 Checking test 066 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 154.428442
-[0] The maximum resident set size (KB)                   = 581612
+[0] The total amount of wall time                        = 155.421058
+[0] The maximum resident set size (KB)                   = 582764
 
 Test 066 control_2threads_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_CubedSphereGrid_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_CubedSphereGrid_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_CubedSphereGrid_debug
 Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2429,446 +2428,458 @@ Checking test 067 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-[0] The total amount of wall time                        = 182.332754
-[0] The maximum resident set size (KB)                   = 539392
+[0] The total amount of wall time                        = 182.501714
+[0] The maximum resident set size (KB)                   = 538596
 
 Test 067 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wrtGauss_netcdf_parallel_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_wrtGauss_netcdf_parallel_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_wrtGauss_netcdf_parallel_debug
 Checking test 068 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 170.427890
-[0] The maximum resident set size (KB)                   = 541260
+[0] The total amount of wall time                        = 170.910181
+[0] The maximum resident set size (KB)                   = 541796
 
 Test 068 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_stochy_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_stochy_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_stochy_debug
 Checking test 069 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 190.905291
-[0] The maximum resident set size (KB)                   = 542836
+[0] The total amount of wall time                        = 192.448212
+[0] The maximum resident set size (KB)                   = 543472
 
 Test 069 control_stochy_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_lndp_debug
 Checking test 070 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 171.576756
-[0] The maximum resident set size (KB)                   = 546400
+[0] The total amount of wall time                        = 173.095663
+[0] The maximum resident set size (KB)                   = 546768
 
 Test 070 control_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_rrtmgp_debug
 Checking test 071 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 186.143281
-[0] The maximum resident set size (KB)                   = 636000
+[0] The total amount of wall time                        = 186.896888
+[0] The maximum resident set size (KB)                   = 635584
 
 Test 071 control_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmg_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmg_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_csawmg_debug
 Checking test 072 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 268.779135
-[0] The maximum resident set size (KB)                   = 577864
+[0] The total amount of wall time                        = 269.940576
+[0] The maximum resident set size (KB)                   = 573500
 
 Test 072 control_csawmg_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_csawmgt_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_csawmgt_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_csawmgt_debug
 Checking test 073 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 264.304771
-[0] The maximum resident set size (KB)                   = 575440
+[0] The total amount of wall time                        = 264.768481
+[0] The maximum resident set size (KB)                   = 575028
 
 Test 073 control_csawmgt_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_ras_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_ras_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_ras_debug
 Checking test 074 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 173.611451
-[0] The maximum resident set size (KB)                   = 555572
+[0] The total amount of wall time                        = 174.039882
+[0] The maximum resident set size (KB)                   = 555916
 
 Test 074 control_ras_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_diag_debug
 Checking test 075 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 175.844821
-[0] The maximum resident set size (KB)                   = 594672
+[0] The total amount of wall time                        = 178.154809
+[0] The maximum resident set size (KB)                   = 595972
 
 Test 075 control_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_debug_p8
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_debug_p8
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_debug_p8
 Checking test 076 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 182.721944
-[0] The maximum resident set size (KB)                   = 557500
+[0] The total amount of wall time                        = 184.140605
+[0] The maximum resident set size (KB)                   = 560464
 
 Test 076 control_debug_p8 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson_debug
 Checking test 077 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 197.123535
-[0] The maximum resident set size (KB)                   = 899104
+[0] The total amount of wall time                        = 198.149736
+[0] The maximum resident set size (KB)                   = 897708
 
 Test 077 control_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_no_aero_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_no_aero_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson_no_aero_debug
 Checking test 078 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 189.364468
-[0] The maximum resident set size (KB)                   = 896412
+[0] The total amount of wall time                        = 190.815931
+[0] The maximum resident set size (KB)                   = 895584
 
 Test 078 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_debug_extdiag
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_extdiag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson_extdiag_debug
 Checking test 079 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 206.780258
-[0] The maximum resident set size (KB)                   = 930492
+[0] The total amount of wall time                        = 207.290943
+[0] The maximum resident set size (KB)                   = 928368
 
 Test 079 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_thompson_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_thompson_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_thompson_progcld_thompson_debug
 Checking test 080 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 197.131237
-[0] The maximum resident set size (KB)                   = 900116
+[0] The total amount of wall time                        = 198.827143
+[0] The maximum resident set size (KB)                   = 899320
 
 Test 080 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/fv3_regional_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/regional_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/regional_debug
 Checking test 081 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-[0] The total amount of wall time                        = 282.085483
-[0] The maximum resident set size (KB)                   = 600520
+[0] The total amount of wall time                        = 283.039965
+[0] The maximum resident set size (KB)                   = 597500
 
 Test 081 regional_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_control_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_control_debug
 Checking test 082 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.324363
-[0] The maximum resident set size (KB)                   = 906808
+[0] The total amount of wall time                        = 305.544045
+[0] The maximum resident set size (KB)                   = 905772
 
 Test 082 rap_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_control_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_unified_drag_suite_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_unified_drag_suite_debug
 Checking test 083 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.566612
-[0] The maximum resident set size (KB)                   = 905552
+[0] The total amount of wall time                        = 305.935720
+[0] The maximum resident set size (KB)                   = 904548
 
 Test 083 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_diag_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_diag_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_diag_debug
 Checking test 084 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 319.920442
-[0] The maximum resident set size (KB)                   = 990860
+[0] The total amount of wall time                        = 320.856980
+[0] The maximum resident set size (KB)                   = 993264
 
 Test 084 rap_diag_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_cires_ugwp_debug
 Checking test 085 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 310.050578
-[0] The maximum resident set size (KB)                   = 910360
+[0] The total amount of wall time                        = 312.592038
+[0] The maximum resident set size (KB)                   = 907580
 
 Test 085 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_unified_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_unified_ugwp_debug
 Checking test 086 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 310.623462
-[0] The maximum resident set size (KB)                   = 905048
+[0] The total amount of wall time                        = 312.797033
+[0] The maximum resident set size (KB)                   = 908700
 
 Test 086 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_noah_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_noah_debug
 Checking test 087 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 301.223543
-[0] The maximum resident set size (KB)                   = 902152
+[0] The total amount of wall time                        = 303.044151
+[0] The maximum resident set size (KB)                   = 902648
 
 Test 087 rap_noah_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_rrtmgp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_rrtmgp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_rrtmgp_debug
 Checking test 088 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 518.748697
-[0] The maximum resident set size (KB)                   = 1006572
+[0] The total amount of wall time                        = 520.855109
+[0] The maximum resident set size (KB)                   = 1004512
 
 Test 088 rap_rrtmgp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_lndp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_lndp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_lndp_debug
 Checking test 089 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 307.008339
-[0] The maximum resident set size (KB)                   = 906332
+[0] The total amount of wall time                        = 307.190611
+[0] The maximum resident set size (KB)                   = 907776
 
 Test 089 rap_lndp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_sfcdiff_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_sfcdiff_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_sfcdiff_debug
 Checking test 090 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.363459
-[0] The maximum resident set size (KB)                   = 903656
+[0] The total amount of wall time                        = 304.753814
+[0] The maximum resident set size (KB)                   = 907328
 
 Test 090 rap_sfcdiff_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_flake_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_flake_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 304.142671
-[0] The maximum resident set size (KB)                   = 905304
+[0] The total amount of wall time                        = 306.196073
+[0] The maximum resident set size (KB)                   = 907036
 
 Test 091 rap_flake_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 092 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 508.051705
-[0] The maximum resident set size (KB)                   = 905804
+[0] The total amount of wall time                        = 509.352016
+[0] The maximum resident set size (KB)                   = 902692
 
 Test 092 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rap_progcld_thompson_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rap_progcld_thompson_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rap_progcld_thompson_debug
 Checking test 093 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 305.223939
-[0] The maximum resident set size (KB)                   = 907620
+[0] The total amount of wall time                        = 305.234523
+[0] The maximum resident set size (KB)                   = 908580
 
 Test 093 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/rrfs_v1beta_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/rrfs_v1beta_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/rrfs_v1beta_debug
 Checking test 094 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-[0] The total amount of wall time                        = 303.640524
-[0] The maximum resident set size (KB)                   = 904820
+[0] The total amount of wall time                        = 303.539808
+[0] The maximum resident set size (KB)                   = 905144
 
 Test 094 rrfs_v1beta_debug PASS
 
 
+baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_debug
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_wam_debug
+Checking test 095 control_wam_debug results ....
+ Comparing sfcf019.nc .........OK
+ Comparing atmf019.nc .........OK
+
+[0] The total amount of wall time                        = 323.119346
+[0] The maximum resident set size (KB)                   = 260260
+
+Test 095 control_wam_debug PASS
+
+
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_atm
 Checking test 096 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 605.042526
-[0] The maximum resident set size (KB)                   = 725892
+[0] The total amount of wall time                        = 601.590311
+[0] The maximum resident set size (KB)                   = 733444
 
 Test 096 hafs_regional_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_thompson_gfdlsf
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_thompson_gfdlsf
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_atm_thompson_gfdlsf
 Checking test 097 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-[0] The total amount of wall time                        = 276.488115
+[0] The total amount of wall time                        = 272.726885
 [0] The maximum resident set size (KB)                   = 1084500
 
 Test 097 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_ocn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_atm_ocn
 Checking test 098 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 395.705296
-[0] The maximum resident set size (KB)                   = 739056
+[0] The total amount of wall time                        = 389.685385
+[0] The maximum resident set size (KB)                   = 737384
 
 Test 098 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_wav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_atm_wav
 Checking test 099 hafs_regional_atm_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 820.480627
-[0] The maximum resident set size (KB)                   = 737504
+[0] The total amount of wall time                        = 821.190713
+[0] The maximum resident set size (KB)                   = 738756
 
 Test 099 hafs_regional_atm_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_atm_ocn_wav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_atm_ocn_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_atm_ocn_wav
 Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2877,58 +2888,58 @@ Checking test 100 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-[0] The total amount of wall time                        = 895.119830
-[0] The maximum resident set size (KB)                   = 746552
+[0] The total amount of wall time                        = 895.606504
+[0] The maximum resident set size (KB)                   = 745468
 
 Test 100 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_1nest_atm
 Checking test 101 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest02.f006.nc .........OK
 
-[0] The total amount of wall time                        = 657.367501
-[0] The maximum resident set size (KB)                   = 308392
+[0] The total amount of wall time                        = 652.972750
+[0] The maximum resident set size (KB)                   = 313028
 
 Test 101 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_telescopic_2nests_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_telescopic_2nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_telescopic_2nests_atm
 Checking test 102 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
- Comparing sfc.nest03.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest03.f006.nc .........OK
 
-[0] The total amount of wall time                        = 790.848344
-[0] The maximum resident set size (KB)                   = 326168
+[0] The total amount of wall time                        = 789.572987
+[0] The maximum resident set size (KB)                   = 332096
 
 Test 102 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_1nest_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_global_1nest_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_global_1nest_atm
 Checking test 103 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc ............ALT CHECK......OK
- Comparing sfc.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-[0] The total amount of wall time                        = 665.430613
-[0] The maximum resident set size (KB)                   = 223172
+[0] The total amount of wall time                        = 656.814099
+[0] The maximum resident set size (KB)                   = 221252
 
 Test 103 hafs_global_1nest_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_global_multiple_4nests_atm
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_global_multiple_4nests_atm
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_global_multiple_4nests_atm
 Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2939,16 +2950,16 @@ Checking test 104 hafs_global_multiple_4nests_atm results ....
  Comparing sfc.nest04.f006.nc .........OK
  Comparing sfc.nest04.f006.nc .........OK
  Comparing atm.nest05.f006.nc .........OK
- Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
+ Comparing sfc.nest05.f006.nc .........OK
 
-[0] The total amount of wall time                        = 1334.095527
-[0] The maximum resident set size (KB)                   = 300416
+[0] The total amount of wall time                        = 1317.851800
+[0] The maximum resident set size (KB)                   = 302720
 
 Test 104 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_docn
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_docn
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2956,14 +2967,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 374.511703
-[0] The maximum resident set size (KB)                   = 740956
+[0] The total amount of wall time                        = 373.605058
+[0] The maximum resident set size (KB)                   = 745444
 
 Test 105 hafs_regional_docn PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_docn_oisst
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_docn_oisst
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2971,105 +2982,105 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-[0] The total amount of wall time                        = 373.863900
-[0] The maximum resident set size (KB)                   = 748088
+[0] The total amount of wall time                        = 372.701286
+[0] The maximum resident set size (KB)                   = 740944
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/hafs_regional_datm_cdeps
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/hafs_regional_datm_cdeps
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-[0] The total amount of wall time                        = 1088.790491
-[0] The maximum resident set size (KB)                   = 897376
+[0] The total amount of wall time                        = 1083.124540
+[0] The maximum resident set size (KB)                   = 895012
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 173.418931
-[0] The maximum resident set size (KB)                   = 724412
+[0] The total amount of wall time                        = 174.379403
+[0] The maximum resident set size (KB)                   = 719224
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 118.294812
-[0] The maximum resident set size (KB)                   = 724176
+[0] The total amount of wall time                        = 119.910818
+[0] The maximum resident set size (KB)                   = 723596
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_control_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 167.274079
-[0] The maximum resident set size (KB)                   = 624452
+[0] The total amount of wall time                        = 168.686259
+[0] The maximum resident set size (KB)                   = 627236
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_stochy_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_stochy_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_stochy_gefs
 Checking test 111 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 169.525802
-[0] The maximum resident set size (KB)                   = 626304
+[0] The total amount of wall time                        = 172.296579
+[0] The maximum resident set size (KB)                   = 625388
 
 Test 111 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_bulk_cfsr
 Checking test 112 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 173.563570
-[0] The maximum resident set size (KB)                   = 743312
+[0] The total amount of wall time                        = 174.665418
+[0] The maximum resident set size (KB)                   = 723472
 
 Test 112 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_bulk_gefs
 Checking test 113 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 168.449351
-[0] The maximum resident set size (KB)                   = 626076
+[0] The total amount of wall time                        = 168.462395
+[0] The maximum resident set size (KB)                   = 624612
 
 Test 113 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_mx025_cfsr
 Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3078,14 +3089,14 @@ Checking test 114 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 358.293307
-[0] The maximum resident set size (KB)                   = 565652
+[0] The total amount of wall time                        = 364.647286
+[0] The maximum resident set size (KB)                   = 575168
 
 Test 114 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_mx025_gefs
 Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3094,51 +3105,51 @@ Checking test 115 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-[0] The total amount of wall time                        = 351.446065
-[0] The maximum resident set size (KB)                   = 541164
+[0] The total amount of wall time                        = 357.612594
+[0] The maximum resident set size (KB)                   = 541780
 
 Test 115 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_multiple_files_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_multiple_files_cfsr
 Checking test 116 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 173.758603
-[0] The maximum resident set size (KB)                   = 739412
+[0] The total amount of wall time                        = 175.676449
+[0] The maximum resident set size (KB)                   = 721084
 
 Test 116 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_3072x1536_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_3072x1536_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_3072x1536_cfsr
 Checking test 117 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-[0] The total amount of wall time                        = 247.726615
-[0] The maximum resident set size (KB)                   = 1897156
+[0] The total amount of wall time                        = 251.568969
+[0] The maximum resident set size (KB)                   = 1896908
 
 Test 117 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/datm_cdeps_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/datm_cdeps_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/datm_cdeps_debug_cfsr
 Checking test 118 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-[0] The total amount of wall time                        = 498.758945
-[0] The maximum resident set size (KB)                   = 728140
+[0] The total amount of wall time                        = 502.351226
+[0] The maximum resident set size (KB)                   = 728300
 
 Test 118 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_atmwav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_atmwav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_atmwav
 Checking test 119 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3182,14 +3193,14 @@ Checking test 119 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-[0] The total amount of wall time                        = 91.882987
-[0] The maximum resident set size (KB)                   = 489012
+[0] The total amount of wall time                        = 92.322076
+[0] The maximum resident set size (KB)                   = 486620
 
 Test 119 control_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_c384gdas_wav
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_2741/control_c384gdas_wav
+working dir  = /gpfs/dell2/ptmp/Jun.Wang/FV3_RT/rt_26009/control_c384gdas_wav
 Checking test 120 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3235,34 +3246,12 @@ Checking test 120 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-[0] The total amount of wall time                        = 627.605967
-[0] The maximum resident set size (KB)                   = 1051188
+[0] The total amount of wall time                        = 626.477621
+[0] The maximum resident set size (KB)                   = 1044744
 
 Test 120 control_c384gdas_wav PASS
 
-FAILED TESTS: 
-Test compile_009 failed in run_compile failed 
-
-REGRESSION TEST FAILED
-Wed Feb 16 05:55:43 UTC 2022
-Elapsed time: 01h:43m:06s. Have a nice day!
-Wed Feb 16 13:26:20 UTC 2022
-Start Regression test
-
-Compile 001 elapsed time 285 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-
-baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20220215/control_wam_debug
-working dir  = /gpfs/dell2/ptmp/Dom.Heinzeller/FV3_RT/rt_54521/control_wam_debug
-Checking test 001 control_wam_debug results ....
- Comparing sfcf019.nc .........OK
- Comparing atmf019.nc .........OK
-
-[0] The total amount of wall time                        = 323.242475
-[0] The maximum resident set size (KB)                   = 263200
-
-Test 001 control_wam_debug PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 16 13:38:59 UTC 2022
-Elapsed time: 00h:12m:41s. Have a nice day!
+Mon Feb 21 23:39:29 UTC 2022
+Elapsed time: 02h:38m:49s. Have a nice day!

--- a/tests/parm/gocart/AERO_ExtData.rc
+++ b/tests/parm/gocart/AERO_ExtData.rc
@@ -95,6 +95,9 @@ OC_ANTEOC2 NA  Y Y %y4-%m2-%d2t12:00:00 none none anteoc2 ExtData/PIESA/sfc/HTAP
 # EDGAR based ship emissions
 OC_SHIP    NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_ship ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_oc.ships.x3600_y1800_t12.2010.nc4
 
+# Aircraft fuel consumption
+OC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none oc_aviation /dev/null
+
 # Aviation emissions during the three phases of flight
 OC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_oc.aviation_lto.x3600_y1800_t12.2010.nc4
 OC_AVIATION_CDS NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_oc.aviation_cds.x3600_y1800_t12.2010.nc4
@@ -119,6 +122,9 @@ BC_ANTEBC2 NA  Y Y %y4-%m2-%d2t12:00:00 none none antebc2 ExtData/PIESA/sfc/HTAP
 # EDGAR based ship emissions
 BC_SHIP NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_ship ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_bc.ships.x3600_y1800_t12.2010.nc4
 
+# Aircraft fuel consumption
+BC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none bc_aviation /dev/null
+
 # Aviation emissions during the LTO, SDC and CRS phases of flight
 BC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_bc.aviation_lto.x3600_y1800_t12.2010.nc4
 BC_AVIATION_CDS NA  Y Y %y4-%m2-%d2t12:00:00 none none bc_aviation ExtData/PIESA/sfc/HTAP/v2.2/htap-v2.2.emis_bc.aviation_cds.x3600_y1800_t12.2010.nc4
@@ -142,6 +148,9 @@ BRC_ANTEBRC2 NA  Y Y %y4-%m2-%d2t12:00:00 none none anteoc2 /dev/null
 
 # EDGAR based ship emissions
 BRC_SHIP    NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_ship /dev/null
+
+# Aircraft fuel consumption
+BRC_AIRCRAFT NA  N Y %y4-%m2-%d2t12:00:00 none none none /dev/null
 
 # Aviation emissions during the three phases of flight
 BRC_AVIATION_LTO NA  Y Y %y4-%m2-%d2t12:00:00 none none oc_aviation /dev/null

--- a/tests/parm/gocart/CA2G_instance_CA.bc.rc
+++ b/tests/parm/gocart/CA2G_instance_CA.bc.rc
@@ -7,6 +7,9 @@ nbins:  2
 aerosol_radBands_optics_file: ExtData/optics/opticsBands_BC.v1_3.RRTMG.nc
 aerosol_monochromatic_optics_file: ExtData/monochromatic/optics_BC.v1_3.nc
 
+# Aircraft emission factor: convert input unit to kg C
+aircraft_fuel_emission_factor: 1.0000
+
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
 
@@ -35,3 +38,4 @@ sigma: 2.0  2.0
 
 pressure_lid_in_hPa: 0.01
 
+point_emissions_srcfilen: /dev/null

--- a/tests/parm/gocart/CA2G_instance_CA.oc.rc
+++ b/tests/parm/gocart/CA2G_instance_CA.oc.rc
@@ -5,6 +5,9 @@
 aerosol_radBands_optics_file: ExtData/optics/opticsBands_OC.v1_3.RRTMG.nc
 aerosol_monochromatic_optics_file: ExtData/monochromatic/optics_OC.v1_3.nc
 
+# Aircraft emission factor: convert input unit to kg C
+aircraft_fuel_emission_factor: 1.0000
+
 # Heights [m] of LTO, CDS and CRS aviation emissions layers
 aviation_vertical_layers: 0.0 100.0 9.0e3 10.0e3
 
@@ -41,3 +44,5 @@ sigma: 2.20  2.20
 pressure_lid_in_hPa: 0.01
 
 nbins: 2 
+
+point_emissions_srcfilen: /dev/null


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description

This update allows the Thompson microphysics scheme to be used with prognostic aerosols (UFS-Aerosols) (#1047) and updates GOCART to version 2.0.2 (#1048).

### Issue(s) addressed

- fixes #1047 
- fixes #1048 

## Testing

This PR was tested on Hera/Intel and Orion/Intel platforms and regression test logs are included.
No changes to the baseline are introduced.

- [x] hera.intel
- [x] hera.gnu
- [x] orion.intel
- [x] cheyenne.intel 
- [x] cheyenne.gnu
- [x] gaea.intel 
- [x] jet.intel
- [x] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [x] CI

## Dependencies

- https://github.com/NOAA-EMC/fv3atm/pull/484