### PR TITLE
Remove the regional_spp_sppt_shum_skeb regression test because it uses uninitialized memory

### DIFF
--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -71,7 +71,11 @@ RUN     | regional_3km                                                          
 COMPILE | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON                     |                                         | fv3 |
 
 RUN     | rap_control                                                                                                             |                                         | fv3 |
-RUN     | regional_spp_sppt_shum_skeb                                                                                             |                                         | fv3 |
+
+# This test uses uninitialized memory, so there is no expectation the results will be consistent:
+#RUN     | regional_spp_sppt_shum_skeb                                                                                             |                                         | fv3 |
+# See https://github.com/NCAR/ccpp-physics/issues/891
+
 # This test is not giving the same results (also not in REPRO mode) - needs to be fixed
 #RUN     | rap_decomp                                                                                                              |                                         |     |
 RUN     | rap_2threads                                                                                                            | - wcoss_cray jet.intel                  |     |


### PR DESCRIPTION
The regional_spp_sppt_shum_skeb uses uninitialized memory. (See https://github.com/NCAR/ccpp-physics/issues/891). It is unreasonable to expect the code to be reproducible, or even work, when it has that bug. 

This is holding up other work (https://github.com/NOAA-GSL/ccpp-physics/pull/143) which changes a totally unrelated files. That unrelated change is just enough to put unphysical data in the uninitialized variables. Valid development work should not be held up by a broken regression test.

# PR Checklist

- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [x] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] ~~Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.~~

- [ ] ~~New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.~~

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsiblity to keep the PR up-to-date with the develop branch of ufs-weather-model. 

## Description

The regional_spp_sppt_shum_skeb test in rt.conf is commented out and surrounded by comments explaining why.

### Issue(s) addressed

This is a temporary solution to https://github.com/NCAR/ccpp-physics/issues/891 to allow other development to continue, until the stochastic thompson scheme developers can fix the bug.

## Testing

This simply removes a regression test, so there is no need to run regression tests.

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

None.
