### PR TITLE
Generate correct atmospheric restart files with multiple fv3atm run phases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/rmontuoro/fv3atm
+  branch = bugfix/clock
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,23 +1,23 @@
-Wed Feb 23 20:16:39 CST 2022
+Thu Feb 24 19:25:59 CST 2022
 Start Regression test
 
-Compile 001 elapsed time 510 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 171 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 425 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 417 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 428 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 368 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 174 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 173 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 149 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 409 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 413 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 206 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 95 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 375 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 550 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 170 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 399 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 412 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 418 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 376 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 182 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 182 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 159 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 408 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 475 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 203 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 91 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 487 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_control_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 214.532913
-  0: The maximum resident set size (KB)                   = 646200
+  0: The total amount of wall time                        = 216.628404
+  0: The maximum resident set size (KB)                   = 650680
 
 Test 001 cpld_control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_2threads_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 242.910754
-  0: The maximum resident set size (KB)                   = 692824
+  0: The total amount of wall time                        = 299.539876
+  0: The maximum resident set size (KB)                   = 695832
 
 Test 002 cpld_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_decomp_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 214.904753
-  0: The maximum resident set size (KB)                   = 643412
+  0: The total amount of wall time                        = 216.955315
+  0: The maximum resident set size (KB)                   = 644504
 
 Test 003 cpld_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_mpi_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 183.477237
-  0: The maximum resident set size (KB)                   = 654476
+  0: The total amount of wall time                        = 187.467065
+  0: The maximum resident set size (KB)                   = 650524
 
 Test 004 cpld_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_control_p7_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 252.246556
-  0: The maximum resident set size (KB)                   = 743940
+  0: The total amount of wall time                        = 251.627826
+  0: The maximum resident set size (KB)                   = 742524
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_bmark_p7
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_bmark_p7
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -374,14 +374,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 884.148108
-  0: The maximum resident set size (KB)                   = 1475604
+  0: The total amount of wall time                        = 904.295381
+  0: The maximum resident set size (KB)                   = 1472388
 
 Test 006 cpld_bmark_p7 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_bmark_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -426,14 +426,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 882.367032
-  0: The maximum resident set size (KB)                   = 1473944
+  0: The total amount of wall time                        = 895.217093
+  0: The maximum resident set size (KB)                   = 1472584
 
 Test 007 cpld_bmark_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_bmark_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_bmark_mpi_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -478,14 +478,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 860.887293
-  0: The maximum resident set size (KB)                   = 1496112
+  0: The total amount of wall time                        = 1037.739229
+  0: The maximum resident set size (KB)                   = 1491680
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_control_c96_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -547,14 +547,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 206.279850
-  0: The maximum resident set size (KB)                   = 608160
+  0: The total amount of wall time                        = 210.770806
+  0: The maximum resident set size (KB)                   = 632664
 
 Test 009 cpld_control_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c96_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_restart_c96_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -604,14 +604,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 113.435439
-  0: The maximum resident set size (KB)                   = 394696
+  0: The total amount of wall time                        = 117.785842
+  0: The maximum resident set size (KB)                   = 394156
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_control_c192_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -661,14 +661,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 851.451803
-  0: The maximum resident set size (KB)                   = 850860
+  0: The total amount of wall time                        = 863.141843
+  0: The maximum resident set size (KB)                   = 850868
 
 Test 011 cpld_control_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c192_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_restart_c192_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -718,14 +718,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 594.909845
-  0: The maximum resident set size (KB)                   = 921128
+  0: The total amount of wall time                        = 604.916519
+  0: The maximum resident set size (KB)                   = 920360
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_control_c384_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -768,14 +768,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1027.868458
-  0: The maximum resident set size (KB)                   = 1440748
+  0: The total amount of wall time                        = 1034.174854
+  0: The maximum resident set size (KB)                   = 1442284
 
 Test 013 cpld_control_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_control_c384_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_restart_c384_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -818,14 +818,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 547.870771
-  0: The maximum resident set size (KB)                   = 1398144
+  0: The total amount of wall time                        = 570.131643
+  0: The maximum resident set size (KB)                   = 1401048
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/cpld_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/cpld_debug_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -875,14 +875,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 670.027628
-  0: The maximum resident set size (KB)                   = 690036
+  0: The total amount of wall time                        = 642.586387
+  0: The maximum resident set size (KB)                   = 689312
 
 Test 015 cpld_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -929,14 +929,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 120.303587
-  0: The maximum resident set size (KB)                   = 483148
+  0: The total amount of wall time                        = 124.074634
+  0: The maximum resident set size (KB)                   = 484164
 
 Test 016 control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_decomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -979,28 +979,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.598265
-  0: The maximum resident set size (KB)                   = 481204
+  0: The total amount of wall time                        = 127.522160
+  0: The maximum resident set size (KB)                   = 485356
 
 Test 017 control_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_2dwrtdecomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 114.924851
-  0: The maximum resident set size (KB)                   = 485592
+  0: The total amount of wall time                        = 115.823837
+  0: The maximum resident set size (KB)                   = 482232
 
 Test 018 control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1043,14 +1043,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 145.218970
- 0: The maximum resident set size (KB)                   = 520548
+ 0: The total amount of wall time                        = 164.404807
+ 0: The maximum resident set size (KB)                   = 525316
 
 Test 019 control_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 65.676810
-  0: The maximum resident set size (KB)                   = 222720
+  0: The total amount of wall time                        = 65.905176
+  0: The maximum resident set size (KB)                   = 224256
 
 Test 020 control_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_fhzero
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1139,14 +1139,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 113.328631
-  0: The maximum resident set size (KB)                   = 485636
+  0: The total amount of wall time                        = 116.035083
+  0: The maximum resident set size (KB)                   = 482484
 
 Test 021 control_fhzero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_CubedSphereGrid
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_CubedSphereGrid
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1173,14 +1173,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.879591
-  0: The maximum resident set size (KB)                   = 480888
+  0: The total amount of wall time                        = 118.143947
+  0: The maximum resident set size (KB)                   = 480968
 
 Test 022 control_CubedSphereGrid PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_latlon
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_latlon
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1191,14 +1191,14 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 119.580071
-  0: The maximum resident set size (KB)                   = 485608
+  0: The total amount of wall time                        = 119.540598
+  0: The maximum resident set size (KB)                   = 486300
 
 Test 023 control_latlon PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_wrtGauss_netcdf_parallel
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.902492
-  0: The maximum resident set size (KB)                   = 484516
+  0: The total amount of wall time                        = 122.328435
+  0: The maximum resident set size (KB)                   = 485900
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_c48
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_c48
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 304.842850
-0: The maximum resident set size (KB)                   = 653300
+0: The total amount of wall time                        = 387.360173
+0: The maximum resident set size (KB)                   = 650268
 
 Test 025 control_c48 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_c192
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 462.329076
-  0: The maximum resident set size (KB)                   = 587212
+  0: The total amount of wall time                        = 464.144684
+  0: The maximum resident set size (KB)                   = 586088
 
 Test 026 control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_c384
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_c384
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1291,14 +1291,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 780.166329
-  0: The maximum resident set size (KB)                   = 880104
+  0: The total amount of wall time                        = 911.806188
+  0: The maximum resident set size (KB)                   = 881644
 
 Test 027 control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_c384gdas
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_c384gdas
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1341,14 +1341,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 669.456644
-  0: The maximum resident set size (KB)                   = 1010756
+  0: The total amount of wall time                        = 804.007125
+  0: The maximum resident set size (KB)                   = 997628
 
 Test 028 control_c384gdas PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_stochy
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1359,28 +1359,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 78.066674
-  0: The maximum resident set size (KB)                   = 481572
+  0: The total amount of wall time                        = 78.214238
+  0: The maximum resident set size (KB)                   = 481556
 
 Test 029 control_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_stochy
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_stochy_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.276417
-  0: The maximum resident set size (KB)                   = 260516
+  0: The total amount of wall time                        = 45.469410
+  0: The maximum resident set size (KB)                   = 261068
 
 Test 030 control_stochy_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_lndp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_lndp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.418498
-  0: The maximum resident set size (KB)                   = 489040
+  0: The total amount of wall time                        = 72.942157
+  0: The maximum resident set size (KB)                   = 488348
 
 Test 031 control_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_iovr4
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_iovr4
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 120.599521
-  0: The maximum resident set size (KB)                   = 485220
+  0: The total amount of wall time                        = 120.702455
+  0: The maximum resident set size (KB)                   = 485408
 
 Test 032 control_iovr4 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_iovr5
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_iovr5
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 120.567964
-  0: The maximum resident set size (KB)                   = 485532
+  0: The total amount of wall time                        = 121.826765
+  0: The maximum resident set size (KB)                   = 483716
 
 Test 033 control_iovr5 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1489,14 +1489,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.955467
-  0: The maximum resident set size (KB)                   = 509196
+  0: The total amount of wall time                        = 135.058233
+  0: The maximum resident set size (KB)                   = 508788
 
 Test 034 control_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_restart_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1535,14 +1535,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 75.963859
-  0: The maximum resident set size (KB)                   = 279048
+  0: The total amount of wall time                        = 76.372874
+  0: The maximum resident set size (KB)                   = 294264
 
 Test 035 control_restart_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_decomp_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1585,14 +1585,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.778704
-  0: The maximum resident set size (KB)                   = 505348
+  0: The total amount of wall time                        = 143.983884
+  0: The maximum resident set size (KB)                   = 503708
 
 Test 036 control_decomp_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_2threads_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1635,14 +1635,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 463.705982
- 0: The maximum resident set size (KB)                   = 579092
+ 0: The total amount of wall time                        = 204.135421
+ 0: The maximum resident set size (KB)                   = 585540
 
 Test 037 control_2threads_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_p7_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_p7_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1689,14 +1689,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.430152
-  0: The maximum resident set size (KB)                   = 608664
+  0: The total amount of wall time                        = 171.745821
+  0: The maximum resident set size (KB)                   = 607372
 
 Test 038 control_p7_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1707,42 +1707,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 294.614781
- 0: The maximum resident set size (KB)                   = 587692
+ 0: The total amount of wall time                        = 298.947063
+ 0: The maximum resident set size (KB)                   = 591948
 
 Test 039 regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 168.771843
- 0: The maximum resident set size (KB)                   = 589256
+ 0: The total amount of wall time                        = 164.184023
+ 0: The maximum resident set size (KB)                   = 590788
 
 Test 040 regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_control_2dwrtdecomp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 293.479453
- 0: The maximum resident set size (KB)                   = 590848
+ 0: The total amount of wall time                        = 300.196370
+ 0: The maximum resident set size (KB)                   = 587484
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_noquilt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_noquilt
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1750,14 +1750,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 298.199716
- 0: The maximum resident set size (KB)                   = 601880
+ 0: The total amount of wall time                        = 299.596278
+ 0: The maximum resident set size (KB)                   = 603164
 
 Test 042 regional_noquilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1768,14 +1768,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 213.032576
- 0: The maximum resident set size (KB)                   = 612016
+ 0: The total amount of wall time                        = 259.461025
+ 0: The maximum resident set size (KB)                   = 600812
 
 Test 043 regional_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_hafs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_hafs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1784,28 +1784,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 293.271871
- 0: The maximum resident set size (KB)                   = 591392
+ 0: The total amount of wall time                        = 292.863716
+ 0: The maximum resident set size (KB)                   = 594208
 
 Test 044 regional_hafs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_netcdf_parallel
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_netcdf_parallel
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 293.823508
- 0: The maximum resident set size (KB)                   = 585356
+ 0: The total amount of wall time                        = 295.694871
+ 0: The maximum resident set size (KB)                   = 591332
 
 Test 045 regional_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_RRTMGP
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_RRTMGP
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1816,14 +1816,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 370.560843
- 0: The maximum resident set size (KB)                   = 717684
+ 0: The total amount of wall time                        = 377.573723
+ 0: The maximum resident set size (KB)                   = 714184
 
 Test 046 regional_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1870,14 +1870,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.743327
-  0: The maximum resident set size (KB)                   = 852856
+  0: The total amount of wall time                        = 340.432293
+  0: The maximum resident set size (KB)                   = 852940
 
 Test 047 rap_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_spp_sppt_shum_skeb
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_spp_sppt_shum_skeb
 Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1888,14 +1888,14 @@ Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 276.009918
-  0: The maximum resident set size (KB)                   = 1015768
+  0: The total amount of wall time                        = 662.672387
+  0: The maximum resident set size (KB)                   = 1015232
 
 Test 048 regional_spp_sppt_shum_skeb PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_2threads
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_2threads
 Checking test 049 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1942,14 +1942,14 @@ Checking test 049 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 409.302472
- 0: The maximum resident set size (KB)                   = 913932
+ 0: The total amount of wall time                        = 501.468817
+ 0: The maximum resident set size (KB)                   = 915208
 
 Test 049 rap_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_restart
 Checking test 050 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1988,14 +1988,14 @@ Checking test 050 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.503907
-  0: The maximum resident set size (KB)                   = 606020
+  0: The total amount of wall time                        = 174.731398
+  0: The maximum resident set size (KB)                   = 604644
 
 Test 050 rap_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_sfcdiff
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_sfcdiff
 Checking test 051 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2042,14 +2042,14 @@ Checking test 051 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.139925
-  0: The maximum resident set size (KB)                   = 852432
+  0: The total amount of wall time                        = 337.870971
+  0: The maximum resident set size (KB)                   = 854052
 
 Test 051 rap_sfcdiff PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_sfcdiff
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_sfcdiff_restart
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_sfcdiff_restart
 Checking test 052 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2088,14 +2088,14 @@ Checking test 052 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.968409
-  0: The maximum resident set size (KB)                   = 602540
+  0: The total amount of wall time                        = 178.091619
+  0: The maximum resident set size (KB)                   = 601940
 
 Test 052 rap_sfcdiff_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hrrr_control
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hrrr_control
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hrrr_control
 Checking test 053 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2142,14 +2142,14 @@ Checking test 053 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 326.588766
-  0: The maximum resident set size (KB)                   = 849264
+  0: The total amount of wall time                        = 326.244810
+  0: The maximum resident set size (KB)                   = 850084
 
 Test 053 hrrr_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rrfs_v1beta
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rrfs_v1beta
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rrfs_v1beta
 Checking test 054 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2196,14 +2196,14 @@ Checking test 054 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 334.105652
-  0: The maximum resident set size (KB)                   = 849772
+  0: The total amount of wall time                        = 333.430453
+  0: The maximum resident set size (KB)                   = 847176
 
 Test 054 rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rrfs_conus13km_hrrr_warm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2212,14 +2212,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 162.471747
-  0: The maximum resident set size (KB)                   = 716592
+  0: The total amount of wall time                        = 148.257035
+  0: The maximum resident set size (KB)                   = 718080
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rrfs_conus13km_radar_tten_warm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2228,14 +2228,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 163.263062
-  0: The maximum resident set size (KB)                   = 717528
+  0: The total amount of wall time                        = 150.352268
+  0: The maximum resident set size (KB)                   = 712920
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_rrtmgp
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_rrtmgp
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_rrtmgp
 Checking test 057 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2246,14 +2246,14 @@ Checking test 057 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.707708
-  0: The maximum resident set size (KB)                   = 600776
+  0: The total amount of wall time                        = 187.638897
+  0: The maximum resident set size (KB)                   = 599168
 
 Test 057 control_rrtmgp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_rrtmgp_c192
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_rrtmgp_c192
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_rrtmgp_c192
 Checking test 058 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2264,14 +2264,14 @@ Checking test 058 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 503.547734
-  0: The maximum resident set size (KB)                   = 804108
+  0: The total amount of wall time                        = 518.825420
+  0: The maximum resident set size (KB)                   = 806212
 
 Test 058 control_rrtmgp_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_csawmg
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_csawmg
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_csawmg
 Checking test 059 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2282,14 +2282,14 @@ Checking test 059 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 304.224446
-  0: The maximum resident set size (KB)                   = 544220
+  0: The total amount of wall time                        = 315.767110
+  0: The maximum resident set size (KB)                   = 540332
 
 Test 059 control_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_csawmgt
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_csawmgt
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_csawmgt
 Checking test 060 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2300,14 +2300,14 @@ Checking test 060 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 301.682961
-  0: The maximum resident set size (KB)                   = 544036
+  0: The total amount of wall time                        = 316.546417
+  0: The maximum resident set size (KB)                   = 540612
 
 Test 060 control_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_flake
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_flake
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_flake
 Checking test 061 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2318,14 +2318,14 @@ Checking test 061 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 215.124789
-  0: The maximum resident set size (KB)                   = 553960
+  0: The total amount of wall time                        = 217.194176
+  0: The maximum resident set size (KB)                   = 555420
 
 Test 061 control_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_ras
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_ras
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_ras
 Checking test 062 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2336,14 +2336,14 @@ Checking test 062 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.512709
-  0: The maximum resident set size (KB)                   = 513760
+  0: The total amount of wall time                        = 167.020689
+  0: The maximum resident set size (KB)                   = 512956
 
 Test 062 control_ras PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson
 Checking test 063 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2354,14 +2354,14 @@ Checking test 063 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 208.246569
-  0: The maximum resident set size (KB)                   = 868480
+  0: The total amount of wall time                        = 206.611871
+  0: The maximum resident set size (KB)                   = 866108
 
 Test 063 control_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson_no_aero
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson_no_aero
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson_no_aero
 Checking test 064 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2372,54 +2372,54 @@ Checking test 064 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.854428
-  0: The maximum resident set size (KB)                   = 864144
+  0: The total amount of wall time                        = 198.483065
+  0: The maximum resident set size (KB)                   = 863832
 
 Test 064 control_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_wam_repro
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_wam_repro
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_wam_repro
 Checking test 065 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 110.263907
-  0: The maximum resident set size (KB)                   = 248444
+  0: The total amount of wall time                        = 111.985567
+  0: The maximum resident set size (KB)                   = 249424
 
 Test 065 control_wam PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_debug
 Checking test 066 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.815420
-  0: The maximum resident set size (KB)                   = 546752
+  0: The total amount of wall time                        = 152.615328
+  0: The maximum resident set size (KB)                   = 545880
 
 Test 066 control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_2threads_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_2threads_debug
 Checking test 067 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 226.102719
- 0: The maximum resident set size (KB)                   = 598488
+ 0: The total amount of wall time                        = 264.668878
+ 0: The maximum resident set size (KB)                   = 600276
 
 Test 067 control_2threads_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_CubedSphereGrid_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_CubedSphereGrid_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_CubedSphereGrid_debug
 Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2446,458 +2446,458 @@ Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 164.977818
-  0: The maximum resident set size (KB)                   = 542300
+  0: The total amount of wall time                        = 164.740146
+  0: The maximum resident set size (KB)                   = 543932
 
 Test 068 control_CubedSphereGrid_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_wrtGauss_netcdf_parallel_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_wrtGauss_netcdf_parallel_debug
 Checking test 069 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.071743
-  0: The maximum resident set size (KB)                   = 546724
+  0: The total amount of wall time                        = 152.913162
+  0: The maximum resident set size (KB)                   = 545536
 
 Test 069 control_wrtGauss_netcdf_parallel_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_stochy_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_stochy_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_stochy_debug
 Checking test 070 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.799789
-  0: The maximum resident set size (KB)                   = 548760
+  0: The total amount of wall time                        = 181.192246
+  0: The maximum resident set size (KB)                   = 547548
 
 Test 070 control_stochy_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_lndp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_lndp_debug
 Checking test 071 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.121097
-  0: The maximum resident set size (KB)                   = 554768
+  0: The total amount of wall time                        = 153.590716
+  0: The maximum resident set size (KB)                   = 558800
 
 Test 071 control_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_rrtmgp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_rrtmgp_debug
 Checking test 072 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.686785
-  0: The maximum resident set size (KB)                   = 639900
+  0: The total amount of wall time                        = 168.378636
+  0: The maximum resident set size (KB)                   = 640600
 
 Test 072 control_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_csawmg_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_csawmg_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_csawmg_debug
 Checking test 073 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 236.038779
-  0: The maximum resident set size (KB)                   = 575648
+  0: The total amount of wall time                        = 233.238824
+  0: The maximum resident set size (KB)                   = 573248
 
 Test 073 control_csawmg_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_csawmgt_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_csawmgt_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_csawmgt_debug
 Checking test 074 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.471006
-  0: The maximum resident set size (KB)                   = 573864
+  0: The total amount of wall time                        = 235.399927
+  0: The maximum resident set size (KB)                   = 576296
 
 Test 074 control_csawmgt_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_ras_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_ras_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_ras_debug
 Checking test 075 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.561144
-  0: The maximum resident set size (KB)                   = 555692
+  0: The total amount of wall time                        = 159.173053
+  0: The maximum resident set size (KB)                   = 553176
 
 Test 075 control_ras_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_diag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_diag_debug
 Checking test 076 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 162.430199
-  0: The maximum resident set size (KB)                   = 597988
+  0: The total amount of wall time                        = 159.375490
+  0: The maximum resident set size (KB)                   = 603404
 
 Test 076 control_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_debug_p8
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_debug_p8
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_debug_p8
 Checking test 077 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.080904
-  0: The maximum resident set size (KB)                   = 568400
+  0: The total amount of wall time                        = 162.865566
+  0: The maximum resident set size (KB)                   = 572212
 
 Test 077 control_debug_p8 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson_debug
 Checking test 078 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 523.103033
-  0: The maximum resident set size (KB)                   = 906840
+  0: The total amount of wall time                        = 177.368131
+  0: The maximum resident set size (KB)                   = 902760
 
 Test 078 control_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson_no_aero_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson_no_aero_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson_no_aero_debug
 Checking test 079 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.217137
-  0: The maximum resident set size (KB)                   = 897288
+  0: The total amount of wall time                        = 171.545127
+  0: The maximum resident set size (KB)                   = 897204
 
 Test 079 control_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson_debug_extdiag
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson_extdiag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson_extdiag_debug
 Checking test 080 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.495563
-  0: The maximum resident set size (KB)                   = 934136
+  0: The total amount of wall time                        = 204.899328
+  0: The maximum resident set size (KB)                   = 933156
 
 Test 080 control_thompson_extdiag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_thompson_progcld_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_thompson_progcld_thompson_debug
 Checking test 081 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.856453
-  0: The maximum resident set size (KB)                   = 898356
+  0: The total amount of wall time                        = 177.999186
+  0: The maximum resident set size (KB)                   = 902304
 
 Test 081 control_thompson_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/fv3_regional_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/regional_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/regional_debug
 Checking test 082 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 246.119703
- 0: The maximum resident set size (KB)                   = 617456
+ 0: The total amount of wall time                        = 255.431812
+ 0: The maximum resident set size (KB)                   = 617056
 
 Test 082 regional_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_control_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_control_debug
 Checking test 083 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.942153
-  0: The maximum resident set size (KB)                   = 908120
+  0: The total amount of wall time                        = 270.620542
+  0: The maximum resident set size (KB)                   = 911124
 
 Test 083 rap_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_control_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_unified_drag_suite_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_unified_drag_suite_debug
 Checking test 084 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.734412
-  0: The maximum resident set size (KB)                   = 908428
+  0: The total amount of wall time                        = 276.770011
+  0: The maximum resident set size (KB)                   = 910724
 
 Test 084 rap_unified_drag_suite_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_diag_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_diag_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_diag_debug
 Checking test 085 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.462868
-  0: The maximum resident set size (KB)                   = 1007656
+  0: The total amount of wall time                        = 290.560234
+  0: The maximum resident set size (KB)                   = 1005328
 
 Test 085 rap_diag_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_cires_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_cires_ugwp_debug
 Checking test 086 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.839422
-  0: The maximum resident set size (KB)                   = 915960
+  0: The total amount of wall time                        = 275.947440
+  0: The maximum resident set size (KB)                   = 912104
 
 Test 086 rap_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_unified_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_unified_ugwp_debug
 Checking test 087 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.019283
-  0: The maximum resident set size (KB)                   = 909740
+  0: The total amount of wall time                        = 279.496990
+  0: The maximum resident set size (KB)                   = 907880
 
 Test 087 rap_unified_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_noah_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_noah_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_noah_debug
 Checking test 088 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.805302
-  0: The maximum resident set size (KB)                   = 908724
+  0: The total amount of wall time                        = 267.098981
+  0: The maximum resident set size (KB)                   = 908508
 
 Test 088 rap_noah_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_rrtmgp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_rrtmgp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_rrtmgp_debug
 Checking test 089 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 461.829028
-  0: The maximum resident set size (KB)                   = 1009436
+  0: The total amount of wall time                        = 468.570094
+  0: The maximum resident set size (KB)                   = 1010892
 
 Test 089 rap_rrtmgp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_lndp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_lndp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_lndp_debug
 Checking test 090 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.246522
-  0: The maximum resident set size (KB)                   = 910748
+  0: The total amount of wall time                        = 269.380925
+  0: The maximum resident set size (KB)                   = 909572
 
 Test 090 rap_lndp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_sfcdiff_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_sfcdiff_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.325531
-  0: The maximum resident set size (KB)                   = 908204
+  0: The total amount of wall time                        = 275.988704
+  0: The maximum resident set size (KB)                   = 908376
 
 Test 091 rap_sfcdiff_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_flake_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_flake_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_flake_debug
 Checking test 092 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.884714
-  0: The maximum resident set size (KB)                   = 910976
+  0: The total amount of wall time                        = 272.317494
+  0: The maximum resident set size (KB)                   = 906676
 
 Test 092 rap_flake_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 093 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 452.379784
-  0: The maximum resident set size (KB)                   = 909536
+  0: The total amount of wall time                        = 465.610308
+  0: The maximum resident set size (KB)                   = 908152
 
 Test 093 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rap_progcld_thompson_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rap_progcld_thompson_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rap_progcld_thompson_debug
 Checking test 094 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.188597
-  0: The maximum resident set size (KB)                   = 909920
+  0: The total amount of wall time                        = 268.877261
+  0: The maximum resident set size (KB)                   = 911328
 
 Test 094 rap_progcld_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/rrfs_v1beta_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/rrfs_v1beta_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/rrfs_v1beta_debug
 Checking test 095 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.280262
-  0: The maximum resident set size (KB)                   = 905136
+  0: The total amount of wall time                        = 275.051989
+  0: The maximum resident set size (KB)                   = 906648
 
 Test 095 rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_wam_debug
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_wam_debug
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_wam_debug
 Checking test 096 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 294.146490
-  0: The maximum resident set size (KB)                   = 275740
+  0: The total amount of wall time                        = 302.734474
+  0: The maximum resident set size (KB)                   = 272496
 
 Test 096 control_wam_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_atm
 Checking test 097 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 250.735226
-  0: The maximum resident set size (KB)                   = 850516
+  0: The total amount of wall time                        = 287.358577
+  0: The maximum resident set size (KB)                   = 850288
 
 Test 097 hafs_regional_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_atm_thompson_gfdlsf
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_atm_thompson_gfdlsf
 Checking test 098 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 305.256389
-  0: The maximum resident set size (KB)                   = 1211816
+  0: The total amount of wall time                        = 346.124106
+  0: The maximum resident set size (KB)                   = 1200248
 
 Test 098 hafs_regional_atm_thompson_gfdlsf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_atm_ocn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_atm_ocn
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_atm_ocn
 Checking test 099 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 353.925152
-  0: The maximum resident set size (KB)                   = 890272
+  0: The total amount of wall time                        = 332.815060
+  0: The maximum resident set size (KB)                   = 890828
 
 Test 099 hafs_regional_atm_ocn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_atm_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_atm_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_atm_wav
 Checking test 100 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 761.798130
-  0: The maximum resident set size (KB)                   = 886920
+  0: The total amount of wall time                        = 742.169424
+  0: The maximum resident set size (KB)                   = 885904
 
 Test 100 hafs_regional_atm_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_atm_ocn_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_atm_ocn_wav
 Checking test 101 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2906,58 +2906,58 @@ Checking test 101 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 852.309529
-  0: The maximum resident set size (KB)                   = 888356
+  0: The total amount of wall time                        = 858.251422
+  0: The maximum resident set size (KB)                   = 886760
 
 Test 101 hafs_regional_atm_ocn_wav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_1nest_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_1nest_atm
 Checking test 102 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 1258.469595
-  0: The maximum resident set size (KB)                   = 397704
+  0: The total amount of wall time                        = 1439.405052
+  0: The maximum resident set size (KB)                   = 387656
 
 Test 102 hafs_regional_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_telescopic_2nests_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_telescopic_2nests_atm
 Checking test 103 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 412.543603
-  0: The maximum resident set size (KB)                   = 426300
+  0: The total amount of wall time                        = 556.991507
+  0: The maximum resident set size (KB)                   = 431884
 
 Test 103 hafs_regional_telescopic_2nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_global_1nest_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_global_1nest_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_global_1nest_atm
 Checking test 104 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 183.431905
-  0: The maximum resident set size (KB)                   = 271500
+  0: The total amount of wall time                        = 259.970532
+  0: The maximum resident set size (KB)                   = 273400
 
 Test 104 hafs_global_1nest_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_global_multiple_4nests_atm
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_global_multiple_4nests_atm
 Checking test 105 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2970,14 +2970,14 @@ Checking test 105 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 548.676643
-  0: The maximum resident set size (KB)                   = 456816
+  0: The total amount of wall time                        = 687.037134
+  0: The maximum resident set size (KB)                   = 457304
 
 Test 105 hafs_global_multiple_4nests_atm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_docn
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_docn
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_docn
 Checking test 106 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2985,14 +2985,14 @@ Checking test 106 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.341044
-  0: The maximum resident set size (KB)                   = 886140
+  0: The total amount of wall time                        = 317.649288
+  0: The maximum resident set size (KB)                   = 887376
 
 Test 106 hafs_regional_docn PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_docn_oisst
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_docn_oisst
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_docn_oisst
 Checking test 107 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3000,105 +3000,105 @@ Checking test 107 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 334.868650
-  0: The maximum resident set size (KB)                   = 887116
+  0: The total amount of wall time                        = 339.598479
+  0: The maximum resident set size (KB)                   = 889308
 
 Test 107 hafs_regional_docn_oisst PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/hafs_regional_datm_cdeps
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/hafs_regional_datm_cdeps
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/hafs_regional_datm_cdeps
 Checking test 108 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 918.596983
-  0: The maximum resident set size (KB)                   = 867196
+  0: The total amount of wall time                        = 922.012895
+  0: The maximum resident set size (KB)                   = 868700
 
 Test 108 hafs_regional_datm_cdeps PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_control_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_control_cfsr
 Checking test 109 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.185192
- 0: The maximum resident set size (KB)                   = 719308
+ 0: The total amount of wall time                        = 147.587652
+ 0: The maximum resident set size (KB)                   = 716572
 
 Test 109 datm_cdeps_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_restart_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_restart_cfsr
 Checking test 110 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 100.067407
- 0: The maximum resident set size (KB)                   = 719392
+ 0: The total amount of wall time                        = 86.532519
+ 0: The maximum resident set size (KB)                   = 719792
 
 Test 110 datm_cdeps_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_control_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_control_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_control_gefs
 Checking test 111 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.600467
- 0: The maximum resident set size (KB)                   = 622424
+ 0: The total amount of wall time                        = 140.677587
+ 0: The maximum resident set size (KB)                   = 618924
 
 Test 111 datm_cdeps_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_stochy_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_stochy_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_stochy_gefs
 Checking test 112 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.427250
- 0: The maximum resident set size (KB)                   = 621256
+ 0: The total amount of wall time                        = 140.648767
+ 0: The maximum resident set size (KB)                   = 620416
 
 Test 112 datm_cdeps_stochy_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_bulk_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_bulk_cfsr
 Checking test 113 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.239874
- 0: The maximum resident set size (KB)                   = 717656
+ 0: The total amount of wall time                        = 145.750349
+ 0: The maximum resident set size (KB)                   = 719344
 
 Test 113 datm_cdeps_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_bulk_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_bulk_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_bulk_gefs
 Checking test 114 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.539643
- 0: The maximum resident set size (KB)                   = 619012
+ 0: The total amount of wall time                        = 139.321512
+ 0: The maximum resident set size (KB)                   = 618628
 
 Test 114 datm_cdeps_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_mx025_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_mx025_cfsr
 Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3107,14 +3107,14 @@ Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 297.472863
-  0: The maximum resident set size (KB)                   = 632724
+  0: The total amount of wall time                        = 314.999469
+  0: The maximum resident set size (KB)                   = 629280
 
 Test 115 datm_cdeps_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_mx025_gefs
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_mx025_gefs
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_mx025_gefs
 Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3123,51 +3123,51 @@ Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 295.428050
-  0: The maximum resident set size (KB)                   = 593352
+  0: The total amount of wall time                        = 297.716529
+  0: The maximum resident set size (KB)                   = 592560
 
 Test 116 datm_cdeps_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_control_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_multiple_files_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_multiple_files_cfsr
 Checking test 117 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.781090
- 0: The maximum resident set size (KB)                   = 721572
+ 0: The total amount of wall time                        = 143.214116
+ 0: The maximum resident set size (KB)                   = 716672
 
 Test 117 datm_cdeps_multiple_files_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_3072x1536_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_3072x1536_cfsr
 Checking test 118 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.618830
- 0: The maximum resident set size (KB)                   = 1832888
+ 0: The total amount of wall time                        = 187.206182
+ 0: The maximum resident set size (KB)                   = 1833336
 
 Test 118 datm_cdeps_3072x1536_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/datm_cdeps_debug_cfsr
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/datm_cdeps_debug_cfsr
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/datm_cdeps_debug_cfsr
 Checking test 119 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 439.331697
- 0: The maximum resident set size (KB)                   = 727124
+ 0: The total amount of wall time                        = 443.530251
+ 0: The maximum resident set size (KB)                   = 729268
 
 Test 119 datm_cdeps_debug_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_atmwav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_atmwav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_atmwav
 Checking test 120 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3211,14 +3211,14 @@ Checking test 120 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 80.050089
-  0: The maximum resident set size (KB)                   = 568580
+  0: The total amount of wall time                        = 86.843750
+  0: The maximum resident set size (KB)                   = 567692
 
 Test 120 control_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20220222/INTEL/control_c384gdas_wav
-working dir  = /work/noaa/stmp/bcurtis/stmp/bcurtis/FV3_RT/rt_421820/control_c384gdas_wav
+working dir  = /work/noaa/stmp/rmontuor/stmp/rmontuor/FV3_RT/rt_53434/control_c384gdas_wav
 Checking test 121 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3264,12 +3264,12 @@ Checking test 121 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 668.475920
-  0: The maximum resident set size (KB)                   = 1222264
+  0: The total amount of wall time                        = 806.608183
+  0: The maximum resident set size (KB)                   = 1206476
 
 Test 121 control_c384gdas_wav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb 23 22:03:56 CST 2022
-Elapsed time: 01h:47m:17s. Have a nice day!
+Thu Feb 24 20:45:49 CST 2022
+Elapsed time: 01h:19m:51s. Have a nice day!


### PR DESCRIPTION
# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [x] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Description

This update ensures that atmospheric restart files are written at the requested times when using multiple NUOPC run phases for fv3atm.

### Issue(s) addressed

- fixes #1064 

## Testing

Regression test logs are provided for the following platforms:

- [ ] hera.intel
- [ ] hera.gnu
- [x] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

- waiting on NOAA-EMC/fv3atm/pull/489